### PR TITLE
Fix the project name (who was TextSecure iOS instead of Signal iOS).

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Signal allows you to make private phone calls and we are working on bringing sec
 
 1) Clone the repo to a working directory
 
-2) [CocoaPods](http://cocoapods.org) is used to manage dependencies. Pods are setup easily and are distributed via a ruby gem. Follow the simple instructions on the website to setup. After setup, run the following command from the toplevel directory of TextSecureiOS to download the dependencies for TextSecure iOS:
+2) [CocoaPods](http://cocoapods.org) is used to manage dependencies. Pods are setup easily and are distributed via a ruby gem. Follow the simple instructions on the website to setup. After setup, run the following command from the toplevel directory of Signal-iOS to download the dependencies for Signal-iOS:
 
 ```
 pod install


### PR DESCRIPTION
The ReadMe file mention the wrong name for the project. Simple typo fix here.
