### PR TITLE
Time Formatter respects the environment's location settings. FREEBIE

### DIFF
--- a/Signal/src/util/DateUtil.m
+++ b/Signal/src/util/DateUtil.m
@@ -6,26 +6,25 @@
 #define ONE_WEEK_TIME_INTERVAL (double)60*60*24*7
 
 static NSString *const DATE_FORMAT_WEEKDAY = @"EEEE";
-static NSString *const DATE_FORMAT_HOUR_MINUTE = @"h:mm a   ";
 
 @implementation DateUtil
 
 + (NSDateFormatter *)dateFormatter {
     NSDateFormatter *formatter = [NSDateFormatter new];
     [formatter setDateFormat:[[[Environment getCurrent] preferences] getDateFormat]];
-return formatter;
+    return formatter;
 }
 
 + (NSDateFormatter *)weekdayFormatter {
     NSDateFormatter *formatter = [NSDateFormatter new];
     [formatter setDateFormat:DATE_FORMAT_WEEKDAY];
-return formatter;
+    return formatter;
 }
 
 + (NSDateFormatter *)timeFormatter {
     NSDateFormatter *formatter = [NSDateFormatter new];
-    [formatter setDateFormat:DATE_FORMAT_HOUR_MINUTE];
-return formatter;
+    [formatter setTimeStyle:NSDateFormatterShortStyle];
+    return formatter;
 }
 
 + (BOOL)dateIsOlderThanOneDay:(NSDate *)date {

--- a/Signal/src/views/InboxFeedTableViewCell.h
+++ b/Signal/src/views/InboxFeedTableViewCell.h
@@ -24,7 +24,7 @@
 @property (nonatomic, strong) IBOutlet UIImageView *contactPictureView;
 @property (nonatomic, strong) IBOutlet UIImageView *callTypeImageView;
 @property (nonatomic, strong) IBOutlet UILabel *numberLabel;
-@property (nonatomic, strong) IBOutlet UILabel *timeLabel;
+@property (nonatomic, strong) IBOutlet UILabel *dateTimeLabel;
 @property (nonatomic, strong) IBOutlet NextResponderScrollView *scrollView;
 @property (nonatomic, strong) IBOutlet UIView *contentContainerView;
 @property (nonatomic, strong) IBOutlet UIView *missedCallView;

--- a/Signal/src/views/InboxFeedTableViewCell.m
+++ b/Signal/src/views/InboxFeedTableViewCell.m
@@ -59,7 +59,7 @@
 
     _missedCallView.hidden = recentCall.userNotified;
     _numberLabel.text = [recentCall.phoneNumber localizedDescriptionForUser];
-    _timeLabel.attributedText = [self dateArrributedString:[recentCall date]];
+    _dateTimeLabel.attributedText = [self dateArrributedString:[recentCall date]];
 }
 
 #pragma mark - Date formatting
@@ -67,7 +67,9 @@
 - (NSAttributedString *)dateArrributedString:(NSDate *)date {
 
     NSString *dateString;
-    NSString *timeString = [[DateUtil timeFormatter] stringFromDate:date];
+    NSString *timeString = [NSString stringWithFormat : @"%@  %@",
+                                [[DateUtil timeFormatter] stringFromDate:date],
+                                @"   "];
 
       
     if ([DateUtil dateIsOlderThanOneWeek:date]) {

--- a/Signal/src/views/xibs/InboxFeedTableViewCell.xib
+++ b/Signal/src/views/xibs/InboxFeedTableViewCell.xib
@@ -113,13 +113,13 @@
                 <outlet property="callTypeImageView" destination="rco-hN-IJi" id="KIi-Or-oUh"/>
                 <outlet property="contactPictureView" destination="SGJ-F7-TXB" id="SP2-5s-dfM"/>
                 <outlet property="contentContainerView" destination="P2L-GB-lTw" id="R7S-Nm-HOb"/>
+                <outlet property="dateTimeLabel" destination="Jvp-D8-ptE" id="zif-AA-MHs"/>
                 <outlet property="deleteImageView" destination="KDh-W4-xtN" id="QS1-a9-NhP"/>
                 <outlet property="deleteView" destination="TjP-Yh-EcA" id="I0p-N5-eee"/>
                 <outlet property="missedCallView" destination="caw-pS-8aG" id="bfx-g4-N59"/>
                 <outlet property="nameLabel" destination="XL5-Bj-JVM" id="OaW-xh-IE1"/>
                 <outlet property="numberLabel" destination="SWw-w0-Ecn" id="n88-4c-kjp"/>
                 <outlet property="scrollView" destination="6KV-fO-6FE" id="Jb7-Gj-uYL"/>
-                <outlet property="timeLabel" destination="Jvp-D8-ptE" id="xz2-mm-WCn"/>
             </connections>
         </tableViewCell>
     </objects>


### PR DESCRIPTION
Respects the system's settings for time formatting.
In response to https://github.com/WhisperSystems/Signal-iOS/issues/34
