### PR TITLE
Fixed packEcCoordinatesFromEcPoint variable-sized output

### DIFF
--- a/Signal/test/network/rtp/zrtp/EC25AgreerTest.m
+++ b/Signal/test/network/rtp/zrtp/EC25AgreerTest.m
@@ -3,17 +3,12 @@
 #import "EC25KeyAgreementParticipant.h"
 #import "EC25KeyAgreementProtocol.h"
 
-@interface EC25AgreerTest : XCTestCase{
-    
-    
-}
+@interface EC25AgreerTest : XCTestCase
 @end
 
 @implementation EC25AgreerTest
 
-
--(void) testKeyExchange {
-    
+-(void) testKeyExchangeMatchesPeerButNotOthers {
     EC25KeyAgreementProtocol* protocol = [EC25KeyAgreementProtocol protocol];
     
     id<KeyAgreementParticipant> ec1 = [protocol generateParticipantWithNewKeys];
@@ -31,6 +26,22 @@
     NSData* shared_3 = [ec3 calculateKeyAgreementAgainstRemotePublicKey:pub_1];
     
     test(![shared_3 isEqualToData:shared_1]);
+}
+
+-(void) testKeyExchangeSucceedsConsistently {
+    EC25KeyAgreementProtocol* protocol = [EC25KeyAgreementProtocol protocol];
+    for (int i = 0; i < 1000; i++) {
+        id<KeyAgreementParticipant> ec1 = [protocol generateParticipantWithNewKeys];
+        id<KeyAgreementParticipant> ec2 = [protocol generateParticipantWithNewKeys];
+
+        NSData* pub_1 = [ec1 getPublicKeyData];
+        NSData* pub_2 = [ec2 getPublicKeyData];
+    
+        NSData* shared_1 = [ec1 calculateKeyAgreementAgainstRemotePublicKey:pub_2];
+        NSData* shared_2 = [ec2 calculateKeyAgreementAgainstRemotePublicKey:pub_1];
+    
+        test([shared_1 isEqualToData:shared_2]);
+    }
 }
 
 @end


### PR DESCRIPTION
`packEcCoordinatesFromEcPoint` was encoding numbers with a variable-sized format, but deserialization was expecting fixed-width. Whenever either of the highest random byte of the public key points happened to come out 0. There were four chances for this to happen per call, so it's probably causing at least 1-(1-1/256)^4 ~= 1.5% of calls to fail.

The function also now checks the return codes of the OpenSSL functions for failures, and cleans up when exceptions occur. (Other code in the file also needs this change.)

Also included is a test which failed (consistently but not guaranteed) for the old code, and passes with the new code. It just runs 1000 ec25 key agreements.
