### PR TITLE
Using "dot" syntax for shared*, is*, and has* getters

### DIFF
--- a/Signal/src/AppDelegate.m
+++ b/Signal/src/AppDelegate.m
@@ -102,14 +102,14 @@
 
 #ifdef DEBUG
     loggingIsEnabled = TRUE;
-    [[DebugLogger sharedInstance] enableTTYLogging];
+    [DebugLogger.sharedInstance enableTTYLogging];
     
 #elif RELEASE
     loggingIsEnabled = [[Environment preferences] loggingIsEnabled];
 #endif
 
     if (loggingIsEnabled) {
-        [[DebugLogger sharedInstance] enableFileLogging];
+        [DebugLogger.sharedInstance enableFileLogging];
     }
     
     [self performUpdateCheck];
@@ -126,7 +126,7 @@
     [Environment setCurrent:[Release releaseEnvironmentWithLogging:logger]];
     [[Environment getCurrent].phoneDirectoryManager startUntilCancelled:nil];
     [[Environment getCurrent].contactsManager doAfterEnvironmentInitSetup];
-    [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleDefault];
+    [UIApplication.sharedApplication setStatusBarStyle:UIStatusBarStyleDefault];
     
     LeftSideMenuViewController *leftSideMenuViewController = [LeftSideMenuViewController new];
     
@@ -156,11 +156,11 @@
 }
 
 - (void)application:(UIApplication*)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData*)deviceToken {
-    [[PushManager sharedManager] registerForPushWithToken:deviceToken];
+    [PushManager.sharedManager registerForPushWithToken:deviceToken];
 }
 
 - (void)application:(UIApplication*)application didFailToRegisterForRemoteNotificationsWithError:(NSError*)error {
-    [[PushManager sharedManager]verifyPushActivated];
+    [PushManager.sharedManager verifyPushActivated];
     DDLogError(@"Failed to register for push notifications: %@", error);
 }
 
@@ -192,17 +192,17 @@
 }
 
 -(void) applicationDidBecomeActive:(UIApplication *)application {
-    [[AppAudioManager sharedInstance] awake];
+    [AppAudioManager.sharedInstance awake];
     
     // Hacky way to clear notification center after processed push
-    [[UIApplication sharedApplication] setApplicationIconBadgeNumber:1];
-    [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
+    [UIApplication.sharedApplication setApplicationIconBadgeNumber:1];
+    [UIApplication.sharedApplication setApplicationIconBadgeNumber:0];
     
     [self removeScreenProtection];
     
-    if ([Environment isRegistered]) {
-        [[PushManager sharedManager] verifyPushActivated];
-        [[AppAudioManager sharedInstance] requestRequiredPermissionsIfNeeded];
+    if (Environment.isRegistered) {
+        [PushManager.sharedManager verifyPushActivated];
+        [AppAudioManager.sharedInstance requestRequiredPermissionsIfNeeded];
     }
 }
 

--- a/Signal/src/async/AsyncUtil.m
+++ b/Signal/src/async/AsyncUtil.m
@@ -85,7 +85,7 @@
                                                 untilCancelled:untilCancelledToken];
     
     return [futureResult catch:^(id error) {
-        bool operationCancelled = [untilCancelledToken isAlreadyCancelled];
+        bool operationCancelled = untilCancelledToken.isAlreadyCancelled;
         bool operationDidNotTimeout = ![error isKindOfClass:[TimeoutFailure class]];
         if (operationCancelled || operationDidNotTimeout) {
             return [Future failed:error];

--- a/Signal/src/async/CancelTokenSource.m
+++ b/Signal/src/async/CancelTokenSource.m
@@ -98,7 +98,7 @@
 }
 
 -(NSString*) description {
-    if ([self isAlreadyCancelled]) return @"Cancelled";
+    if (self.isAlreadyCancelled) return @"Cancelled";
     if (isImmortal) return @"Immortal";
     return @"Not Cancelled Yet";
 }

--- a/Signal/src/async/Future.m
+++ b/Signal/src/async/Future.m
@@ -26,7 +26,7 @@
 -(void) finallyDo:(void(^)(Future* completed))callback {
     require(callback != nil);
     @synchronized(self) {
-        if ([self isIncomplete]) {
+        if (self.isIncomplete) {
             [callbacks addObject:[callback copy]];
             return;
         }
@@ -54,14 +54,14 @@
 
 -(id) forceGetResult {
     @synchronized(self) {
-        requireState([self hasSucceeded]);
+        requireState(self.hasSucceeded);
     }
     return result;
 }
 
 -(id) forceGetFailure {
     @synchronized(self) {
-        requireState([self hasFailed]);
+        requireState(self.hasFailed);
     }
     return failure;
 }

--- a/Signal/src/async/FutureSource.m
+++ b/Signal/src/async/FutureSource.m
@@ -77,7 +77,7 @@
     }
     
     [futureResult finallyDo:^(Future* completed) {
-        if ([completed hasSucceeded]) {
+        if (completed.hasSucceeded) {
             [self trySet:[completed forceGetResult]
                   failed:false
               isUnwiring:true];
@@ -94,8 +94,8 @@
 -(NSString*) description {
     @synchronized(self) {
         if (isWiredToComplete) return @"Incomplete Future [Wired to Complete]";
-        if ([self isIncomplete]) return @"Incomplete Future";
-        if ([self hasSucceeded]) return [NSString stringWithFormat:@"Completed: %@", result];
+        if (self.isIncomplete) return @"Incomplete Future";
+        if (self.hasSucceeded) return [NSString stringWithFormat:@"Completed: %@", result];
         return [NSString stringWithFormat:@"Failed: %@", failure];
     }
 }

--- a/Signal/src/async/FutureUtil.m
+++ b/Signal/src/async/FutureUtil.m
@@ -10,7 +10,7 @@
     void(^callbackCopy)(id result) = [callback copy];
     
     [self finallyDo:^(Future* completed){
-        if ([completed hasSucceeded]) {
+        if (completed.hasSucceeded) {
             callbackCopy([completed forceGetResult]);
         }
     }];
@@ -20,7 +20,7 @@
     void(^callbackCopy)(id result) = [catcher copy];
     
     [self finallyDo:^(Future* completed){
-        if ([completed hasFailed]) {
+        if (completed.hasFailed) {
             callbackCopy([completed forceGetFailure]);
         }
     }];
@@ -46,7 +46,7 @@
     id(^callbackCopy)(id value) = [projection copy];
     
     return [self finally:^id(Future* completed){
-        if ([completed hasFailed]) return completed;
+        if (completed.hasFailed) return completed;
         
         return callbackCopy([completed forceGetResult]);
     }];
@@ -56,7 +56,7 @@
     id(^callbackCopy)(id value) = [catcher copy];
     
     return [self finally:^id(Future* completed){
-        if ([completed hasSucceeded]) return completed;
+        if (completed.hasSucceeded) return completed;
         
         return callbackCopy([completed forceGetFailure]);
     }];

--- a/Signal/src/async/ObservableValue.m
+++ b/Signal/src/async/ObservableValue.m
@@ -17,7 +17,7 @@
                            untilCancelled:(id<CancelToken>)untilCancelledToken {
     
     require(callback != nil);
-    if ([untilCancelledToken isAlreadyCancelled]) return;
+    if (untilCancelledToken.isAlreadyCancelled) return;
     
     void(^callbackCopy)(id value) = [callback copy];
     [self queueRun:^{

--- a/Signal/src/audio/AppAudioManager.m
+++ b/Signal/src/audio/AppAudioManager.m
@@ -158,7 +158,7 @@ AppAudioManager*  sharedAppAudioManager;
 }
 
 -(void) requestRequiredPermissionsIfNeeded {
-    [[AVAudioSession sharedInstance] requestRecordPermission:^(BOOL granted) {
+    [AVAudioSession.sharedInstance requestRecordPermission:^(BOOL granted) {
         if (!granted) {
             UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:NSLocalizedString(@"ACTION_REQUIRED_TITLE", @"") message:NSLocalizedString(@"AUDIO_PERMISSION_MESSAGE", @"") delegate:nil cancelButtonTitle:NSLocalizedString(@"OK", @"") otherButtonTitles:nil, nil];
             [alertView show];
@@ -168,13 +168,13 @@ AppAudioManager*  sharedAppAudioManager;
 
 -(BOOL) changeAudioSessionCategoryTo:(NSString*) category {
     NSError* e;
-    [[AVAudioSession sharedInstance] setCategory:category error:&e];
+    [AVAudioSession.sharedInstance setCategory:category error:&e];
     return (nil != e);
 }
 
 -(BOOL) setAudioEnabled:(BOOL) enable {
     NSError* e;
-    [[AVAudioSession sharedInstance] setActive:enable error:&e];
+    [AVAudioSession.sharedInstance setActive:enable error:&e];
     [_soundPlayer awake];
     return ( nil !=e );
 }

--- a/Signal/src/audio/AudioRouter.m
+++ b/Signal/src/audio/AudioRouter.m
@@ -7,23 +7,23 @@
 @implementation AudioRouter
 
 +(void) restoreDefaults {
-    AVAudioSession* session = [AVAudioSession sharedInstance];
+    AVAudioSession* session = AVAudioSession.sharedInstance;
     [session setActive:YES error:nil];
     [AudioRouter routeAllAudioToExternalSpeaker];
 }
 
 +(void) routeAllAudioToInteralSpeaker {
-    AVAudioSession* session = [AVAudioSession sharedInstance];
+    AVAudioSession* session = AVAudioSession.sharedInstance;
     [session setCategory:DEFAULT_CATAGORY error:nil];
 }
 
 +(void) routeAllAudioToExternalSpeaker {
-    AVAudioSession* session = [AVAudioSession sharedInstance];
+    AVAudioSession* session = AVAudioSession.sharedInstance;
     [session setCategory:DEFAULT_CATAGORY withOptions:AVAudioSessionCategoryOptionDefaultToSpeaker error:nil];
 }
 
 +(BOOL) isOutputRoutedToSpeaker{
-    AVAudioSession* session = [AVAudioSession sharedInstance];
+    AVAudioSession* session = AVAudioSession.sharedInstance;
     AVAudioSessionRouteDescription* routeDesc = [session currentRoute];
     
     for( AVAudioSessionPortDescription* portDesc in routeDesc.outputs){
@@ -35,7 +35,7 @@
 }
 
 +(BOOL) isOutputRoutedToReciever{
-    AVAudioSession* session = [AVAudioSession sharedInstance];
+    AVAudioSession* session = AVAudioSession.sharedInstance;
     AVAudioSessionRouteDescription* routeDesc = [session currentRoute];
     
     for( AVAudioSessionPortDescription* portDesc in routeDesc.outputs){

--- a/Signal/src/audio/incall_audio/AudioPacker.m
+++ b/Signal/src/audio/incall_audio/AudioPacker.m
@@ -21,7 +21,7 @@
 
 -(void)packFrame:(EncodedAudioFrame*)frame{
     require(frame != nil);
-    require(![frame isMissingAudioData]);
+    require(!frame.isMissingAudioData);
     [framesToSend addObject:[frame tryGetAudioData]];
 }
 

--- a/Signal/src/audio/incall_audio/CallAudioManager.m
+++ b/Signal/src/audio/incall_audio/CallAudioManager.m
@@ -30,7 +30,7 @@
     @synchronized(self) {
         requireState(!started);
         started = true;
-        if ([untilCancelledToken isAlreadyCancelled]) return;
+        if (untilCancelledToken.isAlreadyCancelled) return;
         audioInterface = [RemoteIOAudio remoteIOInterfaceStartedWithDelegate:self untilCancelled:untilCancelledToken];
         PacketHandlerBlock handler = ^(EncodedAudioPacket* packet) {
             [audioProcessor receivedPacket:packet];

--- a/Signal/src/audio/incall_audio/RemoteIOAudio.m
+++ b/Signal/src/audio/incall_audio/RemoteIOAudio.m
@@ -47,7 +47,7 @@ static bool doesActiveInstanceExist;
 }
 
 -(void)setupAudio {
-    [[AppAudioManager sharedInstance] requestRecordingPrivlege];
+    [AppAudioManager.sharedInstance requestRecordingPrivlege];
     rioAudioUnit = [self makeAudioUnit];
     [self setAudioEnabled];
     [self setAudioStreamFormat];
@@ -177,7 +177,7 @@ static bool doesActiveInstanceExist;
             state = TERMINATED;
             doesActiveInstanceExist = false;
             [self checkDone:AudioOutputUnitStop(rioAudioUnit)];
-            [[AppAudioManager sharedInstance] releaseRecordingPrivlege];
+            [AppAudioManager.sharedInstance releaseRecordingPrivlege];
             [unusedBuffers removeAllObjects];
         }
     }];
@@ -327,7 +327,7 @@ static OSStatus playbackCallback(void *inRefCon,
 }
 
 -(BOOL) toggleMute {
-	BOOL shouldBeMuted = ![self isAudioMuted];
+	BOOL shouldBeMuted = !self.isAudioMuted;
 	UInt32 newValue =  shouldBeMuted ? FLAG_MUTED : FLAG_UNMUTED;
 	
 	[self checkDone:AudioUnitSetProperty(rioAudioUnit,

--- a/Signal/src/audio/incall_audio/processing/AudioProcessor.m
+++ b/Signal/src/audio/incall_audio/processing/AudioProcessor.m
@@ -54,7 +54,7 @@
 }
 -(NSData*) tryDecodeOrInferFrame {
     EncodedAudioFrame* frame = [self pullFrame];
-    haveReceivedDataYet |= ![frame isMissingAudioData];
+    haveReceivedDataYet |= !frame.isMissingAudioData;
     if (!haveReceivedDataYet) return nil;
     
     NSData* raw = [codec decode:[frame tryGetAudioData]];

--- a/Signal/src/call/RecentCallManager.m
+++ b/Signal/src/call/RecentCallManager.m
@@ -62,7 +62,7 @@ typedef BOOL (^SearchTermConditionalBlock)(RecentCall*, NSUInteger, BOOL*);
     
     [call.futureCallLocallyAcceptedOrRejected finallyDo:^(Future* interactionCompletion) {
         bool isOutgoingCall = call.initiatedLocally;
-        bool isMissedCall = [interactionCompletion hasFailed];
+        bool isMissedCall = interactionCompletion.hasFailed;
         Contact* contact = [self tryGetContactForCall:call];
         
         RPRecentCallType callType = isOutgoingCall ? RPRecentCallTypeOutgoing

--- a/Signal/src/contact/ContactsManager.m
+++ b/Signal/src/contact/ContactsManager.m
@@ -441,7 +441,7 @@ void onAddressBookChanged(ABAddressBookRef notifyAddressBook, CFDictionaryRef in
 
 +(NSArray *)favouritesForAllContacts:(NSArray *)contacts {
     return [contacts filter:^int(Contact* contact) {
-        return [contact isFavourite];
+        return contact.isFavourite;
     }];
 }
 

--- a/Signal/src/environment/DebugLogger.m
+++ b/Signal/src/environment/DebugLogger.m
@@ -36,7 +36,7 @@ MacrosSingletonImplemention
 }
 
 - (void)enableTTYLogging{
-    [DDLog addLogger:[DDTTYLogger sharedInstance]];
+    [DDLog addLogger:DDTTYLogger.sharedInstance];
 }
 
 - (void)wipeLogs{

--- a/Signal/src/environment/Environment.m
+++ b/Signal/src/environment/Environment.m
@@ -170,7 +170,7 @@ phoneDirectoryManager;
     [SGNKeychainUtil wipeKeychain];
     [[Environment preferences] clear];
     if ([[self preferences] loggingIsEnabled]) {
-        [[DebugLogger sharedInstance] wipeLogs];
+        [DebugLogger.sharedInstance wipeLogs];
     }
     [[self preferences] setAndGetCurrentVersion];
 }

--- a/Signal/src/environment/VersionMigrations.m
+++ b/Signal/src/environment/VersionMigrations.m
@@ -43,7 +43,7 @@
         
         // Some users push IDs were not correctly registered, by precaution, we are going to re-register all of them
         
-        [[PushManager sharedManager] askForPushRegistration];
+        [PushManager.sharedManager askForPushRegistration];
         
         [[NSFileManager defaultManager] removeItemAtPath:path error:&error];
         

--- a/Signal/src/network/PushManager.m
+++ b/Signal/src/network/PushManager.m
@@ -31,7 +31,7 @@
 }
 
 - (void)verifyPushActivated{
-    UIRemoteNotificationType notificationTypes = [[UIApplication sharedApplication] enabledRemoteNotificationTypes];
+    UIRemoteNotificationType notificationTypes = [UIApplication.sharedApplication enabledRemoteNotificationTypes];
     
     BOOL needsPushSettingChangeAlert = NO;
 
@@ -70,7 +70,7 @@
 - (void)askForPushRegistration{
     
     if(SYSTEM_VERSION_LESS_THAN(_iOS_8_0)){
-        [[UIApplication sharedApplication] registerForRemoteNotificationTypes:(UIRemoteNotificationTypeAlert | UIRemoteNotificationTypeSound | UIRemoteNotificationTypeBadge)];
+        [UIApplication.sharedApplication registerForRemoteNotificationTypes:(UIRemoteNotificationTypeAlert | UIRemoteNotificationTypeSound | UIRemoteNotificationTypeBadge)];
     } else{
 #if __IPHONE_OS_VERSION_MAX_ALLOWED > __IPHONE_7_1
         UIMutableUserNotificationAction *action_accept = [[UIMutableUserNotificationAction alloc]init];
@@ -93,8 +93,8 @@
         
         NSSet *categories = [NSSet setWithObject:callCategory];
         
-        [[UIApplication sharedApplication] registerForRemoteNotifications];
-        [[UIApplication sharedApplication] registerUserNotificationSettings:[UIUserNotificationSettings settingsForTypes:(UIRemoteNotificationTypeAlert|UIRemoteNotificationTypeBadge|UIRemoteNotificationTypeSound) categories:categories]];
+        [UIApplication.sharedApplication registerForRemoteNotifications];
+        [UIApplication.sharedApplication registerUserNotificationSettings:[UIUserNotificationSettings settingsForTypes:(UIRemoteNotificationTypeAlert|UIRemoteNotificationTypeBadge|UIRemoteNotificationTypeSound) categories:categories]];
         
 #endif
 
@@ -104,7 +104,7 @@
 }
 
 - (void)registerForPushWithToken:(NSData*)token{
-    [[CallServerRequestsManager sharedInstance] registerPushToken:token success:^(NSURLSessionDataTask *task, id responseObject) {
+    [CallServerRequestsManager.sharedInstance registerPushToken:token success:^(NSURLSessionDataTask *task, id responseObject) {
         if ([task.response isKindOfClass: [NSHTTPURLResponse class]]){
             NSInteger statusCode = [(NSHTTPURLResponse*) task.response statusCode];
             if (statusCode == 200) {

--- a/Signal/src/network/http/HttpManager.m
+++ b/Signal/src/network/http/HttpManager.m
@@ -77,7 +77,7 @@
                                            unlessCancelled:unlessCancelledToken];
     
     return [futureResponse then:^(HttpResponse* response) {
-        if (![response isOkResponse]) return [Future failed:response];
+        if (!response.isOkResponse) return [Future failed:response];
         return [Future finished:response];
     }];
 }
@@ -116,7 +116,7 @@
         require(requestOrResponse != nil);
         require([requestOrResponse isKindOfClass:[HttpRequestOrResponse class]]);
         @synchronized (self) {
-            if ([requestOrResponse isRequest]) {
+            if (requestOrResponse.isRequest) {
                 HttpResponse* response = requestHandler([requestOrResponse request]);
                 requireState(response != nil);
                 [httpChannel send:[HttpRequestOrResponse httpRequestOrResponse:response]];

--- a/Signal/src/network/http/HttpRequest.m
+++ b/Signal/src/network/http/HttpRequest.m
@@ -97,7 +97,7 @@
     require(data != nil);
     NSUInteger requestSize;
     HttpRequestOrResponse* http = [HttpRequestOrResponse tryExtractFromPartialData:data usedLengthOut:&requestSize];
-    checkOperation([http isRequest] && requestSize == data.length);
+    checkOperation(http.isRequest && requestSize == data.length);
     return [http request];
 }
 

--- a/Signal/src/network/http/HttpRequestOrResponse.m
+++ b/Signal/src/network/http/HttpRequestOrResponse.m
@@ -9,7 +9,7 @@
     
     HttpRequestOrResponse* h = [HttpRequestOrResponse new];
     h->requestOrResponse = requestOrResponse;
-    require([h isResponse] || [h isRequest]);
+    require(h.isResponse || h.isRequest);
     return h;
 }
 -(bool) isRequest {
@@ -19,11 +19,11 @@
     return [requestOrResponse isKindOfClass:[HttpResponse class]];
 }
 -(HttpRequest*) request {
-    requireState([self isRequest]);
+    requireState(self.isRequest);
     return requestOrResponse;
 }
 -(HttpResponse*) response {
-    requireState([self isResponse]);
+    requireState(self.isResponse);
     return requestOrResponse;
 }
 -(NSData*) serialize {

--- a/Signal/src/network/http/HttpResponse.m
+++ b/Signal/src/network/http/HttpResponse.m
@@ -41,7 +41,7 @@
     require(data != nil);
     NSUInteger responseSize;
     HttpRequestOrResponse* http = [HttpRequestOrResponse tryExtractFromPartialData:data usedLengthOut:&responseSize];
-    checkOperation([http isResponse] && responseSize == data.length);
+    checkOperation(http.isResponse && responseSize == data.length);
     return [http response];
 }
 +(HttpResponse*) httpResponse200Ok {
@@ -123,8 +123,8 @@
     return [NSString stringWithFormat:@"%lu %@%@",
             (unsigned long)statusCode,
             statusText,
-            ![self hasBody] ? @""
-              : [self hasEmptyBody] ? @" [empty body]"
+            !self.hasBody ? @""
+              : self.hasEmptyBody ? @" [empty body]"
               : @" [...body...]"];
 }
 -(bool) hasBody {

--- a/Signal/src/network/rtp/RtpPacket.m
+++ b/Signal/src/network/rtp/RtpPacket.m
@@ -347,8 +347,8 @@ andSynchronizationSourceIdentifier:(uint32_t)synchronizedSourceIdentifier
     if (other == nil) return false;
     if (version != [other version]) return false;
     if (padding != [other padding]) return false;
-    if (hasExtensionHeader != [other hasExtensionHeader]) return false;
-    if (isMarkerBitSet != [other isMarkerBitSet]) return false;
+    if (hasExtensionHeader != other.hasExtensionHeader) return false;
+    if (isMarkerBitSet != other.isMarkerBitSet) return false;
     if (payloadType != [other payloadType]) return false;
     if (timeStamp != [other timeStamp]) return false;
     if (synchronizationSourceIdentifier != [other synchronizationSourceIdentifier]) return false;

--- a/Signal/src/network/rtp/zrtp/ZrtpInitiator.m
+++ b/Signal/src/network/rtp/zrtp/ZrtpInitiator.m
@@ -35,7 +35,7 @@
 }
 
 -(MasterSecret*) getMasterSecret {
-    requireState([self hasHandshakeFinishedSuccessfully]);
+    requireState(self.hasHandshakeFinishedSuccessfully);
     return masterSecret;
 }
 
@@ -168,7 +168,7 @@
 }
 
 -(SrtpSocket*) useKeysToSecureRtpSocket:(RtpSocket*)rtpSocket {
-    requireState([self hasHandshakeFinishedSuccessfully]);
+    requireState(self.hasHandshakeFinishedSuccessfully);
     return [SrtpSocket srtpSocketOverRtp:rtpSocket
                     andIncomingCipherKey:[masterSecret responderSrtpKey]
                        andIncomingMacKey:[masterSecret responderMacKey]

--- a/Signal/src/network/rtp/zrtp/ZrtpManager.m
+++ b/Signal/src/network/rtp/zrtp/ZrtpManager.m
@@ -23,7 +23,7 @@
     
     ZrtpHandshakeSocket* handshakeChannel = [ZrtpHandshakeSocket zrtpHandshakeSocketOverRtp:rtpSocket];
     
-    id<ZrtpRole> role = [callController isInitiator]
+    id<ZrtpRole> role = callController.isInitiator
                       ? [ZrtpInitiator zrtpInitiatorWithCallController:callController]
                       : [ZrtpResponder zrtpResponderWithCallController:callController];
     
@@ -173,7 +173,7 @@
     if (response != nil) {
         [self setAndSendPacketToTransmit:response];
     }
-    if ([zrtpRole hasHandshakeFinishedSuccessfully]) {
+    if (zrtpRole.hasHandshakeFinishedSuccessfully) {
         done = true;
         handshakeCompletedSuccesfully = true;
         

--- a/Signal/src/network/rtp/zrtp/ZrtpResponder.m
+++ b/Signal/src/network/rtp/zrtp/ZrtpResponder.m
@@ -89,7 +89,7 @@
 }
 
 -(MasterSecret*) getMasterSecret {
-    requireState([self hasHandshakeFinishedSuccessfully]);
+    requireState(self.hasHandshakeFinishedSuccessfully);
     return masterSecret;
 }
 
@@ -148,7 +148,7 @@
 }
 
 -(SrtpSocket*) useKeysToSecureRtpSocket:(RtpSocket*)rtpSocket {
-    requireState([self hasHandshakeFinishedSuccessfully]);
+    requireState(self.hasHandshakeFinishedSuccessfully);
     return [SrtpSocket srtpSocketOverRtp:rtpSocket
                     andIncomingCipherKey:[masterSecret initiatorSrtpKey]
                        andIncomingMacKey:[masterSecret initiatorMacKey]

--- a/Signal/src/network/rtp/zrtp/packets/HandshakePacket.m
+++ b/Signal/src/network/rtp/zrtp/packets/HandshakePacket.m
@@ -48,7 +48,7 @@
     require(rtpPacket != nil);
     checkOperation([rtpPacket timeStamp] == HANDSHAKE_PACKET_TIMESTAMP_COOKIE);
     checkOperation([rtpPacket version] == 0);
-    checkOperation([rtpPacket hasExtensionHeader]);
+    checkOperation(rtpPacket.hasExtensionHeader);
     checkOperation([rtpPacket extensionHeaderIdentifier] == HANDSHAKE_PACKET_EXTENSION_IDENTIFIER);
     checkOperation([[rtpPacket extensionHeaderData] length] >= HEADER_FOOTER_LENGTH_WITHOUT_HMAC);
     

--- a/Signal/src/network/tcp/tls/NetworkStream.m
+++ b/Signal/src/network/tcp/tls/NetworkStream.m
@@ -69,7 +69,7 @@
     }
 }
 -(void) tryWriteBufferedData {
-    if (![futureConnectedAndWritableSource hasSucceeded]) return;
+    if (!futureConnectedAndWritableSource.hasSucceeded) return;
     if (![[futureConnectedAndWritableSource forceGetResult] isEqual:@YES]) return;
     NSStreamStatus status = [outputStream streamStatus];
     if (status < NSStreamStatusOpen) return;
@@ -80,7 +80,7 @@
         return;
     }
     
-    while ([writeBuffer enqueuedLength] > 0 && [outputStream hasSpaceAvailable]) {
+    while ([writeBuffer enqueuedLength] > 0 && outputStream.hasSpaceAvailable) {
         NSData* data = [writeBuffer peekVolatileHeadOfData];
         NSInteger d = [outputStream write:[data bytes] maxLength:data.length];
         
@@ -143,7 +143,7 @@
 -(void) onSpaceAvailableToWrite {
     [self tryWriteBufferedData];
     
-    if ([futureConnectedAndWritableSource isCompletedOrWiredToComplete]) return;
+    if (futureConnectedAndWritableSource.isCompletedOrWiredToComplete) return;
     
     Future* checked = [remoteEndPoint asyncHandleStreamsConnected:[StreamPair streamPairWithInput:inputStream
                                                                                         andOutput:outputStream]];
@@ -180,10 +180,10 @@
 
 -(void) onBytesAvailableToRead {
     if (rawDataHandler == nil) return;
-    if (![futureConnectedAndWritableSource hasSucceeded]) return;
+    if (!futureConnectedAndWritableSource.hasSucceeded) return;
     if (![[futureConnectedAndWritableSource forceGetResult] isEqual:@YES]) return;
     
-    while ([inputStream hasBytesAvailable]) {
+    while (inputStream.hasBytesAvailable) {
         NSInteger numRead = [inputStream read:[readBuffer mutableBytes] maxLength:readBuffer.length];
         
         if (numRead < 0) [self onErrorOccurred:@"Read Error"];
@@ -240,10 +240,10 @@
 -(NSString *)description {
     NSString* status = @"Not Started";
     if (started) status = @"Connecting";
-    if ([futureOpenedSource hasSucceeded]) status = @"Connecting (TCP Handshake Completed)";
-    if ([futureConnectedAndWritableSource hasSucceeded]) status = @"Connected";
+    if (futureOpenedSource.hasSucceeded) status = @"Connecting (TCP Handshake Completed)";
+    if (futureConnectedAndWritableSource.hasSucceeded) status = @"Connected";
     if (closedLocally) status = @"Closed";
-    if ([futureConnectedAndWritableSource hasFailed]) status = @"Failed";
+    if (futureConnectedAndWritableSource.hasFailed) status = @"Failed";
     
     return [NSString stringWithFormat:@"Status: %@, RemoteEndPoint: %@",
             status,

--- a/Signal/src/network/udp/UdpSocket.m
+++ b/Signal/src/network/udp/UdpSocket.m
@@ -45,7 +45,7 @@
     @synchronized(self) {
         require(packet != nil);
         requireState(socket != nil);
-        requireState([self isRemoteEndPointKnown]);
+        requireState(self.isRemoteEndPointKnown);
         
         hasSentData = true;
         CFTimeInterval t = 2.0;
@@ -66,7 +66,7 @@
 }
 
 -(IpEndPoint *)remoteEndPoint {
-    requireState([self isRemoteEndPointKnown]);
+    requireState(self.isRemoteEndPointKnown);
     if (specifiedRemoteEndPoint != nil) return specifiedRemoteEndPoint;
     return clientConnectedFromRemoteEndPoint;
 }
@@ -79,7 +79,7 @@
 }
 
 -(in_port_t) localPort {
-    requireState([self isLocalPortKnown]);
+    requireState(self.isLocalPortKnown);
     if (specifiedLocalPort != 0) return specifiedLocalPort;
     return measuredLocalPort;
 }
@@ -101,7 +101,7 @@ void onReceivedData(CFSocketRef socket, CFSocketCallBackType type, CFDataRef add
         @try {
             checkOperation(type == kCFSocketDataCallBack);
             
-            bool waitingForClient = ![self isRemoteEndPointKnown];
+            bool waitingForClient = !self.isRemoteEndPointKnown;
             bool packetHasContent = data.length > 0;
             bool haveNotSentPacketToBeBounced = !hasSentData;
             checkOperationDescribe(packetHasContent || waitingForClient || haveNotSentPacketToBeBounced,

--- a/Signal/src/phone/PhoneNumber.m
+++ b/Signal/src/phone/PhoneNumber.m
@@ -15,7 +15,7 @@ static NSString *const RPDefaultsKeyPhoneNumberCanonical = @"RPDefaultsKeyPhoneN
     require(text != nil);
     require(regionCode != nil);
     
-    NBPhoneNumberUtil *phoneUtil = [NBPhoneNumberUtil sharedInstance];
+    NBPhoneNumberUtil *phoneUtil = NBPhoneNumberUtil.sharedInstance;
     
     NSError* parseError = nil;
     NBPhoneNumber *number = [phoneUtil parse:text
@@ -73,7 +73,7 @@ static NSString *const RPDefaultsKeyPhoneNumberCanonical = @"RPDefaultsKeyPhoneN
 
 
 +(NSString*) regionCodeFromCountryCodeString:(NSString*) countryCodeString {
-    NBPhoneNumberUtil* phoneUtil = [NBPhoneNumberUtil sharedInstance];
+    NBPhoneNumberUtil* phoneUtil = NBPhoneNumberUtil.sharedInstance;
     NSString* regionCode = [phoneUtil getRegionCodeForCountryCode:@([[countryCodeString substringFromIndex:1] integerValue])];
     return regionCode;
 }
@@ -136,11 +136,11 @@ static NSString *const RPDefaultsKeyPhoneNumberCanonical = @"RPDefaultsKeyPhoneN
 }
 
 -(BOOL)isValid {
-    return [[NBPhoneNumberUtil sharedInstance] isValidNumber:phoneNumber];
+    return [NBPhoneNumberUtil.sharedInstance isValidNumber:phoneNumber];
 }
 
 -(NSString *)localizedDescriptionForUser {
-    NBPhoneNumberUtil *phoneUtil = [NBPhoneNumberUtil sharedInstance];
+    NBPhoneNumberUtil *phoneUtil = NBPhoneNumberUtil.sharedInstance;
 
     NSError* formatError = nil;
     NSString* pretty = [phoneUtil format:phoneNumber

--- a/Signal/src/phone/callstate/CallController.m
+++ b/Signal/src/phone/callstate/CallController.m
@@ -144,11 +144,11 @@
 -(void) enableBackground {
     [progress watchLatestValueOnArbitraryThread:^(CallProgress* latestProgress) {
         if( CallProgressType_Connecting == latestProgress.type) {
-            backgroundtask = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
+            backgroundtask = [UIApplication.sharedApplication beginBackgroundTaskWithExpirationHandler:^{
                 //todo: handle premature expiration
             }];
         }else if(CallProgressType_Terminated == latestProgress.type){
-            [[UIApplication sharedApplication] endBackgroundTask:backgroundtask];
+            [UIApplication.sharedApplication endBackgroundTask:backgroundtask];
         }
     } untilCancelled:canceller.getToken];
 }

--- a/Signal/src/phone/signaling/CallConnectUtil_Initiator.m
+++ b/Signal/src/phone/signaling/CallConnectUtil_Initiator.m
@@ -15,7 +15,7 @@
     
     require(remoteNumber != nil);
     require(callController != nil);
-    require([callController isInitiator]);
+    require(callController.isInitiator);
     
     Future* futureInitiatorSessionDescriptor = [self asyncConnectToSignalServerAndGetInitiatorSessionDescriptorWithCallController:callController];
     
@@ -101,12 +101,12 @@
     require(callController != nil);
     
     // heart beat?
-    if ([request isKeepAlive]) {
+    if (request.isKeepAlive) {
         return [HttpResponse httpResponse200Ok];
     }
     
     // too soon?
-    if (![futureInitiatorSessionDescriptor hasSucceeded]) {
+    if (!futureInitiatorSessionDescriptor.hasSucceeded) {
         [callController terminateWithReason:CallTerminationType_BadInteractionWithServer
                             withFailureInfo:[IgnoredPacketFailure new:@"Didn't receive session id from signaling server. Not able to understand request."]
                              andRelatedInfo:request];

--- a/Signal/src/phone/signaling/CallConnectUtil_Responder.m
+++ b/Signal/src/phone/signaling/CallConnectUtil_Responder.m
@@ -14,7 +14,7 @@
     
     require(sessionDescriptor != nil);
     require(callController != nil);
-    require(![callController isInitiator]);
+    require(!callController.isInitiator);
     
     Future* futureSignalsAreGo = [self asyncConnectToSignalServerDescribedBy:sessionDescriptor
                                                           withCallController:callController];
@@ -99,7 +99,7 @@
     require(callController != nil);
     
     // heart beat?
-    if ([request isKeepAlive]) {
+    if (request.isKeepAlive) {
         return [HttpResponse httpResponse200Ok];
     }
     

--- a/Signal/src/phone/signaling/CallConnectUtil_Server.m
+++ b/Signal/src/phone/signaling/CallConnectUtil_Server.m
@@ -158,7 +158,7 @@
     Future* futureRelaySocket = [futureFirstResponseData then:^id(NSData* openPortResponseData) {
         HttpResponse* openPortResponse = [HttpResponse httpResponseFromData:openPortResponseData];
         [logger markOccurrence:openPortResponse];
-        if (![openPortResponse isOkResponse]) return [Future failed:openPortResponse];
+        if (!openPortResponse.isOkResponse) return [Future failed:openPortResponse];
         
         return udpSocket;
     }];

--- a/Signal/src/phone/signaling/SignalUtil.m
+++ b/Signal/src/phone/signaling/SignalUtil.m
@@ -22,7 +22,7 @@
     sessionIdText = [sessionIdText stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
     NSNumber* sessionIdNumber = [sessionIdText tryParseAsDecimalNumber];
 
-    if ([sessionIdNumber hasLongLongValue]) return sessionIdNumber;
+    if (sessionIdNumber.hasLongLongValue) return sessionIdNumber;
     
     return nil;
 }

--- a/Signal/src/phone/signaling/number directory/PhoneNumberDirectoryFilter.m
+++ b/Signal/src/phone/signaling/number directory/PhoneNumberDirectoryFilter.m
@@ -35,7 +35,7 @@
 +(PhoneNumberDirectoryFilter*) phoneNumberDirectoryFilterFromHttpResponse:(HttpResponse*)response {
     require(response != nil);
     
-    checkOperation([response isOkResponse]);
+    checkOperation(response.isOkResponse);
     
     NSString* hashCountHeader = [response getHeaders][HASH_COUNT_HEADER_KEY];
     checkOperation(hashCountHeader != nil);

--- a/Signal/src/util/PhoneNumberUtil.m
+++ b/Signal/src/util/PhoneNumberUtil.m
@@ -15,13 +15,13 @@
 }
 
 + (NSString *)callingCodeFromCountryCode:(NSString *)code {
-    NSNumber *callingCode = [[NBPhoneNumberUtil sharedInstance] getCountryCodeForRegion:code];
+    NSNumber *callingCode = [NBPhoneNumberUtil.sharedInstance getCountryCodeForRegion:code];
     return [NSString stringWithFormat:@"%@%@", COUNTRY_CODE_PREFIX, callingCode];
 }
 
 + (NSArray *)countryCodesForSearchTerm:(NSString *)searchTerm {
     
-    NSArray *countryCodes = [NSLocale ISOCountryCodes];
+    NSArray *countryCodes = NSLocale.ISOCountryCodes;
     
     if (searchTerm) {
         countryCodes = [countryCodes filter:^int(NSString *code) {
@@ -33,7 +33,7 @@
 }
 
 + (NSString*) normalizePhoneNumber:(NSString *) number {
-    return [[NBPhoneNumberUtil sharedInstance] normalizePhoneNumber:number];
+    return [NBPhoneNumberUtil.sharedInstance normalizePhoneNumber:number];
 }
 
 @end

--- a/Signal/src/util/StringUtil.m
+++ b/Signal/src/util/StringUtil.m
@@ -138,7 +138,7 @@
 }
 -(NSNumber*) tryParseAsUnsignedInteger {
     NSNumber* value = [self tryParseAsDecimalNumber];
-    return [value hasUnsignedIntegerValue] ? value : nil;
+    return value.hasUnsignedIntegerValue ? value : nil;
 }
 
 @end

--- a/Signal/src/util/ThreadManager.m
+++ b/Signal/src/util/ThreadManager.m
@@ -29,7 +29,7 @@
 -(void) runLoopUntilCancelled {
     NSThread* curThread = [NSThread currentThread];
     NSRunLoop* curRunLoop = [NSRunLoop currentRunLoop];
-    while (![curThread isCancelled]) {
+    while (!curThread.isCancelled) {
         [curRunLoop runUntilDate:[NSDate dateWithTimeIntervalSinceNow:5]];
     }
 }
@@ -53,24 +53,24 @@ static ThreadManager* sharedThreadManagerInternal;
 }
 
 +(NSThread*)lowLatencyThread {
-    return [self sharedThreadManager]->low.thread;
+    return self.sharedThreadManager->low.thread;
 }
 +(NSRunLoop*)lowLatencyThreadRunLoop {
-    return [self sharedThreadManager]->low.runLoop;
+    return self.sharedThreadManager->low.runLoop;
 }
 
 +(NSThread*)normalLatencyThread {
-    return [self sharedThreadManager]->normal.thread;
+    return self.sharedThreadManager->normal.thread;
 }
 +(NSRunLoop *)normalLatencyThreadRunLoop {
-    return [self sharedThreadManager]->normal.runLoop;
+    return self.sharedThreadManager->normal.runLoop;
 }
 
 +(NSThread*)highLatencyThread {
-    return [self sharedThreadManager]->high.thread;
+    return self.sharedThreadManager->high.thread;
 }
 +(NSRunLoop *)highLatencyThreadRunLoop {
-    return [self sharedThreadManager]->high.runLoop;
+    return self.sharedThreadManager->high.runLoop;
 }
 
 +(void) terminate {

--- a/Signal/src/util/TimeUtil.m
+++ b/Signal/src/util/TimeUtil.m
@@ -114,7 +114,7 @@
     require(interval >= 0);
     require(!repeats || interval > 0);
     
-    if ([untilCancelledToken isAlreadyCancelled]) {
+    if (untilCancelledToken.isAlreadyCancelled) {
         return;
     }
     if (!repeats && interval == 0) {

--- a/Signal/src/view controllers/ContactBrowseViewController.m
+++ b/Signal/src/view controllers/ContactBrowseViewController.m
@@ -104,7 +104,7 @@ static NSString *const CONTACT_BROWSE_TABLE_CELL_IDENTIFIER = @"ContactTableView
     
     _newWhisperUsers = users;
 
-    BOOL isViewVisible = [self isViewLoaded] && self.view.window;
+    BOOL isViewVisible = self.isViewLoaded && self.view.window;
     
     if (isViewVisible) {
         [self showNotificationViewAnimated:YES];

--- a/Signal/src/view controllers/ContactDetailViewController.m
+++ b/Signal/src/view controllers/ContactDetailViewController.m
@@ -142,13 +142,13 @@ static NSString *const FAVOURITE_FALSE_ICON_NAME = @"favourite_false_icon";
 
 - (void)openPhoneAppWithPhoneNumber:(PhoneNumber *)phoneNumber {
     if (phoneNumber) {
-        [[UIApplication sharedApplication] openURL:[phoneNumber toSystemDialerURL]];
+        [UIApplication.sharedApplication openURL:[phoneNumber toSystemDialerURL]];
     }
 }
 
 - (void)openEmailAppWithEmail:(NSString *)email {
     NSString *mailURL = [NSString stringWithFormat:@"%@%@",MAIL_URL_PREFIX, email];
-    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:mailURL]];
+    [UIApplication.sharedApplication openURL:[NSURL URLWithString:mailURL]];
 }
 
 - (void)startSecureCallWithNumber:(PhoneNumber *)number {

--- a/Signal/src/view controllers/DialerViewController.m
+++ b/Signal/src/view controllers/DialerViewController.m
@@ -117,7 +117,7 @@
     
     if( shouldTryCall){
         [self initiateCallToPhoneNumber:phoneNumber];
-    }else if([phoneNumber isValid]){
+    }else if(phoneNumber.isValid){
         [self promptToInvitePhoneNumber:phoneNumber];
     }
 }

--- a/Signal/src/view controllers/FavouritesViewController.m
+++ b/Signal/src/view controllers/FavouritesViewController.m
@@ -89,7 +89,7 @@ static NSString *const CONTACT_TABLE_VIEW_CELL_IDENTIFIER = @"ContactTableViewCe
         }
     }
 
-    [[UIApplication sharedApplication] openURL:[contact.parsedPhoneNumbers[0] toSystemDialerURL]];
+    [UIApplication.sharedApplication openURL:[contact.parsedPhoneNumbers[0] toSystemDialerURL]];
 }
 
 #pragma mark - UITableViewDelegate

--- a/Signal/src/view controllers/InCallViewController.m
+++ b/Signal/src/view controllers/InCallViewController.m
@@ -62,7 +62,7 @@ static NSInteger connectingFlashCounter = 0;
     [super viewWillDisappear:animated];
     [self stopRingingAnimation];
     [self stopConnectingFlashAnimation];
-    [[AppAudioManager sharedInstance] cancellAllAudio];
+    [AppAudioManager.sharedInstance cancellAllAudio];
 }
 
 - (void)dealloc {
@@ -83,7 +83,7 @@ static NSInteger connectingFlashCounter = 0;
 }
 
 - (void)startConnectingFlashAnimation {
-    if(![_ringingAnimationTimer isValid]){
+    if(!_ringingAnimationTimer.isValid){
         _connectingFlashTimer = [NSTimer scheduledTimerWithTimeInterval:CONNECTING_FLASH_DURATION
                                                                  target:self
                                                                selector:@selector(flashConnectingIndicator)
@@ -206,7 +206,7 @@ static NSInteger connectingFlashCounter = 0;
 -(void) onCallProgressed:(CallProgress*)latestProgress {
     BOOL showAcceptRejectButtons = !_callState.initiatedLocally && [latestProgress type] <= CallProgressType_Ringing;
     [self displayAcceptRejectButtons:showAcceptRejectButtons];
-    [[AppAudioManager sharedInstance] respondToProgressChange:[latestProgress type]
+    [AppAudioManager.sharedInstance respondToProgressChange:[latestProgress type]
                                        forLocallyInitiatedCall:_callState.initiatedLocally];
     
     if ([latestProgress type] == CallProgressType_Ringing) {
@@ -216,7 +216,7 @@ static NSInteger connectingFlashCounter = 0;
     if ([latestProgress type] == CallProgressType_Terminated) {
         [[_callState futureTermination] thenDo:^(CallTermination* termination) {
             [self onCallEnded:termination];
-            [[AppAudioManager  sharedInstance] respondToTerminationType:[termination type]];
+            [AppAudioManager.sharedInstance respondToTerminationType:[termination type]];
         }];
     } else {
         _callStatusLabel.text = [latestProgress localizedDescriptionForUser];
@@ -244,7 +244,7 @@ static NSInteger connectingFlashCounter = 0;
 }
 
 - (void)speakerButtonTapped {
-    _speakerButton.selected = [[AppAudioManager sharedInstance] toggleSpeakerPhone];
+    _speakerButton.selected = [AppAudioManager.sharedInstance toggleSpeakerPhone];
 }
 
 - (void)answerButtonTapped {
@@ -274,7 +274,7 @@ static NSInteger connectingFlashCounter = 0;
 }
 
 -(void) dismissViewWithOptionalDelay:(BOOL) useDelay {
-    if(useDelay && UIApplicationStateActive == [[UIApplication sharedApplication] applicationState]){
+    if(useDelay && UIApplicationStateActive == [UIApplication.sharedApplication applicationState]){
         [self dismissViewControllerAfterDelay:END_CALL_CLEANUP_DELAY];
     }else{
         [self dismissViewControllerAnimated:NO completion:nil];

--- a/Signal/src/view controllers/InboxFeedViewController.m
+++ b/Signal/src/view controllers/InboxFeedViewController.m
@@ -63,7 +63,7 @@ static NSString *const FOOTER_TABLE_CELL_IDENTIFIER = @"InboxFeedFooterCell";
     [_searchBarTitleView updateAutoCorrectionType];
     [_inboxFeedTableView reloadData];
     
-    if (![Environment isRegistered]) {
+    if (!Environment.isRegistered) {
         [Environment resetAppData];
         RegisterViewController *registerViewController = [RegisterViewController registerViewController];
         [self presentViewController:registerViewController animated:NO completion:nil];

--- a/Signal/src/view controllers/LeftSideMenuViewController.m
+++ b/Signal/src/view controllers/LeftSideMenuViewController.m
@@ -124,15 +124,15 @@ static NSString *WHISPER_SYSTEMS_BUGREPORT_URL = @"http://support.whispersystems
 }
 
 - (void)openAboutWhisperUrl {
-    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:WHISPER_SYSTEMS_URL]];
+    [UIApplication.sharedApplication openURL:[NSURL URLWithString:WHISPER_SYSTEMS_URL]];
 }
 
 - (void)openBugReporterUrl {
-    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:WHISPER_SYSTEMS_BUGREPORT_URL]];
+    [UIApplication.sharedApplication openURL:[NSURL URLWithString:WHISPER_SYSTEMS_BUGREPORT_URL]];
 }
 
 - (void)openBlogUrl {
-    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:WHISPER_SYSTEMS_BLOG_URL]];
+    [UIApplication.sharedApplication openURL:[NSURL URLWithString:WHISPER_SYSTEMS_BLOG_URL]];
 }
 
 #pragma mark - UITableViewDelegate
@@ -186,7 +186,7 @@ static NSString *WHISPER_SYSTEMS_BUGREPORT_URL = @"http://support.whispersystems
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
     [tableView deselectRowAtIndexPath:indexPath animated:YES];
 
-    if ([self isLeftSideViewOpenCompletely]) {
+    if (self.isLeftSideViewOpenCompletely) {
         NSString *menuOption;
         if (indexPath.section == FIRST_SECTION_INDEX) {
             menuOption = _firstSectionOptions[(NSUInteger)indexPath.row];

--- a/Signal/src/view controllers/RegisterViewController.m
+++ b/Signal/src/view controllers/RegisterViewController.m
@@ -46,7 +46,7 @@
     
     _scrollView.contentSize = _containerView.bounds.size;
 
-    BOOL isRegisteredAlready = [Environment isRegistered];
+    BOOL isRegisteredAlready = Environment.isRegistered;
     _registerCancelButton.hidden = !isRegisteredAlready;
 
     [self initializeKeyboardHandlers];
@@ -101,7 +101,7 @@
 - (void)populateDefaultCountryNameAndCode {
     NSLocale *locale = [NSLocale currentLocale];
     NSString *countryCode = [locale objectForKey:NSLocaleCountryCode];
-    NSNumber *cc = [[NBPhoneNumberUtil sharedInstance] getCountryCodeForRegion:countryCode];
+    NSNumber *cc = [NBPhoneNumberUtil.sharedInstance getCountryCodeForRegion:countryCode];
     
     _countryCodeLabel.text = [NSString stringWithFormat:@"%@%@",COUNTRY_CODE_PREFIX, cc];
     _countryNameLabel.text = [PhoneNumberUtil countryNameFromCountryCode:countryCode];
@@ -202,7 +202,7 @@
     }];
     
     [futureChallengeAcceptedSource thenDo:^(id value) {
-        [[PushManager sharedManager] askForPushRegistrationWithSuccess:^{
+        [PushManager.sharedManager askForPushRegistrationWithSuccess:^{
             [Environment setRegistered:YES];
             [registered trySetResult:@YES];
             [[[Environment getCurrent] phoneDirectoryManager] forceUpdate];

--- a/Signal/src/view controllers/SettingsViewController.m
+++ b/Signal/src/view controllers/SettingsViewController.m
@@ -231,10 +231,10 @@ static NSString *const CHECKBOX_EMPTY_IMAGE_NAME = @"checkbox_empty";
     BOOL loggingEnabled = !_disableDebugLogsButton.selected;
     
     if (!loggingEnabled) {
-        [[DebugLogger sharedInstance] disableFileLogging];
-        [[DebugLogger sharedInstance] wipeLogs];
+        [DebugLogger.sharedInstance disableFileLogging];
+        [DebugLogger.sharedInstance wipeLogs];
     } else{
-        [[DebugLogger sharedInstance] enableFileLogging];
+        [DebugLogger.sharedInstance enableFileLogging];
     }
 
     [[Environment preferences] setLoggingEnabled:loggingEnabled];
@@ -338,13 +338,13 @@ static NSString *const CHECKBOX_EMPTY_IMAGE_NAME = @"checkbox_empty";
     
     NSString *urlString = [NSString stringWithString: [[NSString stringWithFormat:@"mailto:%@?subject=iOS%%20Debug%%20Log&body=", emailAddress] stringByAppendingString:[[NSString stringWithFormat:@"Log URL: %@ \n Tell us about the issue: ", url]stringByAddingPercentEscapesUsingEncoding:NSASCIIStringEncoding]]];
     
-    [[UIApplication sharedApplication] openURL: [NSURL URLWithString: urlString]];
+    [UIApplication.sharedApplication openURL: [NSURL URLWithString: urlString]];
 }
 
 - (void)pasteBoardCopy:(NSString*)url{
     UIPasteboard *pb = [UIPasteboard generalPasteboard];
     [pb setString:url];
-    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"https://github.com/WhisperSystems/Signal-iOS/issues"]];
+    [UIApplication.sharedApplication openURL:[NSURL URLWithString:@"https://github.com/WhisperSystems/Signal-iOS/issues"]];
 }
 
 - (void)findAndLocalizeLabelsForView:(UIView *)view {

--- a/Signal/src/views/InteractiveLabel.m
+++ b/Signal/src/views/InteractiveLabel.m
@@ -37,7 +37,7 @@
 -(void) didRegisterLongPress:(UILongPressGestureRecognizer*) recognizer {
     if (recognizer.state == UIGestureRecognizerStateBegan) {
         [self becomeFirstResponder];
-        UIMenuController *menu = [UIMenuController sharedMenuController];
+        UIMenuController *menu = UIMenuController.sharedMenuController;
         [menu setTargetRect:self.frame inView:self.superview];
         [menu setMenuVisible:YES animated:YES];
 

--- a/Signal/test/async/AsyncUtilTest.m
+++ b/Signal/test/async/AsyncUtilTest.m
@@ -19,9 +19,9 @@
     CancellableOperationStarter (^makeStarter)(Future*) = ^(Future* future) {
         return ^(id<CancelToken> c) {
             [c whenCancelled:^{
-                if ([future hasFailed]) f += 1;
-                if ([future hasSucceeded]) s += 1;
-                if ([future isIncomplete]) i += 1;
+                if (future.hasFailed) f += 1;
+                if (future.hasSucceeded) s += 1;
+                if (future.isIncomplete) i += 1;
             }];
             return future;
         };
@@ -35,11 +35,11 @@
                                       untilCancelled:nil];
     
     [v2 trySetFailure:@1];
-    test([r isIncomplete]);
+    test(r.isIncomplete);
     test(f == 0 && s == 0 && i == 0);
     
     [v3 trySetResult:@2];
-    test([r hasSucceeded]);
+    test(r.hasSucceeded);
     test([[r forceGetResult] isEqual:@2]);
     test(f == 1 && s == 0 && i == 1);
     
@@ -65,7 +65,7 @@
                                       untilCancelled:[CancelledToken cancelledToken]];
     
     test(i == 3);
-    test([r hasFailed]);
+    test(r.hasFailed);
     test([(NSArray*)[r forceGetFailure] count] == 3);
 }
 -(void) testRaceCancellableOperations_Losers {
@@ -78,7 +78,7 @@
     
     Future* r = [AsyncUtil raceCancellableOperations:(@[s,s,s])
                                       untilCancelled:nil];
-    test([r hasFailed]);
+    test(r.hasFailed);
     test([[r forceGetFailure] isEqual:(@[@1,@1,@1])]);
 }
 
@@ -100,7 +100,7 @@
     Future* f = [AsyncUtil raceCancellableOperation:s
                                      againstTimeout:1.0
                                      untilCancelled:[cts getToken]];
-    test([f hasFailed]);
+    test(f.hasFailed);
     test([[f forceGetFailure] isEqual:@1]);
     test(n == 0);
 }
@@ -122,7 +122,7 @@
     Future* f = [AsyncUtil raceCancellableOperation:s
                                      againstTimeout:1.0
                                      untilCancelled:[cts getToken]];
-    test([f hasSucceeded]);
+    test(f.hasSucceeded);
     test([[f forceGetResult] isEqual:@1]);
     test(n == 0);
 }
@@ -146,7 +146,7 @@
                                      untilCancelled:[cts getToken]];
     
     test(n == 0);
-    testChurnUntil([f hasFailed], 1.0);
+    testChurnUntil(f.hasFailed, 1.0);
     test(n == 1);
     test([[f forceGetFailure] isKindOfClass:[TimeoutFailure class]]);
 }
@@ -172,7 +172,7 @@
     test(n == 0);
     [cts cancel];
     test(n == 1);
-    testChurnUntil([f hasFailed], 1.0);
+    testChurnUntil(f.hasFailed, 1.0);
     test([[f forceGetFailure] conformsToProtocol:@protocol(CancelToken)]);
 }
 
@@ -191,11 +191,11 @@
                     withBaseTimeout:0.5/8
                      andRetryFactor:2
                      untilCancelled:nil];
-    testChurnUntil(![f isIncomplete], 5.0);
+    testChurnUntil(!f.isIncomplete, 5.0);
 
     test(repeat == 3 || repeat == 4);
     test(evalCount == 1);
-    test([f hasSucceeded]);
+    test(f.hasSucceeded);
     test([[f forceGetResult] isEqual:@YES]);
 }
 -(void) testAsyncTryFail {
@@ -213,11 +213,11 @@
                     withBaseTimeout:0.5/8
                      andRetryFactor:2
                      untilCancelled:nil];
-    testChurnUntil(![f isIncomplete], 5.0);
+    testChurnUntil(!f.isIncomplete, 5.0);
     
     test(repeat >= 1);
     test(evalCount >= 1);
-    test([f hasFailed]);
+    test(f.hasFailed);
     test([[f forceGetFailure] isEqual:@13]);
 }
 -(void) testAsyncTryTimeout {
@@ -235,11 +235,11 @@
                     withBaseTimeout:0.5/8
                      andRetryFactor:2
                      untilCancelled:nil];
-    testChurnUntil(![f isIncomplete], 5.0);
+    testChurnUntil(!f.isIncomplete, 5.0);
     
     test(repeat == 2);
     test(evalCount == 0);
-    test([f hasFailed]);
+    test(f.hasFailed);
     test([[f forceGetFailure] isKindOfClass:[TimeoutFailure class]]);
 }
 -(void) testAsyncTryCancel {
@@ -262,11 +262,11 @@
                     withBaseTimeout:0.5/8
                      andRetryFactor:2
                      untilCancelled:[s getToken]];
-    testChurnUntil(![f isIncomplete], 5.0);
+    testChurnUntil(!f.isIncomplete, 5.0);
     
     test(repeat == 2);
     test(evalCount == 0);
-    test([f hasFailed]);
+    test(f.hasFailed);
     test([[f forceGetFailure] conformsToProtocol:@protocol(CancelToken)]);
 }
 

--- a/Signal/test/async/FutureSourceTest.m
+++ b/Signal/test/async/FutureSourceTest.m
@@ -11,47 +11,47 @@
 
 -(void) testConstructors {
     FutureSource* inc = [FutureSource new];
-    test([inc isIncomplete]);
-    test(![inc hasSucceeded]);
-    test(![inc hasFailed]);
+    test(inc.isIncomplete);
+    test(!inc.hasSucceeded);
+    test(!inc.hasFailed);
     testThrows([inc forceGetResult]);
     testThrows([inc forceGetFailure]);
 
     FutureSource* done = [FutureSource finished:@1];
-    test(![done isIncomplete]);
-    test([done hasSucceeded]);
-    test(![done hasFailed]);
+    test(!done.isIncomplete);
+    test(done.hasSucceeded);
+    test(!done.hasFailed);
     testDoesNotThrow([done forceGetResult]);
     testThrows([done forceGetFailure]);
 
     Future* done2 = [Future finished:@2];
-    test(![done2 isIncomplete]);
-    test([done2 hasSucceeded]);
-    test(![done2 hasFailed]);
+    test(!done2.isIncomplete);
+    test(done2.hasSucceeded);
+    test(!done2.hasFailed);
     testDoesNotThrow([done2 forceGetResult]);
     testThrows([done2 forceGetFailure]);
 
     FutureSource* fail3 = [FutureSource failed:@3];
-    test(![fail3 isIncomplete]);
-    test(![fail3 hasSucceeded]);
-    test([fail3 hasFailed]);
+    test(!fail3.isIncomplete);
+    test(!fail3.hasSucceeded);
+    test(fail3.hasFailed);
     testThrows([fail3 forceGetResult]);
     testDoesNotThrow([fail3 forceGetFailure]);
 
     Future* fail4 = [Future failed:@4];
-    test(![fail4 isIncomplete]);
-    test(![fail4 hasSucceeded]);
-    test([fail4 hasFailed]);
+    test(!fail4.isIncomplete);
+    test(!fail4.hasSucceeded);
+    test(fail4.hasFailed);
     testThrows([fail4 forceGetResult]);
     testDoesNotThrow([fail4 forceGetFailure]);    
 }
 -(void) testAutoUnwrap {
     Future* f = [Future finished:[Future finished:[Future failed:@1]]];
-    test([f hasFailed]);
+    test(f.hasFailed);
     test([[f forceGetFailure] isEqual:@1]);
     
     Future* f2 = [Future finished:[Future finished:[Future finished:@2]]];
-    test([f2 hasSucceeded]);
+    test(f2.hasSucceeded);
     test([[f2 forceGetResult] isEqual:@2]);
 
     test([[[[Future finished:@1] then:^id(id value) {
@@ -72,7 +72,7 @@
     
     // set result
     test([setR trySetResult:@1]);
-    test([setR hasSucceeded]);
+    test(setR.hasSucceeded);
     test(![setR trySetResult:@0]);
     test(![setR trySetFailure:@0]);
     test(![setR trySetResult:wr]);
@@ -81,7 +81,7 @@
 
     // set fail
     test([setF trySetFailure:@2]);
-    test([setF hasFailed]);
+    test(setF.hasFailed);
     test(![setF trySetResult:@0]);
     test(![setF trySetFailure:@0]);
     test(![setF trySetResult:wr]);
@@ -90,7 +90,7 @@
 
     // wire result
     test([setWR trySetResult:wr]);
-    test([setWR isIncomplete]);
+    test(setWR.isIncomplete);
     test(![setWR trySetResult:@0]);
     test(![setWR trySetFailure:@0]);
     test(![setWR trySetResult:wf]);
@@ -98,22 +98,22 @@
     
     // wire failure
     test([setWF trySetResult:wf]);
-    test([setWF isIncomplete]);
+    test(setWF.isIncomplete);
     test(![setWF trySetResult:@0]);
     test(![setWF trySetFailure:@0]);
     test(![setWF trySetResult:wf]);
     test(![setWF trySetResult:wr]);
 
     // set result via wire
-    test([setWR isIncomplete]);
+    test(setWR.isIncomplete);
     [wr trySetResult:@3];
-    test([setWR hasSucceeded]);
+    test(setWR.hasSucceeded);
     test([[setWR forceGetResult] isEqual:@3]);
 
     // set failure via wire
-    test([setWF isIncomplete]);
+    test(setWF.isIncomplete);
     [wf trySetFailure:@4];
-    test([setWF hasFailed]);
+    test(setWF.hasFailed);
     test([[setWF forceGetFailure] isEqual:@4]);
 }
 
@@ -257,7 +257,7 @@
         test([value isEqual:@1]);
         return @2;
     }];
-    test([f2 isIncomplete]);
+    test(f2.isIncomplete);
     [f trySetResult:@1];
     test([[f2 forceGetResult] isEqual:@2]);
 
@@ -290,7 +290,7 @@
         test([value isEqual:@1]);
         return @2;
     }];
-    test([f2 isIncomplete]);
+    test(f2.isIncomplete);
     [f trySetFailure:@1];
     test([[f2 forceGetResult] isEqual:@2]);
     
@@ -323,7 +323,7 @@
         test([[completed forceGetResult] isEqual:@1]);
         return @2;
     }];
-    test([f2 isIncomplete]);
+    test(f2.isIncomplete);
     [f trySetResult:@1];
     test([[f2 forceGetResult] isEqual:@2]);
     
@@ -338,16 +338,16 @@
 -(void) completedAsCancelToken_OnSuccess {
     FutureSource* f = [FutureSource new];
     id<CancelToken> c = [f completionAsCancelToken];
-    test(![c isAlreadyCancelled]);
+    test(!c.isAlreadyCancelled);
     [f trySetResult:nil];
-    test([c isAlreadyCancelled]);
+    test(c.isAlreadyCancelled);
 }
 -(void) completedAsCancelToken_OnFailure {
     FutureSource* f = [FutureSource new];
     id<CancelToken> c = [f completionAsCancelToken];
-    test(![c isAlreadyCancelled]);
+    test(!c.isAlreadyCancelled);
     [f trySetFailure:nil];
-    test([c isAlreadyCancelled]);
+    test(c.isAlreadyCancelled);
 }
 
 @end

--- a/Signal/test/network/dns/DnsManagerTest.m
+++ b/Signal/test/network/dns/DnsManagerTest.m
@@ -22,21 +22,21 @@
 -(void) testQueryAddresses_Sequential {
     Future* f1 = [DnsManager asyncQueryAddressesForDomainName:reliableHostName
                                               unlessCancelled:nil];
-    testChurnUntil([f1 hasSucceeded], 5.0);
+    testChurnUntil(f1.hasSucceeded, 5.0);
     test([(NSArray*)[f1 forceGetResult] count] > 0);
 
     Future* f2 = [DnsManager asyncQueryAddressesForDomainName:invalidHostname
                                               unlessCancelled:nil];
-    testChurnUntil([f2 hasFailed], 5.0);
+    testChurnUntil(f2.hasFailed, 5.0);
 
     Future* f3 = [DnsManager asyncQueryAddressesForDomainName:nonExistentHostname
                                               unlessCancelled:nil];
-    testChurnUntil([f3 hasFailed], 5.0);
+    testChurnUntil(f3.hasFailed, 5.0);
 
     Future* f4 = [DnsManager asyncQueryAddressesForDomainName:infrastructureTestHostName
                                               unlessCancelled:nil];
-    testChurnUntil([f4 hasSucceeded], 5.0);
-    test([f4 hasSucceeded] && [(NSArray*)[f4 forceGetResult] count] > 0);
+    testChurnUntil(f4.hasSucceeded, 5.0);
+    test(f4.hasSucceeded && [(NSArray*)[f4 forceGetResult] count] > 0);
     
 }
 
@@ -50,9 +50,9 @@
     Future* f4 = [DnsManager asyncQueryAddressesForDomainName:infrastructureTestHostName
                                               unlessCancelled:nil];
     
-    testChurnUntil([f1 hasSucceeded] && [f2 hasFailed] && [f3 hasFailed] && [f4 hasSucceeded], 5.0);
-    test([f1 hasSucceeded] && [(NSArray*)[f1 forceGetResult] count] > 0);
-    test([f4 hasSucceeded] && [(NSArray*)[f4 forceGetResult] count] > 0);
+    testChurnUntil(f1.hasSucceeded && f2.hasFailed && f3.hasFailed && f4.hasSucceeded, 5.0);
+    test(f1.hasSucceeded && [(NSArray*)[f1 forceGetResult] count] > 0);
+    test(f4.hasSucceeded && [(NSArray*)[f4 forceGetResult] count] > 0);
 }
 
 -(void) testQueryAddresses_Cancel {
@@ -67,11 +67,11 @@
                                               unlessCancelled:[c getToken]];
     [c cancel];
     
-    testChurnUntil(![f1 isIncomplete] && [f2 hasFailed] && [f3 hasFailed] && ![f4 isIncomplete], 5.0);
-    test([f1 hasSucceeded] || [[f1 forceGetFailure] conformsToProtocol:@protocol(CancelToken)]);
-    test([f2 hasFailed]);
-    test([f3 hasFailed]);
-    test([f4 hasSucceeded] || [[f4 forceGetFailure] conformsToProtocol:@protocol(CancelToken)]);
+    testChurnUntil(!f1.isIncomplete && f2.hasFailed && f3.hasFailed && !f4.isIncomplete, 5.0);
+    test(f1.hasSucceeded || [[f1 forceGetFailure] conformsToProtocol:@protocol(CancelToken)]);
+    test(f2.hasFailed);
+    test(f3.hasFailed);
+    test(f4.hasSucceeded || [[f4 forceGetFailure] conformsToProtocol:@protocol(CancelToken)]);
 }
 
 -(void)testQueryAddresses_FastCancel {
@@ -79,7 +79,7 @@
     Future* f = [DnsManager asyncQueryAddressesForDomainName:reliableHostName
                                              unlessCancelled:[c getToken]];
     [c cancel];
-    test(![f isIncomplete]);
+    test(!f.isIncomplete);
 }
 
 @end

--- a/Signal/test/network/http/HttpRequestResponseTest.m
+++ b/Signal/test/network/http/HttpRequestResponseTest.m
@@ -79,14 +79,14 @@
 }
 -(void) testResponseFromData {
     HttpResponse* h = [HttpResponse httpResponseFromData:[@"HTTP/1.1 200 OK\r\n\r\n" encodedAsUtf8]];
-    test([h isOkResponse]);
+    test(h.isOkResponse);
     test([h getStatusCode] == 200);
     test([[h getStatusText] isEqualToString: @"OK"]);
     test([h getOptionalBodyText] == nil);
     test([[h getHeaders] count] == 0);
     
     HttpResponse* h2 = [HttpResponse httpResponseFromData:[@"HTTP/1.1 404 Not Found\r\n\r\n" encodedAsUtf8]];
-    test(![h2 isOkResponse]);
+    test(!h2.isOkResponse);
     test([h2 getStatusCode] == 404);
     test([[h2 getStatusText] isEqualToString:@"Not Found"]);
     test([h2 getOptionalBodyText] == nil);
@@ -106,12 +106,12 @@
     test(h == nil);
 
     h = [HttpRequestOrResponse tryExtractFromPartialData:[@"HTTP/1.1 200 OK\r\n\r\n" encodedAsUtf8] usedLengthOut:&len];
-    test([h isResponse]);
+    test(h.isResponse);
     test([[h response] isOkResponse]);
     test(len == 19);
     
     h = [HttpRequestOrResponse tryExtractFromPartialData:[@"HTTP/1.1 200 OK\r\n\r\n*&DY*SWA(TD&(BTNGNSADN" encodedAsUtf8] usedLengthOut:&len];
-    test([h isResponse]);
+    test(h.isResponse);
     test([[h response] isOkResponse]);
     test(len == 19);
 
@@ -121,12 +121,12 @@
     test(h == nil);
     
     h = [HttpRequestOrResponse tryExtractFromPartialData:[@"GET /index.html HTTP/1.0\r\n\r\n" encodedAsUtf8] usedLengthOut:&len];
-    test([h isRequest]);
+    test(h.isRequest);
     test([[[h request] method] isEqualToString:@"GET"]);
     test(len == 28);
     
     h = [HttpRequestOrResponse tryExtractFromPartialData:[@"GET /index.html HTTP/1.0\r\n\r\nU$%#*(NYVYAY*" encodedAsUtf8] usedLengthOut:&len];
-    test([h isRequest]);
+    test(h.isRequest);
     test([[[h request] method] isEqualToString:@"GET"]);
     test(len == 28);
 

--- a/Signal/test/network/rtp/RtpPacketTests.m
+++ b/Signal/test/network/rtp/RtpPacketTests.m
@@ -26,10 +26,10 @@
     // values were retained
     test([r version] == 2);
     test([r padding] == 0);
-    test([r hasExtensionHeader] == false);
+    test(r.hasExtensionHeader == false);
     test([[r contributingSourceIdentifiers] count] == 0);
     test([r synchronizationSourceIdentifier] == 0);
-    test([r isMarkerBitSet] == false);
+    test(r.isMarkerBitSet == false);
     test([r payloadType] == 0);
     test([r sequenceNumber] == 5);
     test([r timeStamp] == 0);
@@ -64,10 +64,10 @@
     // values were retained
     test([r version] == 2);
     test([r padding] == 3);
-    test([r hasExtensionHeader] == false);
+    test(r.hasExtensionHeader == false);
     test([[r contributingSourceIdentifiers] isEqualToArray:(@[@101, @102])]);
     test([r synchronizationSourceIdentifier] == 0x45645645);
-    test([r isMarkerBitSet] == true);
+    test(r.isMarkerBitSet == true);
     test([r payloadType] == 0x77);
     test([r sequenceNumber] == 0x2122);
     test([r timeStamp] == 0xABCDEFAB);
@@ -102,12 +102,12 @@
     // values were retained
     test([r version] == 2);
     test([r padding] == 0);
-    test([r hasExtensionHeader] == true);
+    test(r.hasExtensionHeader == true);
     test([r extensionHeaderIdentifier] == 0xFEAB);
     test([[r extensionHeaderData] isEqualToData:increasingDataFrom(10, 5)]);
     test([[r contributingSourceIdentifiers] count] == 0);
     test([r synchronizationSourceIdentifier] == 0);
-    test([r isMarkerBitSet] == false);
+    test(r.isMarkerBitSet == false);
     test([r payloadType] == 0);
     test([r sequenceNumber] == 5);
     test([r timeStamp] == 0);

--- a/Signal/test/network/rtp/zrtp/ZrtpTest.m
+++ b/Signal/test/network/rtp/zrtp/ZrtpTest.m
@@ -45,9 +45,9 @@ bool pm(HandshakePacket* p1, HandshakePacket* p2) {
     Future* f2 = [ZrtpManager asyncPerformHandshakeOver:[RtpSocket rtpSocketOverUdp:u2 interopOptions:@[]]
                                       andCallController:cc2];
     
-    testChurnUntil(![f1 isIncomplete] && ![f2 isIncomplete], 15.0);
-    test([f1 hasSucceeded]);
-    test([f2 hasSucceeded]);
+    testChurnUntil(!f1.isIncomplete && !f2.isIncomplete, 15.0);
+    test(f1.hasSucceeded);
+    test(f2.hasSucceeded);
     
     [cc1 terminateWithReason:CallTerminationType_HangupLocal withFailureInfo:nil andRelatedInfo:nil];
     [cc2 terminateWithReason:CallTerminationType_HangupLocal withFailureInfo:nil andRelatedInfo:nil];
@@ -72,12 +72,12 @@ bool pm(HandshakePacket* p1, HandshakePacket* p2) {
     Future* f2 = [ZrtpManager asyncPerformHandshakeOver:[RtpSocket rtpSocketOverUdp:u2 interopOptions:@[]]
                                       andCallController:cc2];
     
-    testChurnUntil(![f2 isIncomplete], 15.0);
-    test([f2 hasSucceeded]);
-    test([f1 isIncomplete]);
+    testChurnUntil(!f2.isIncomplete, 15.0);
+    test(f2.hasSucceeded);
+    test(f1.isIncomplete);
     
     // send authenticated data to signal end of handshake
-    if ([f2 hasSucceeded]) {
+    if (f2.hasSucceeded) {
         ZrtpHandshakeResult* result = [f2 forceGetResult];
         SrtpSocket* socket = [result secureRtpSocket];
         [socket startWithHandler:[PacketHandler packetHandler:^(id packet) { test(false); }
@@ -87,8 +87,8 @@ bool pm(HandshakePacket* p1, HandshakePacket* p2) {
     }
     
     
-    testChurnUntil(![f1 isIncomplete], 5.0);
-    test([f1 hasSucceeded]);
+    testChurnUntil(!f1.isIncomplete, 5.0);
+    test(f1.hasSucceeded);
     
     [cc1 terminateWithReason:CallTerminationType_HangupLocal withFailureInfo:nil andRelatedInfo:nil];
     [cc2 terminateWithReason:CallTerminationType_HangupLocal withFailureInfo:nil andRelatedInfo:nil];

--- a/Signal/test/network/tcp/LowLatencyConnectorTest.m
+++ b/Signal/test/network/tcp/LowLatencyConnectorTest.m
@@ -27,7 +27,7 @@
                                                                                                              andPort:80]
                                                        untilCancelled:nil];
     
-    testChurnUntil(![f isIncomplete], 5.0);
+    testChurnUntil(!f.isIncomplete, 5.0);
     
     LowLatencyCandidate* r = [f forceGetResult];
     NetworkStream* channel = [r networkStream];
@@ -58,7 +58,7 @@
                                                                                                              andPort:80]
                                                        untilCancelled:nil];
     
-    testChurnUntil(![f isIncomplete], 5.0);
+    testChurnUntil(!f.isIncomplete, 5.0);
     
     LowLatencyCandidate* r = [f forceGetResult];
     NetworkStream* channel = [r networkStream];
@@ -87,9 +87,9 @@
     Future* f = [LowLatencyConnector asyncLowLatencyConnectToEndPoint:[HostNameEndPoint hostNameEndPointWithHostName:reliableHostName andPort:80]
                                                        untilCancelled:[CancelledToken cancelledToken]];
     
-    testChurnUntil(![f isIncomplete], 5.0);
+    testChurnUntil(!f.isIncomplete, 5.0);
     
-    test([f hasFailed]);
+    test(f.hasFailed);
 }
 
 @end

--- a/Signal/test/network/tcp/tls/NetworkStreamTest.m
+++ b/Signal/test/network/tcp/tls/NetworkStreamTest.m
@@ -91,9 +91,9 @@
     }]];
     Future* f = [s asyncConnectionCompleted];
     
-    testChurnUntil(![f isIncomplete], 5.0);
+    testChurnUntil(!f.isIncomplete, 5.0);
     
-    test([f hasSucceeded] && [[f forceGetResult] isEqual:@YES]);
+    test(f.hasSucceeded && [[f forceGetResult] isEqual:@YES]);
     
     [s terminate];
 }

--- a/Signal/test/network/udp/UdpSocketTest.m
+++ b/Signal/test/network/udp/UdpSocketTest.m
@@ -40,9 +40,9 @@
         failed = true;
     }] untilCancelled:[senderLife getToken]];
     
-    test([receiver isLocalPortKnown]);
+    test(receiver.isLocalPortKnown);
     test([receiver localPort] == port1);
-    test([sender isLocalPortKnown]);
+    test(sender.isLocalPortKnown);
     test([sender localPort] == port2);
 
     testChurnAndConditionMustStayTrue(received == nil, 0.1);
@@ -146,9 +146,9 @@
         test(false);
     }] untilCancelled:[senderLife getToken]];
     
-    test(![listener isRemoteEndPointKnown]);
+    test(!listener.isRemoteEndPointKnown);
     testThrows([listener remoteEndPoint]);
-    test([client isRemoteEndPointKnown]);
+    test(client.isRemoteEndPointKnown);
     test([client remoteEndPoint] == e);
     test(listenerReceiveCount == 0);
     test(clientReceiveCount == 0);
@@ -156,7 +156,7 @@
     [client send:increasingData(10)];
     testChurnUntil(listenerReceiveCount > 0, 1.0);
     test(clientReceiveCount == 0);
-    test([listener isRemoteEndPointKnown]);
+    test(listener.isRemoteEndPointKnown);
     test([[[[listener remoteEndPoint] address] description] isEqualToString:@"127.0.0.1"]);
     test(listenerReceiveLength == 10);
     test([listenerReceivedLast isEqualToData:increasingData(10)]);

--- a/Signal/test/util/CancelTokenTest.m
+++ b/Signal/test/util/CancelTokenTest.m
@@ -74,7 +74,7 @@
         }
     }
     test(c != nil);
-    test(![c isAlreadyCancelled]);
+    test(!c.isAlreadyCancelled);
     test(dealloced);
 }
 

--- a/Signal/test/util/UtilTest.m
+++ b/Signal/test/util/UtilTest.m
@@ -350,33 +350,33 @@
     testThrows([@"0" decodedAsHexString]);
 }
 -(void) testHasUnsignedIntegerValue {
-    test([@0 hasUnsignedIntegerValue]);
-    test([@1 hasUnsignedIntegerValue]);
-    test([@0xFFFFFFFF hasUnsignedIntegerValue]);
-    test([@(pow(2, 31)) hasUnsignedIntegerValue]);
-    test(![@-1 hasUnsignedIntegerValue]);
-    test(![@0.5 hasUnsignedIntegerValue]);
+    test((@0).hasUnsignedIntegerValue);
+    test((@1).hasUnsignedIntegerValue);
+    test((@0xFFFFFFFF).hasUnsignedIntegerValue);
+    test(@(pow(2, 31)).hasUnsignedIntegerValue);
+    test(!(@-1).hasUnsignedIntegerValue);
+    test(!(@0.5).hasUnsignedIntegerValue);
 }
 -(void) testHasUnsignedLongLongValue {
-    test([@0 hasUnsignedLongLongValue]);
-    test([@1 hasUnsignedLongLongValue]);
-    test([@0xFFFFFFFFFFFFFFFF hasUnsignedLongLongValue]);
-    test([@(pow(2, 63)) hasUnsignedLongLongValue]);
-    test(![@(pow(2, 64)) hasUnsignedLongLongValue]);
-    test(![@-1 hasUnsignedLongLongValue]);
-    test(![@0.5 hasUnsignedLongLongValue]);
+    test((@0).hasUnsignedLongLongValue);
+    test((@1).hasUnsignedLongLongValue);
+    test((@0xFFFFFFFFFFFFFFFF).hasUnsignedLongLongValue);
+    test(@(pow(2, 63)).hasUnsignedLongLongValue);
+    test(!@(pow(2, 64)).hasUnsignedLongLongValue);
+    test(!(@-1).hasUnsignedLongLongValue);
+    test(!(@0.5).hasUnsignedLongLongValue);
 }
 -(void) testHasLongLongValue {
-    test([@0 hasLongLongValue]);
-    test([@1 hasLongLongValue]);
-    test([@-11 hasLongLongValue]);
-    test([@LONG_LONG_MAX hasLongLongValue]);
-    test([@LONG_LONG_MIN hasLongLongValue]);
-    test(![@ULONG_LONG_MAX hasLongLongValue]);
-    test([@(pow(2, 62)) hasLongLongValue]);
-    test(![@(pow(2, 63)) hasLongLongValue]);
-    test(![@(-pow(2, 64)) hasLongLongValue]);
-    test(![@0.5 hasLongLongValue]);
+    test((@0).hasLongLongValue);
+    test((@1).hasLongLongValue);
+    test((@-11).hasLongLongValue);
+    test(@LONG_LONG_MAX.hasLongLongValue);
+    test(@LONG_LONG_MIN.hasLongLongValue);
+    test(!@ULONG_LONG_MAX.hasLongLongValue);
+    test(@(pow(2, 62)).hasLongLongValue);
+    test(!@(pow(2, 63)).hasLongLongValue);
+    test(!@(-pow(2, 64)).hasLongLongValue);
+    test(!(@0.5).hasLongLongValue);
 }
 -(void) tryParseAsUnsignedInteger {
     test([@"" tryParseAsUnsignedInteger] == nil);


### PR DESCRIPTION
Ran a search against `\[([^\*\]\[]+) (is[a-z_]*)\]`, `\[([^\*\]\[]+) (has[a-z_]*)\]`, and `\[([^\*\]\[]+) (shared[a-z_]*)\]`, replacing them with `\1.\2`.

(Then checked it all over, undid hashChainGeneratedWhatever being converted, and fixed a few spacing mixups.)
