### PR TITLE
Using dot syntax for local*, all*, full*, first*, last*, to*, encodedAs*...

### DIFF
--- a/Signal/src/audio/SoundPlayer.m
+++ b/Signal/src/audio/SoundPlayer.m
@@ -50,7 +50,7 @@ NSMutableDictionary* currentActiveAudioPlayers;
 }
 
 -(void) stopAllAudio{
-    for( SoundInstance* sound in [currentActiveAudioPlayers allValues]){
+    for( SoundInstance* sound in currentActiveAudioPlayers.allValues){
         [self stopSound:sound];
     }
 }
@@ -60,7 +60,7 @@ NSMutableDictionary* currentActiveAudioPlayers;
 }
 
 -(void) awake {
-    for( SoundInstance* sound in [currentActiveAudioPlayers allValues]){
+    for( SoundInstance* sound in currentActiveAudioPlayers.allValues){
         [sound play];
     }
 }

--- a/Signal/src/call/RecentCallManager.m
+++ b/Signal/src/call/RecentCallManager.m
@@ -95,20 +95,20 @@ typedef BOOL (^SearchTermConditionalBlock)(RecentCall*, NSUInteger, BOOL*);
 
 -(void) updateRecentCall:(RecentCall*) recentCall withContactId:(ABRecordID) contactId {
     [recentCall updateRecentCallWithContactId:contactId];
-    [observableRecentsController updateValue:[_allRecents copy]];
+    [observableRecentsController updateValue:_allRecents.copy];
     [self saveContactsToDefaults];
 }
 
 - (void)addRecentCall:(RecentCall *)recentCall {
     [_allRecents insertObject:recentCall atIndex:0];
     [[Environment preferences] setFreshInstallTutorialsEnabled:NO];
-    [observableRecentsController updateValue:[_allRecents copy]];
+    [observableRecentsController updateValue:_allRecents.copy];
     [self saveContactsToDefaults];
 }
 
 - (void)removeRecentCall:(RecentCall *)recentCall {
     [_allRecents removeObject:recentCall];
-    [observableRecentsController updateValue:[_allRecents copy]];
+    [observableRecentsController updateValue:_allRecents.copy];
     [self saveContactsToDefaults];
 }
 
@@ -117,18 +117,18 @@ typedef BOOL (^SearchTermConditionalBlock)(RecentCall*, NSUInteger, BOOL*);
     recentCall.isArchived = YES;
     _allRecents[indexOfRecent] = recentCall;
     [self saveContactsToDefaults];
-    [observableRecentsController updateValue:[_allRecents copy]];
+    [observableRecentsController updateValue:_allRecents.copy];
 }
 
 - (void)clearRecentCalls {
     [_allRecents removeAllObjects];
-    [observableRecentsController updateValue:[_allRecents copy]];
+    [observableRecentsController updateValue:_allRecents.copy];
     [self saveContactsToDefaults];
 }
 
 - (void)saveContactsToDefaults {
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    NSData *saveData = [NSKeyedArchiver archivedDataWithRootObject:[_allRecents copy]];
+    NSData *saveData = [NSKeyedArchiver archivedDataWithRootObject:_allRecents.copy];
 
     [defaults setObject:saveData forKey:RECENT_CALLS_DEFAULT_KEY];
     [defaults synchronize];

--- a/Signal/src/contact/Contact.m
+++ b/Signal/src/contact/Contact.m
@@ -34,7 +34,7 @@ static NSString *const DEFAULTS_KEY_DATE = @"DefaultsKeyDate";
 		}
 	}
 
-	contact->parsedPhoneNumbers = [parsedPhoneNumbers copy];
+	contact->parsedPhoneNumbers = parsedPhoneNumbers.copy;
 
 	return contact;
 }

--- a/Signal/src/contact/ContactsManager.m
+++ b/Signal/src/contact/ContactsManager.m
@@ -190,11 +190,11 @@ void onAddressBookChanged(ABAddressBookRef notifyAddressBook, CFDictionaryRef in
             if (phoneNumber.length>0) {
                 result = YES;
                 break;
-                }
             }
+        }
         CFRelease(phoneNumbers);
         return result;
-        }];
+    }];
     CFRelease(allPeople);
     NSArray* filteredContacts = [sortedPeople filteredArrayUsingPredicate:predicate];
     
@@ -204,8 +204,8 @@ void onAddressBookChanged(ABAddressBookRef notifyAddressBook, CFDictionaryRef in
 }
 
 -(NSArray*)latestContactsWithSearchString:(NSString *)searchString {
-    return [[latestContactsById allValues] filter:^int(Contact *contact) {
-        return searchString.length == 0 || [ContactsManager name:[contact fullName] matchesQuery:searchString];
+    return [latestContactsById.allValues filter:^int(Contact *contact) {
+        return searchString.length == 0 || [ContactsManager name:contact.fullName matchesQuery:searchString];
     }];
 }
 
@@ -223,7 +223,7 @@ void onAddressBookChanged(ABAddressBookRef notifyAddressBook, CFDictionaryRef in
         if (companyName) {
             firstName = companyName;
         } else if (phoneNumbers.count) {
-            firstName =	[phoneNumbers firstObject];
+            firstName =	phoneNumbers.firstObject;
         }
     }
 
@@ -249,7 +249,7 @@ void onAddressBookChanged(ABAddressBookRef notifyAddressBook, CFDictionaryRef in
 }
 
 -(Contact*)latestContactForPhoneNumber:(PhoneNumber *)phoneNumber {
-    NSArray *allContacts = [latestContactsById allValues];
+    NSArray *allContacts = latestContactsById.allValues;
 
     ContactSearchBlock searchBlock = ^BOOL(Contact *contact, NSUInteger idx, BOOL *stop) {
         for (PhoneNumber *number in contact.parsedPhoneNumbers) {
@@ -272,7 +272,7 @@ void onAddressBookChanged(ABAddressBookRef notifyAddressBook, CFDictionaryRef in
 }
 
 - (BOOL)phoneNumber:(PhoneNumber *)phoneNumber1 matchesNumber:(PhoneNumber *)phoneNumber2 {
-    return [[phoneNumber1 toE164] isEqualToString:[phoneNumber2 toE164]];
+    return [phoneNumber1.toE164 isEqualToString:phoneNumber2.toE164];
 }
 
 - (NSArray *)phoneNumbersForRecord:(ABRecordRef)record {
@@ -320,7 +320,7 @@ void onAddressBookChanged(ABAddressBookRef notifyAddressBook, CFDictionaryRef in
     require(contacts != nil);
 
     NSArray *matchingContacts = [contacts filter:^int(Contact *contact) {
-        return optionalSearchString.length == 0 || [self name:[contact fullName] matchesQuery:optionalSearchString];
+        return optionalSearchString.length == 0 || [self name:contact.fullName matchesQuery:optionalSearchString];
     }];
 
     return [matchingContacts groupBy:^id(Contact *contact) {
@@ -328,18 +328,18 @@ void onAddressBookChanged(ABAddressBookRef notifyAddressBook, CFDictionaryRef in
     
         BOOL firstNameOrdering = ABPersonGetSortOrdering() == kABPersonCompositeNameFormatFirstNameFirst?YES:NO;
         
-        if (firstNameOrdering && [contact firstName] != nil && [[contact firstName] length] > 0) {
-            nameToUse = [contact firstName];
-        } else if (!firstNameOrdering && [contact lastName] != nil && [[contact lastName] length] > 0){
-            nameToUse = [contact lastName];
-        } else if ([contact lastName] == nil) {
-            if ([[contact fullName] length] > 0) {
-                nameToUse = [contact fullName];
+        if (firstNameOrdering && contact.firstName != nil && contact.firstName.length > 0) {
+            nameToUse = contact.firstName;
+        } else if (!firstNameOrdering && contact.lastName != nil && contact.lastName.length > 0){
+            nameToUse = contact.lastName;
+        } else if (contact.lastName == nil) {
+            if (contact.fullName.length > 0) {
+                nameToUse = contact.fullName;
             } else {
                 return nameToUse;
             }
         } else {
-            nameToUse = [contact lastName];
+            nameToUse = contact.lastName;
         }
         
         return [[[nameToUse substringToIndex:1] uppercaseString] decomposedStringWithCompatibilityMapping];
@@ -379,10 +379,8 @@ void onAddressBookChanged(ABAddressBookRef notifyAddressBook, CFDictionaryRef in
 }
 
 +(BOOL)phoneNumber:(PhoneNumber *)phoneNumber matchesQuery:(NSString *)queryString {
-    NSString *phoneNumberString = [phoneNumber localizedDescriptionForUser];
-    NSString *searchString = [[phoneNumberString componentsSeparatedByCharactersInSet:
-                            [[NSCharacterSet decimalDigitCharacterSet] invertedSet]]
-                           componentsJoinedByString:@""];
+    NSString *phoneNumberString = phoneNumber.localizedDescriptionForUser;
+    NSString *searchString = phoneNumberString.digitsOnly;
 
     if (queryString.length == 0) return YES;
     NSStringCompareOptions searchOpts = NSCaseInsensitiveSearch | NSAnchoredSearch;
@@ -405,7 +403,7 @@ void onAddressBookChanged(ABAddressBookRef notifyAddressBook, CFDictionaryRef in
 
 -(NSMutableArray *)loadFavouriteIds {
     NSArray *favourites = [[NSUserDefaults standardUserDefaults] objectForKey:FAVOURITES_DEFAULT_KEY];
-    return favourites == nil ? [NSMutableArray array] : [favourites mutableCopy];
+    return favourites == nil ? [NSMutableArray array] : favourites.mutableCopy;
 }
 
 -(void)saveFavouriteIds {
@@ -445,8 +443,8 @@ void onAddressBookChanged(ABAddressBookRef notifyAddressBook, CFDictionaryRef in
 #pragma mark - Whisper User Management
 
 -(NSUInteger) checkForNewWhisperUsers {
-	NSArray *currentUsers = [self getWhisperUsersFromContactsArray:[latestContactsById allValues]];
-	NSArray *newUsers     = [self getNewItemsFrom:currentUsers comparedTo:[latestWhisperUsersById allValues]];
+	NSArray *currentUsers = [self getWhisperUsersFromContactsArray:latestContactsById.allValues];
+	NSArray *newUsers     = [self getNewItemsFrom:currentUsers comparedTo:latestWhisperUsersById.allValues];
     
 	if(newUsers.count > 0){
 		[observableWhisperUsersController updateValue:currentUsers];
@@ -471,7 +469,7 @@ void onAddressBookChanged(ABAddressBookRef notifyAddressBook, CFDictionaryRef in
 }
 
 -(NSUInteger) getNumberOfUnacknowledgedCurrentUsers{
-    NSArray *currentUsers = [self getWhisperUsersFromContactsArray:[latestContactsById allValues]];
+    NSArray *currentUsers = [self getWhisperUsersFromContactsArray:latestContactsById.allValues];
     return [[self getUnacknowledgedUsersFrom:currentUsers] count];
 }
 
@@ -507,7 +505,7 @@ void onAddressBookChanged(ABAddressBookRef notifyAddressBook, CFDictionaryRef in
     for( Contact *contact in contacts){
         [_knownWhisperUserIds addObject:@([contact recordID])];
     }
-    NSMutableSet *users = [NSMutableSet setWithArray:[latestWhisperUsersById allValues]];
+    NSMutableSet *users = [NSMutableSet setWithArray:latestWhisperUsersById.allValues];
     [users addObjectsFromArray:contacts];
     
     [observableWhisperUsersController updateValue:[users allObjects]];
@@ -521,7 +519,7 @@ void onAddressBookChanged(ABAddressBookRef notifyAddressBook, CFDictionaryRef in
 
 -(NSMutableArray*) loadKnownWhisperUsers{
     NSArray *knownUsers = [[NSUserDefaults standardUserDefaults] objectForKey:KNOWN_USERS_DEFAULT_KEY];
-    return knownUsers == nil ? [NSMutableArray array] : [knownUsers mutableCopy];
+    return knownUsers == nil ? [NSMutableArray array] : knownUsers.mutableCopy;
 }
 
 -(void) saveKnownWhisperUsers{

--- a/Signal/src/crypto/CryptoTools.m
+++ b/Signal/src/crypto/CryptoTools.m
@@ -28,8 +28,8 @@
     require(password != nil);
     
     NSData* d = [[@(counter) stringValue] encodedAsUtf8];
-    NSData* h = [d hmacWithSha1WithKey:[password encodedAsUtf8]];
-    return [h encodedAsBase64];
+    NSData* h = [d hmacWithSha1WithKey:password.encodedAsUtf8];
+    return h.encodedAsBase64;
 }
 
 @end

--- a/Signal/src/environment/PreferencesUtil.m
+++ b/Signal/src/environment/PreferencesUtil.m
@@ -151,7 +151,7 @@
 }
 
 -(NSString*)setAndGetCurrentVersion{
-    NSString *lastVersion = [self lastRanVersion];
+    NSString *lastVersion = self.lastRanVersion;
     
     [[NSUserDefaults standardUserDefaults] setObject:[NSString stringWithFormat:@"%@", [[NSBundle mainBundle] infoDictionary][@"CFBundleVersion"]] forKey:kSignalVersionKey];
     [[NSUserDefaults standardUserDefaults] synchronize];

--- a/Signal/src/environment/Release.m
+++ b/Signal/src/environment/Release.m
@@ -6,11 +6,11 @@
 #import "RecentCallManager.h"
 #import "PhoneNumberDirectoryFilterManager.h"
 
-#define RELEASE_ZRTP_CLIENT_ID [@"Whisper 000     " encodedAsAscii]
-#define RELEASE_ZRTP_VERSION_ID [@"1.10" encodedAsAscii]
+#define RELEASE_ZRTP_CLIENT_ID @"Whisper 000     ".encodedAsAscii
+#define RELEASE_ZRTP_VERSION_ID @"1.10".encodedAsAscii
 
-#define TESTING_ZRTP_CLIENT_ID [@"RedPhone 019    " encodedAsAscii]
-#define TESTING_ZRTP_VERSION_ID [@"1.10" encodedAsAscii]
+#define TESTING_ZRTP_CLIENT_ID @"RedPhone 019    ".encodedAsAscii
+#define TESTING_ZRTP_VERSION_ID @"1.10".encodedAsAscii
 
 static unsigned char DH3K_PRIME[]={
     0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xC9,0x0F,0xDA,0xA2,0x21,0x68,0xC2,

--- a/Signal/src/environment/SGNKeychainUtil.m
+++ b/Signal/src/environment/SGNKeychainUtil.m
@@ -52,9 +52,9 @@
 
 + (void)setLocalNumberTo:(PhoneNumber *)localNumber{
     require(localNumber != nil);
-    require([localNumber toE164]!= nil);
+    require(localNumber.toE164!= nil);
     
-    NSString *e164 = [localNumber toE164];
+    NSString *e164 = localNumber.toE164;
     [self storeString:e164 forKey:LOCAL_NUMBER_KEY];
 }
 

--- a/Signal/src/network/dns/HostNameEndPoint.m
+++ b/Signal/src/network/dns/HostNameEndPoint.m
@@ -13,7 +13,7 @@
     require(port > 0);
     
     HostNameEndPoint* h = [HostNameEndPoint new];
-    h->hostname = [hostname copy]; // avoid mutability
+    h->hostname = hostname.copy; // avoid mutability
     h->port = port;
     return h;
 }

--- a/Signal/src/network/http/CallServerRequestsManager.m
+++ b/Signal/src/network/http/CallServerRequestsManager.m
@@ -48,12 +48,14 @@ MacrosSingletonImplemention
 failure:(void (^)(NSURLSessionDataTask *task, NSError *error))failure{
     self.operationManager.requestSerializer = [self basicAuthenticationSerializer];
     
-    [self.operationManager PUT:[NSString stringWithFormat:@"/apn/%@",[deviceToken encodedAsHexString]] parameters:@{} success:success failure:failure];
+    [self.operationManager PUT:[NSString stringWithFormat:@"/apn/%@",deviceToken.encodedAsHexString] parameters:@{} success:success failure:failure];
 }
 
 - (AFHTTPRequestSerializer*)basicAuthenticationSerializer{
     AFHTTPRequestSerializer *serializer = [AFHTTPRequestSerializer serializer];
-    [serializer setValue:[HttpRequest computeBasicAuthorizationTokenForLocalNumber:[SGNKeychainUtil localNumber]andPassword:[SGNKeychainUtil serverAuthPassword]] forHTTPHeaderField:@"Authorization"];
+    [serializer setValue:[HttpRequest computeBasicAuthorizationTokenForLocalNumber:SGNKeychainUtil.localNumber
+                                                                       andPassword:SGNKeychainUtil.serverAuthPassword]
+      forHTTPHeaderField:@"Authorization"];
     return serializer;
 }
 

--- a/Signal/src/network/http/HttpRequest.m
+++ b/Signal/src/network/http/HttpRequest.m
@@ -108,16 +108,16 @@
     require(password != nil);
     
     NSString* rawToken = [NSString stringWithFormat:@"%@:%@:%lld",
-                          [localNumber toE164],
+                          localNumber.toE164,
                           [CryptoTools computeOtpWithPassword:password andCounter:counterValue],
                           counterValue];
-    return [@"OTP " stringByAppendingString:[[rawToken encodedAsUtf8] encodedAsBase64]];
+    return [@"OTP " stringByAppendingString:rawToken.encodedAsUtf8.encodedAsBase64];
 }
 +(NSString*) computeBasicAuthorizationTokenForLocalNumber:(PhoneNumber*)localNumber andPassword:(NSString*)password {
     NSString* rawToken = [NSString stringWithFormat:@"%@:%@",
-                          [localNumber toE164],
+                          localNumber.toE164,
                           password];
-    return [@"Basic " stringByAppendingString:[[rawToken encodedAsUtf8] encodedAsBase64]];
+    return [@"Basic " stringByAppendingString:rawToken.encodedAsUtf8.encodedAsBase64];
 }
 
 -(NSString*) toHttp {
@@ -141,10 +141,10 @@
     return [r componentsJoinedByString:@""];
 }
 -(NSData*) serialize {
-    return [[self toHttp] encodedAsUtf8];
+    return self.toHttp.encodedAsUtf8;
 }
 -(bool) isEqualToHttpRequest:(HttpRequest *)other {
-    return [[self toHttp] isEqualToString:[other toHttp]]
+    return [self.toHttp isEqualToString:other.toHttp]
         && [self.method isEqualToString:other.method]
         && [self.location isEqualToString:other.location]
         && (self.optionalBody == other.optionalBody || [self.optionalBody isEqualToString:[other optionalBody]])

--- a/Signal/src/network/http/HttpRequestOrResponse.m
+++ b/Signal/src/network/http/HttpRequestOrResponse.m
@@ -34,11 +34,11 @@
     require(data != nil);
 
     // first line should contain HTTP
-    checkOperation([data tryFindIndexOf:[@"\r\n" encodedAsAscii]] == nil || [data tryFindIndexOf:[@"HTTP" encodedAsAscii]] != nil);
+    checkOperation([data tryFindIndexOf:@"\r\n".encodedAsAscii] == nil || [data tryFindIndexOf:@"HTTP".encodedAsAscii] != nil);
     // expecting \r\n line endings
-    checkOperation(([data tryFindIndexOf:[@"\n" encodedAsAscii]] == nil) == ([data tryFindIndexOf:[@"\r\n" encodedAsAscii]] == nil));
+    checkOperation(([data tryFindIndexOf:@"\n".encodedAsAscii] == nil) == ([data tryFindIndexOf:@"\r\n".encodedAsAscii] == nil));
     
-    NSNumber* tryHeaderLength = [data tryFindIndexOf:[@"\r\n\r\n" encodedAsUtf8]];
+    NSNumber* tryHeaderLength = [data tryFindIndexOf:@"\r\n\r\n".encodedAsUtf8];
     if (tryHeaderLength == nil) return nil;
     NSUInteger headerLength = [tryHeaderLength unsignedIntegerValue];
     NSString* fullHeader = [[data take:headerLength] decodedAsUtf8];

--- a/Signal/src/network/http/HttpRequestUtil.m
+++ b/Signal/src/network/http/HttpRequestUtil.m
@@ -18,7 +18,7 @@
     return [HttpRequest httpRequestWithBasicAuthenticationAndMethod:method
                                                         andLocation:location
                                                     andOptionalBody:optionalBody
-                                                     andLocalNumber:[SGNKeychainUtil localNumber]
+                                                     andLocalNumber:SGNKeychainUtil.localNumber
                                                         andPassword:[SGNKeychainUtil serverAuthPassword]];
 }
 +(HttpRequest*)httpRequestWithOtpAuthenticationAndMethod:(NSString*)method
@@ -33,7 +33,7 @@
     return [HttpRequest httpRequestWithOtpAuthenticationAndMethod:method
                                                       andLocation:location
                                                   andOptionalBody:optionalBody
-                                                   andLocalNumber:[SGNKeychainUtil localNumber]
+                                                   andLocalNumber:SGNKeychainUtil.localNumber
                                                       andPassword:[SGNKeychainUtil serverAuthPassword]
                                                        andCounter:[SGNKeychainUtil getAndIncrementOneTimeCounter]];
 }

--- a/Signal/src/network/http/HttpResponse.m
+++ b/Signal/src/network/http/HttpResponse.m
@@ -90,7 +90,7 @@
 }
 -(NSData*) getOptionalBodyData {
     if (optionalBodyData != nil) return optionalBodyData;
-    if (optionalBodyText != nil) return [optionalBodyText encodedAsUtf8];
+    if (optionalBodyText != nil) return optionalBodyText.encodedAsUtf8;
     return nil;
 }
 
@@ -116,7 +116,7 @@
     return [r componentsJoinedByString:@""];
 }
 -(NSData*) serialize {
-    return [[self toHttp] encodedAsUtf8];
+    return self.toHttp.encodedAsUtf8;
 }
 
 -(NSString*) description {

--- a/Signal/src/network/rtp/RtpSocket.m
+++ b/Signal/src/network/rtp/RtpSocket.m
@@ -10,7 +10,7 @@
     
     RtpSocket* s = [RtpSocket new];
     s->udpSocket = udpSocket;
-    s->interopOptions = [interopOptions mutableCopy];
+    s->interopOptions = interopOptions.mutableCopy;
     return s;
 }
 

--- a/Signal/src/network/rtp/zrtp/MasterSecret.m
+++ b/Signal/src/network/rtp/zrtp/MasterSecret.m
@@ -78,7 +78,7 @@
                     
                     counter,
                     dhResult,
-                    [@"ZRTP-HMAC-KDF" encodedAsUtf8],
+                    @"ZRTP-HMAC-KDF".encodedAsUtf8,
                     [initiatorZid getData],
                     [responderZid getData],
                     totalHash,
@@ -147,7 +147,7 @@
     NSData* input = [@[
                      
                      counter,
-                     [label encodedAsUtf8],
+                     label.encodedAsUtf8,
                      [@[@0] toUint8Data],
                      [initiatorZid getData],
                      [responderZid getData],

--- a/Signal/src/network/rtp/zrtp/agreement/DH3KKeyAgreementProtocol.h
+++ b/Signal/src/network/rtp/zrtp/agreement/DH3KKeyAgreementProtocol.h
@@ -2,7 +2,7 @@
 #import "KeyAgreementProtocol.h"
 #import "CryptoTools.h"
 
-#define DH3k_KEY_AGREEMENT_ID [@"DH3k" encodedAsUtf8]
+#define DH3k_KEY_AGREEMENT_ID @"DH3k".encodedAsUtf8
 
 /**
  *

--- a/Signal/src/network/rtp/zrtp/agreement/EC25KeyAgreementProtocol.h
+++ b/Signal/src/network/rtp/zrtp/agreement/EC25KeyAgreementProtocol.h
@@ -1,7 +1,7 @@
 #import <Foundation/Foundation.h>
 #import "KeyAgreementProtocol.h"
 
-#define EC25_KEY_AGREEMENT_ID [@"EC25" encodedAsUtf8]
+#define EC25_KEY_AGREEMENT_ID @"EC25".encodedAsUtf8
 
 @interface EC25KeyAgreementProtocol : NSObject<KeyAgreementProtocol>{
 }

--- a/Signal/src/network/rtp/zrtp/packets/HandshakePacket.h
+++ b/Signal/src/network/rtp/zrtp/packets/HandshakePacket.h
@@ -28,20 +28,20 @@
  *
 **/
 
-#define HANDSHAKE_TYPE_HELLO       [@"Hello   " encodedAsAscii]
-#define HANDSHAKE_TYPE_HELLO_ACK   [@"HelloAck" encodedAsAscii]
-#define HANDSHAKE_TYPE_COMMIT      [@"Commit  " encodedAsAscii]
-#define HANDSHAKE_TYPE_DH_1        [@"DHPart1 " encodedAsAscii]
-#define HANDSHAKE_TYPE_DH_2        [@"DHPart2 " encodedAsAscii]
-#define HANDSHAKE_TYPE_CONFIRM_1   [@"Confirm1" encodedAsAscii]
-#define HANDSHAKE_TYPE_CONFIRM_2   [@"Confirm2" encodedAsAscii]
-#define HANDSHAKE_TYPE_CONFIRM_ACK [@"Conf2Ack" encodedAsAscii]
+#define HANDSHAKE_TYPE_HELLO       @"Hello   ".encodedAsAscii
+#define HANDSHAKE_TYPE_HELLO_ACK   @"HelloAck".encodedAsAscii
+#define HANDSHAKE_TYPE_COMMIT      @"Commit  ".encodedAsAscii
+#define HANDSHAKE_TYPE_DH_1        @"DHPart1 ".encodedAsAscii
+#define HANDSHAKE_TYPE_DH_2        @"DHPart2 ".encodedAsAscii
+#define HANDSHAKE_TYPE_CONFIRM_1   @"Confirm1".encodedAsAscii
+#define HANDSHAKE_TYPE_CONFIRM_2   @"Confirm2".encodedAsAscii
+#define HANDSHAKE_TYPE_CONFIRM_ACK @"Conf2Ack".encodedAsAscii
 
-#define COMMIT_DEFAULT_HASH_SPEC_ID    [@"S256" encodedAsAscii]
-#define COMMIT_DEFAULT_CIPHER_SPEC_ID  [@"AES1" encodedAsAscii]
-#define COMMIT_DEFAULT_AUTH_SPEC_ID    [@"HS80" encodedAsAscii]
-#define COMMIT_DEFAULT_AGREE_SPEC_ID   [@"DH3k" encodedAsAscii]
-#define COMMIT_DEFAULT_SAS_SPEC_ID     [@"B256" encodedAsAscii]
+#define COMMIT_DEFAULT_HASH_SPEC_ID    @"S256".encodedAsAscii
+#define COMMIT_DEFAULT_CIPHER_SPEC_ID  @"AES1".encodedAsAscii
+#define COMMIT_DEFAULT_AUTH_SPEC_ID    @"HS80".encodedAsAscii
+#define COMMIT_DEFAULT_AGREE_SPEC_ID   @"DH3k".encodedAsAscii
+#define COMMIT_DEFAULT_SAS_SPEC_ID     @"B256".encodedAsAscii
 
 #define HANDSHAKE_TRUNCATED_HMAC_LENGTH 8
 

--- a/Signal/src/network/rtp/zrtp/packets/HandshakePacket.m
+++ b/Signal/src/network/rtp/zrtp/packets/HandshakePacket.m
@@ -11,8 +11,8 @@
 #import "ConfirmAckPacket.h"
 #import "HelloAckPacket.h"
 
-#define HANDSHAKE_PACKET_EXTENSION_IDENTIFIER [[@"PZ" encodedAsAscii] bigEndianUInt16At:0]
-#define HANDSHAKE_PACKET_TIMESTAMP_COOKIE [[@"ZRTP" encodedAsAscii] bigEndianUInt32At:0]
+#define HANDSHAKE_PACKET_EXTENSION_IDENTIFIER [@"PZ".encodedAsAscii bigEndianUInt16At:0]
+#define HANDSHAKE_PACKET_TIMESTAMP_COOKIE [@"ZRTP".encodedAsAscii bigEndianUInt32At:0]
 
 #define HANDSHAKE_TYPE_ID_LENGTH 8
 #define HANDSHAKE_CRC_LENGTH 4

--- a/Signal/src/network/rtp/zrtp/packets/HelloPacket.m
+++ b/Signal/src/network/rtp/zrtp/packets/HelloPacket.m
@@ -242,7 +242,7 @@
     return embedding;
 }
 -(NSArray*) agreeIdsIncludingImplied {
-    NSMutableArray* a = [agreeIds mutableCopy];
+    NSMutableArray* a = agreeIds.mutableCopy;
     [a addObject:COMMIT_DEFAULT_AGREE_SPEC_ID];
     return a;
 }

--- a/Signal/src/phone/signaling/SignalUtil.m
+++ b/Signal/src/phone/signaling/SignalUtil.m
@@ -58,7 +58,7 @@
 +(HttpRequest*) httpRequestToInitiateToRemoteNumber:(PhoneNumber*)remoteNumber {
     require(remoteNumber != nil);
     
-    NSString* formattedRemoteNumber = [remoteNumber toE164];
+    NSString* formattedRemoteNumber = remoteNumber.toE164;
     NSString* interopVersionInsert = CLAIMED_INTEROP_VERSION_IN_INITIATE_SIGNAL == 0
                                    ? @""
                                    : [NSString stringWithFormat:@"/%d", CLAIMED_INTEROP_VERSION_IN_INITIATE_SIGNAL];
@@ -80,8 +80,8 @@
 +(HttpRequest*) httpRequestToVerifyAccessToPhoneNumberWithChallenge:(NSString*)challenge {
     require(challenge != nil);
     
-    PhoneNumber* localPhoneNumber = [SGNKeychainUtil localNumber];
-    NSString* query = [NSString stringWithFormat:@"/users/verification/%@", [localPhoneNumber toE164]];
+    PhoneNumber* localPhoneNumber = SGNKeychainUtil.localNumber;
+    NSString* query = [NSString stringWithFormat:@"/users/verification/%@", localPhoneNumber.toE164];
     [SGNKeychainUtil generateSignaling];
     
     NSData* signalingCipherKey = [SGNKeychainUtil signalingCipherKey];
@@ -97,7 +97,7 @@
 +(HttpRequest*) httpRequestToRegisterForApnSignalingWithDeviceToken:(NSData*)deviceToken {
     require(deviceToken != nil);
     
-    NSString* query = [NSString stringWithFormat:@"/apn/%@", [deviceToken encodedAsHexString]];
+    NSString* query = [NSString stringWithFormat:@"/apn/%@", deviceToken.encodedAsHexString];
     
     return [HttpRequest httpRequestWithBasicAuthenticationAndMethod:@"PUT"
                                                         andLocation:query];

--- a/Signal/src/phone/signaling/number directory/PhoneNumberDirectoryFilter.m
+++ b/Signal/src/phone/signaling/number directory/PhoneNumberDirectoryFilter.m
@@ -59,7 +59,7 @@
 
 -(bool) containsPhoneNumber:(PhoneNumber*)phoneNumber {
     if (phoneNumber == nil) return false;
-    return [bloomFilter contains:[phoneNumber toE164]];
+    return [bloomFilter contains:phoneNumber.toE164];
 }
 
 @end

--- a/Signal/src/util/BloomFilter.m
+++ b/Signal/src/util/BloomFilter.m
@@ -43,7 +43,7 @@
 
 -(bool) contains:(NSString*)entity {
     require(entity != nil);
-    NSData* value = [entity encodedAsUtf8];
+    NSData* value = entity.encodedAsUtf8;
     for (NSUInteger i = 0; i < hashCount; i++) {
         uint32_t bitIndex = [self hash:value index:i];
         if (![self isBitSetAt:bitIndex]) {

--- a/Signal/src/util/SmsInvite.m
+++ b/Signal/src/util/SmsInvite.m
@@ -17,7 +17,7 @@
         NSString *inviteMessage = INVITE_USERS_MESSAGE;
         
         messageController.body = [inviteMessage stringByAppendingString:@" https://itunes.apple.com/app/id874139669"];
-        messageController.recipients = @[[number toE164]];
+        messageController.recipients = @[number.toE164];
         messageController.messageComposeDelegate = self;
         
         [parent presentViewController:messageController

--- a/Signal/src/util/StringUtil.m
+++ b/Signal/src/util/StringUtil.m
@@ -51,7 +51,7 @@
 -(NSString*) withMatchesAgainst:(NSRegularExpression*)regex replacedBy:(NSString*)replacement {
     require(regex != nil);
     require(replacement != nil);
-    NSMutableString* m = [self mutableCopy];
+    NSMutableString* m = self.mutableCopy;
     [regex replaceMatchesInString:m options:0 range:NSMakeRange(0, m.length) withTemplate:replacement];
     return m;
 }
@@ -66,14 +66,14 @@
 }
 -(NSData*) decodedAsJsonIntoData {
     NSError* jsonParseError = nil;
-    id parsedJson = [NSJSONSerialization dataWithJSONObject:[self encodedAsUtf8] options:0 error:&jsonParseError];
+    id parsedJson = [NSJSONSerialization dataWithJSONObject:self.encodedAsUtf8 options:0 error:&jsonParseError];
     checkOperationDescribe(jsonParseError == nil, ([NSString stringWithFormat:@"Invalid json: %@", self]));
     checkOperationDescribe([parsedJson isKindOfClass:[NSData class]], @"Unexpected json data");
     return parsedJson;
 }
 -(NSDictionary*) decodedAsJsonIntoDictionary {
     NSError* jsonParseError = nil;
-    id parsedJson = [NSJSONSerialization JSONObjectWithData:[self encodedAsUtf8] options:0 error:&jsonParseError];
+    id parsedJson = [NSJSONSerialization JSONObjectWithData:self.encodedAsUtf8 options:0 error:&jsonParseError];
     checkOperationDescribe(jsonParseError == nil, ([NSString stringWithFormat:@"Json parse error: %@, on json: %@", jsonParseError, self]));
     checkOperationDescribe([parsedJson isKindOfClass:[NSDictionary class]], @"Unexpected json data");
     return parsedJson;
@@ -102,7 +102,7 @@
     checkOperation(bitCount % BitsPerByte == 0);
     
     // ASCII to base 64
-    NSData* asciiData = [self encodedAsAscii];
+    NSData* asciiData = self.encodedAsAscii;
     uint8_t base64Words[base64WordCount];
     for (NSUInteger i = 0; i < base64WordCount; i++) {
         base64Words[i] = CharToValueMap[[asciiData uint8At:i]];

--- a/Signal/src/view controllers/ContactDetailViewController.m
+++ b/Signal/src/view controllers/ContactDetailViewController.m
@@ -31,7 +31,7 @@ static NSString *const FAVOURITE_FALSE_ICON_NAME = @"favourite_false_icon";
         self.navigationController.navigationBar.barTintColor = [UIUtil darkBackgroundColor];
         self.navigationController.navigationBar.tintColor = [UIColor whiteColor];
         self.navigationController.navigationBar.translucent = NO;
-        _contactNameLabel.text = [_contact fullName];
+        _contactNameLabel.text = _contact.fullName;
         if (_contact.image) {
             _contactImageView.image = _contact.image;
         }
@@ -142,7 +142,7 @@ static NSString *const FAVOURITE_FALSE_ICON_NAME = @"favourite_false_icon";
 
 - (void)openPhoneAppWithPhoneNumber:(PhoneNumber *)phoneNumber {
     if (phoneNumber) {
-        [UIApplication.sharedApplication openURL:[phoneNumber toSystemDialerURL]];
+        [UIApplication.sharedApplication openURL:phoneNumber.toSystemDialerURL];
     }
 }
 

--- a/Signal/src/view controllers/DialerViewController.m
+++ b/Signal/src/view controllers/DialerViewController.m
@@ -44,7 +44,7 @@
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
     if (_phoneNumber) {
-        _currentNumberMutable = [[_phoneNumber toE164] mutableCopy];
+        _currentNumberMutable = _phoneNumber.toE164.mutableCopy;
         [self updateNumberLabel];
     }
 }
@@ -168,7 +168,7 @@
             [self removeContactImage];
         }
         
-        [_addContactButton setTitle:[_contact fullName] forState:UIControlStateNormal];
+        [_addContactButton setTitle:_contact.fullName forState:UIControlStateNormal];
         
     } else {
         [_addContactButton setTitle:@"" forState:UIControlStateNormal];

--- a/Signal/src/view controllers/FavouritesViewController.m
+++ b/Signal/src/view controllers/FavouritesViewController.m
@@ -142,7 +142,7 @@ static NSString *const CONTACT_TABLE_VIEW_CELL_IDENTIFIER = @"ContactTableViewCe
 
 - (NSArray *)favouritesForSearchTerm:(NSString *)searchTerm {
     return [_favourites filter:^int(Contact *contact) {
-        return searchTerm.length == 0 || [ContactsManager name:[contact fullName] matchesQuery:searchTerm];
+        return searchTerm.length == 0 || [ContactsManager name:contact.fullName matchesQuery:searchTerm];
     }];
 }
 

--- a/Signal/src/view controllers/InCallViewController.m
+++ b/Signal/src/view controllers/InCallViewController.m
@@ -165,7 +165,7 @@ static NSInteger connectingFlashCounter = 0;
             [UIUtil applyRoundedBorderToImageView:&_contactImageView];
         }
         
-        _nameLabel.text = [_potentiallyKnownContact fullName];
+        _nameLabel.text = _potentiallyKnownContact.fullName;
     } else {
         _nameLabel.text = UNKNOWN_CONTACT_NAME;
     }
@@ -182,10 +182,10 @@ static NSInteger connectingFlashCounter = 0;
 }
 
 -(void) populateImmediateDetails {
-    _phoneNumberLabel.text = [_callState.remoteNumber localizedDescriptionForUser];
+    _phoneNumberLabel.text = _callState.remoteNumber.localizedDescriptionForUser;
 
     if (_potentiallyKnownContact) {
-        _nameLabel.text = [_potentiallyKnownContact fullName];
+        _nameLabel.text = _potentiallyKnownContact.fullName;
         if (_potentiallyKnownContact.image) {
             _contactImageView.image = _potentiallyKnownContact.image;
         }
@@ -219,7 +219,7 @@ static NSInteger connectingFlashCounter = 0;
             [AppAudioManager.sharedInstance respondToTerminationType:[termination type]];
         }];
     } else {
-        _callStatusLabel.text = [latestProgress localizedDescriptionForUser];
+        _callStatusLabel.text = latestProgress.localizedDescriptionForUser;
     }
 }
 
@@ -259,7 +259,7 @@ static NSInteger connectingFlashCounter = 0;
 }
 
 -(void) updateViewForTermination:(CallTermination*) termination{
-    NSString* message = [termination localizedDescriptionForUser];
+    NSString* message = termination.localizedDescriptionForUser;
     
     if ([termination type] == CallTerminationType_ServerMessage) {
         CallFailedServerMessage* serverMessage = [termination messageInfo];

--- a/Signal/src/view controllers/InboxFeedViewController.m
+++ b/Signal/src/view controllers/InboxFeedViewController.m
@@ -393,8 +393,8 @@ static NSString *const FOOTER_TABLE_CELL_IDENTIFIER = @"InboxFeedFooterCell";
         }
     }
 
-    _searchRegisteredContacts = [registeredContacts copy];
-    _searchUnregisteredContacts = [unregisteredContacts copy];
+    _searchRegisteredContacts = registeredContacts.copy;
+    _searchUnregisteredContacts = unregisteredContacts.copy;
 }
 
 #pragma mark - Keyboard

--- a/Signal/src/view controllers/InviteContactsViewController.m
+++ b/Signal/src/view controllers/InviteContactsViewController.m
@@ -88,7 +88,7 @@ static NSString *const INVITE_CONTACTS_TABLE_CELL_IDENTIFIER = @"ContactTableVie
         BOOL matchesSearchQuery = YES;
      
         if (searchTerm != nil) {
-            matchesSearchQuery = [ContactsManager name:[contact fullName] matchesQuery:searchTerm];
+            matchesSearchQuery = [ContactsManager name:contact.fullName matchesQuery:searchTerm];
         }
      
         return ![contactsManager isContactRegisteredWithWhisper:contact] && matchesSearchQuery;
@@ -104,7 +104,7 @@ static NSString *const INVITE_CONTACTS_TABLE_CELL_IDENTIFIER = @"ContactTableVie
     actionSheet.title = INVITE_USERS_ACTION_SHEET_TITLE;
     
     for (PhoneNumber *number in _selectedContactNumbers) {
-        [actionSheet addButtonWithTitle:[number localizedDescriptionForUser]];
+        [actionSheet addButtonWithTitle:number.localizedDescriptionForUser];
     }
     actionSheet.cancelButtonIndex = [actionSheet addButtonWithTitle:TXT_CANCEL_TITLE];
     

--- a/Signal/src/view controllers/SettingsViewController.m
+++ b/Signal/src/view controllers/SettingsViewController.m
@@ -65,7 +65,7 @@ static NSString *const CHECKBOX_EMPTY_IMAGE_NAME = @"checkbox_empty";
 #pragma mark - Local number
 
 - (void)configureLocalNumber {
-    PhoneNumber *localNumber = [SGNKeychainUtil localNumber];
+    PhoneNumber *localNumber = SGNKeychainUtil.localNumber;
     if (localNumber) {
         _phoneNumberLabel.attributedText = [self localNumberAttributedStringForNumber:localNumber];
     } else {
@@ -75,7 +75,7 @@ static NSString *const CHECKBOX_EMPTY_IMAGE_NAME = @"checkbox_empty";
 
 - (NSAttributedString *)localNumberAttributedStringForNumber:(PhoneNumber *)number {
     NSString *numberPrefixString = SETTINGS_NUMBER_PREFIX;
-    NSString *localNumberString = [number toE164];
+    NSString *localNumberString = number.toE164;
     
     NSString *displayString = [NSString stringWithFormat:@"%@ %@", numberPrefixString, localNumberString];
     NSMutableAttributedString *attributedString = [[NSMutableAttributedString alloc] initWithString:displayString];

--- a/Signal/src/views/CallLogTableViewCell.m
+++ b/Signal/src/views/CallLogTableViewCell.m
@@ -34,7 +34,7 @@
 - (void)configureWithRecentCall:(RecentCall *)recentCall {
     Contact *contact = [[[Environment getCurrent] contactsManager] latestContactWithRecordId:recentCall.contactRecordID];
     if (contact) {
-        _contactNameLabel.text = [contact fullName];
+        _contactNameLabel.text = contact.fullName;
     } else {
         _contactNameLabel.text = UNKNOWN_CONTACT_NAME;
     }
@@ -45,7 +45,7 @@
         _callTypeImageView.image = [UIImage imageNamed:CALL_TYPE_IMAGE_NAME_INCOMING];
     }
 
-    _contactNumberLabel.text = [recentCall.phoneNumber localizedDescriptionForUser];
+    _contactNumberLabel.text = recentCall.phoneNumber.localizedDescriptionForUser;
 
     if ([DateUtil dateIsOlderThanOneWeek:[recentCall date]]) {
         _timeLabel.text = [[DateUtil dateFormatter] stringFromDate:[recentCall date]];

--- a/Signal/src/views/ContactDetailTableViewCell.m
+++ b/Signal/src/views/ContactDetailTableViewCell.m
@@ -23,7 +23,7 @@
                                          INFO_DISPLAY_LABEL_DEFAULT_WIDTH,
                                          CGRectGetHeight(_infoDisplayLabel.frame));
 
-    _infoDisplayLabel.text = [phoneNumber localizedDescriptionForUser];
+    _infoDisplayLabel.text = phoneNumber.localizedDescriptionForUser;
         
     if (isSecure) {
         _infoTypeLabel.text = CONTACT_DETAIL_COMM_TYPE_SECURE;

--- a/Signal/src/views/ContactTableViewCell.m
+++ b/Signal/src/views/ContactTableViewCell.m
@@ -36,7 +36,7 @@
 }
 
 - (NSAttributedString *)attributedStringForContact:(Contact *)contact {
-    NSMutableAttributedString *fullNameAttributedString = [[NSMutableAttributedString alloc] initWithString:[contact fullName]];
+    NSMutableAttributedString *fullNameAttributedString = [[NSMutableAttributedString alloc] initWithString:contact.fullName];
 
     UIFont *firstNameFont;
     UIFont *lastNameFont;
@@ -48,10 +48,10 @@
         firstNameFont = [UIFont systemFontOfSize:_nameLabel.font.pointSize];
         lastNameFont  = [UIFont boldSystemFontOfSize:_nameLabel.font.pointSize];
     }
-    [fullNameAttributedString addAttribute:NSFontAttributeName value:firstNameFont range:NSMakeRange(0, [[contact firstName] length])];
-    [fullNameAttributedString addAttribute:NSFontAttributeName value:lastNameFont range:NSMakeRange([[contact firstName] length] + 1, [[contact lastName] length])];
+    [fullNameAttributedString addAttribute:NSFontAttributeName value:firstNameFont range:NSMakeRange(0, contact.firstName.length)];
+    [fullNameAttributedString addAttribute:NSFontAttributeName value:lastNameFont range:NSMakeRange(contact.firstName.length + 1, contact.lastName.length)];
     
-    [fullNameAttributedString addAttribute:NSForegroundColorAttributeName value:[UIColor blackColor] range:NSMakeRange(0, [[contact fullName] length])];
+    [fullNameAttributedString addAttribute:NSForegroundColorAttributeName value:[UIColor blackColor] range:NSMakeRange(0, contact.fullName.length)];
     return fullNameAttributedString;
 }
 

--- a/Signal/src/views/FavouriteTableViewCell.m
+++ b/Signal/src/views/FavouriteTableViewCell.m
@@ -40,11 +40,11 @@
 }
 
 - (NSAttributedString *)attributedStringForContact:(Contact *)contact {
-    NSMutableAttributedString *fullNameAttributedString = [[NSMutableAttributedString alloc] initWithString:[contact fullName]];
+    NSMutableAttributedString *fullNameAttributedString = [[NSMutableAttributedString alloc] initWithString:contact.fullName];
 
-    [fullNameAttributedString addAttribute:NSFontAttributeName value:[UIFont systemFontOfSize:_nameLabel.font.pointSize] range:NSMakeRange(0, [[contact firstName] length])];
-    [fullNameAttributedString addAttribute:NSFontAttributeName value:[UIFont boldSystemFontOfSize:_nameLabel.font.pointSize] range:NSMakeRange([[contact firstName] length] + 1, [[contact lastName] length])];
-    [fullNameAttributedString addAttribute:NSForegroundColorAttributeName value:[UIColor blackColor] range:NSMakeRange(0, [[contact fullName] length])];
+    [fullNameAttributedString addAttribute:NSFontAttributeName value:[UIFont systemFontOfSize:_nameLabel.font.pointSize] range:NSMakeRange(0, contact.firstName.length)];
+    [fullNameAttributedString addAttribute:NSFontAttributeName value:[UIFont boldSystemFontOfSize:_nameLabel.font.pointSize] range:NSMakeRange(contact.firstName.length + 1, contact.lastName.length)];
+    [fullNameAttributedString addAttribute:NSForegroundColorAttributeName value:[UIColor blackColor] range:NSMakeRange(0, contact.fullName.length)];
     return fullNameAttributedString;
 }
 

--- a/Signal/src/views/InboxFeedTableViewCell.m
+++ b/Signal/src/views/InboxFeedTableViewCell.m
@@ -40,7 +40,7 @@
     Contact *contact = [[[Environment getCurrent] contactsManager] latestContactWithRecordId:recentCall.contactRecordID];
 
     if (contact) {
-        _nameLabel.text = [contact fullName];
+        _nameLabel.text = contact.fullName;
         if (contact.image) {
             _contactPictureView.image = contact.image;
         } else {
@@ -58,7 +58,7 @@
     }
 
     _missedCallView.hidden = recentCall.userNotified;
-    _numberLabel.text = [recentCall.phoneNumber localizedDescriptionForUser];
+    _numberLabel.text = recentCall.phoneNumber.localizedDescriptionForUser;
     _timeLabel.attributedText = [self dateArrributedString:[recentCall date]];
 }
 

--- a/Signal/src/views/UnseenWhisperUserCell.m
+++ b/Signal/src/views/UnseenWhisperUserCell.m
@@ -15,7 +15,7 @@
 }
 
 - (void)configureWithContact:(Contact *)contact {
-    _nameLabel.text = [contact fullName];
+    _nameLabel.text = contact.fullName;
     
     PhoneNumberDirectoryFilter *filter = [[[Environment getCurrent] phoneDirectoryManager] getCurrentFilter];
     BOOL foundPhoneNumber = NO;
@@ -23,7 +23,7 @@
     for (PhoneNumber *number in contact.parsedPhoneNumbers) {
         if ([filter containsPhoneNumber:number]) {
             foundPhoneNumber = YES;
-            _numberLabel.text = [number localizedDescriptionForUser];
+            _numberLabel.text = number.localizedDescriptionForUser;
         }
     }
 }

--- a/Signal/test/network/IpEndPointTest.m
+++ b/Signal/test/network/IpEndPointTest.m
@@ -9,7 +9,7 @@
 
 @implementation IpEndPointTest
 -(void) testTrivial {
-    IpAddress* a = [IpAddress localhost];
+    IpAddress* a = IpAddress.localhost;
     IpEndPoint* p = [IpEndPoint ipEndPointAtAddress:a onPort:2];
     test([p address] == a);
     test([p port] == 2);

--- a/Signal/test/network/http/HttpRequestResponseTest.m
+++ b/Signal/test/network/http/HttpRequestResponseTest.m
@@ -24,15 +24,15 @@
 //    HttpRequest* h = [HttpRequest httpRequestToInitiateToRemoteNumber:[PhoneNumber phoneNumberFromE164:@"+19023334444"]];
 //    test([[h method] isEqualToString:@"GET"]);
 //    test([[h location] isEqualToString:@"/session/1/+19023334444"]);
-//    NSLog(@"HTTP rep: %@", [h toHttp]);
-//    test([[h toHttp] isEqualToString:@"GET /session/1/+19023334444 HTTP/1.0\r\nAuthorization: OTP KzE5MDI3Nzc4ODg4OmluQ3lLcE1ZaFRQS0ZwN3BITlN3bUxVMVpCTT06MjM1Nw==\r\n\r\n"]);
+//    NSLog(@"HTTP rep: %@", h.toHttp);
+//    test([h.toHttp isEqualToString:@"GET /session/1/+19023334444 HTTP/1.0\r\nAuthorization: OTP KzE5MDI3Nzc4ODg4OmluQ3lLcE1ZaFRQS0ZwN3BITlN3bUxVMVpCTT06MjM1Nw==\r\n\r\n"]);
 //    test([h isEqualToHttpRequest:[HttpRequest httpRequestFromData:[h serialize]]]);
 //}
 -(void) testRequestToOpenPort {
     HttpRequest* h = [HttpRequest httpRequestToOpenPortWithSessionId:2357];
     test([[h method] isEqualToString:@"GET"]);
     test([[h location] isEqualToString:@"/open/2357"]);
-    test([[h toHttp] isEqualToString:@"GET /open/2357 HTTP/1.0\r\n\r\n"]);
+    test([h.toHttp isEqualToString:@"GET /open/2357 HTTP/1.0\r\n\r\n"]);
     test([h isEqualToHttpRequest:[HttpRequest httpRequestFromData:[h serialize]]]);
 }
 //-(void) testRequestToRing {
@@ -43,7 +43,7 @@
 //    HttpRequest* h = [HttpRequest httpRequestToRingWithSessionId:458847238];
 //    test([[h method] isEqualToString:@"RING"]);
 //    test([[h location] isEqualToString:@"/session/458847238"]);
-//    test([[h toHttp] isEqualToString:@"RING /session/458847238 HTTP/1.0\r\nAuthorization: OTP KzE5MDI1NTU1NTU1OnpOV1owY3k3S3A5S3NNd0RXbnlHZFBNR2ZzTT06MA==\r\n\r\n"]);
+//    test([h.toHttp isEqualToString:@"RING /session/458847238 HTTP/1.0\r\nAuthorization: OTP KzE5MDI1NTU1NTU1OnpOV1owY3k3S3A5S3NNd0RXbnlHZFBNR2ZzTT06MA==\r\n\r\n"]);
 //    test([h isEqualToHttpRequest:[HttpRequest httpRequestFromData:[h serialize]]]);
 //}
 -(void) testRequestFromData {
@@ -61,15 +61,15 @@
     test([[h1 headers][@"Content-Length"] isEqualToString:@"10"]);
     test([[h1 optionalBody] isEqualToString:@"abcdefghij"]);
     
-    HttpRequest* h = [HttpRequest httpRequestFromData:[@"GET /index.html HTTP/1.0\r\n\r\n" encodedAsUtf8]];
+    HttpRequest* h = [HttpRequest httpRequestFromData:@"GET /index.html HTTP/1.0\r\n\r\n".encodedAsUtf8];
     test([[h method] isEqualToString:@"GET"]);
     test([[h location] isEqualToString:@"/index.html"]);
     test([[h headers] count] == 0);
     test([h optionalBody] == nil);
     
-    testThrows([HttpRequest httpRequestFromData:[@"GET /index.html HTTP/1.0\r\n" encodedAsUtf8]]);
+    testThrows([HttpRequest httpRequestFromData:@"GET /index.html HTTP/1.0\r\n".encodedAsUtf8]);
     testThrows([HttpRequest httpRequestFromData:[@"GET /index.html HTTP/1.0\r\nContent-Length: 10\r\n\r\n" encodedAsUtf8]]);
-    testThrows([HttpRequest httpRequestFromData:[@"GET /index.html\r\n\r\n" encodedAsUtf8]]);
+    testThrows([HttpRequest httpRequestFromData:@"GET /index.html\r\n\r\n".encodedAsUtf8]);
 }
 -(void) testResponseOk {
     HttpResponse* h = [HttpResponse httpResponse200Ok];
@@ -78,34 +78,34 @@
     test([[h getHeaders] count] == 0);
 }
 -(void) testResponseFromData {
-    HttpResponse* h = [HttpResponse httpResponseFromData:[@"HTTP/1.1 200 OK\r\n\r\n" encodedAsUtf8]];
+    HttpResponse* h = [HttpResponse httpResponseFromData:@"HTTP/1.1 200 OK\r\n\r\n".encodedAsUtf8];
     test(h.isOkResponse);
     test([h getStatusCode] == 200);
     test([[h getStatusText] isEqualToString: @"OK"]);
     test([h getOptionalBodyText] == nil);
     test([[h getHeaders] count] == 0);
     
-    HttpResponse* h2 = [HttpResponse httpResponseFromData:[@"HTTP/1.1 404 Not Found\r\n\r\n" encodedAsUtf8]];
+    HttpResponse* h2 = [HttpResponse httpResponseFromData:@"HTTP/1.1 404 Not Found\r\n\r\n".encodedAsUtf8];
     test(!h2.isOkResponse);
     test([h2 getStatusCode] == 404);
     test([[h2 getStatusText] isEqualToString:@"Not Found"]);
     test([h2 getOptionalBodyText] == nil);
     test([[h2 getHeaders] count] == 0);
 
-    testThrows([HttpResponse httpResponseFromData:[@"HTTP/1.1 200 OK\r\n" encodedAsUtf8]]);
-    testThrows([HttpResponse httpResponseFromData:[@"HTTP/1.1 200\r\n\r\n" encodedAsUtf8]]);
+    testThrows([HttpResponse httpResponseFromData:@"HTTP/1.1 200 OK\r\n".encodedAsUtf8]);
+    testThrows([HttpResponse httpResponseFromData:@"HTTP/1.1 200\r\n\r\n".encodedAsUtf8]);
 }
 -(void) testTryFromPartialData {
     NSUInteger len;
     HttpRequestOrResponse* h;
-    h = [HttpRequestOrResponse tryExtractFromPartialData:[@"HTTP/1.1 200" encodedAsUtf8] usedLengthOut:&len];
+    h = [HttpRequestOrResponse tryExtractFromPartialData:@"HTTP/1.1 200".encodedAsUtf8 usedLengthOut:&len];
     test(h == nil);
-    h = [HttpRequestOrResponse tryExtractFromPartialData:[@"HTTP/1.1 200 OK" encodedAsUtf8] usedLengthOut:&len];
+    h = [HttpRequestOrResponse tryExtractFromPartialData:@"HTTP/1.1 200 OK".encodedAsUtf8 usedLengthOut:&len];
     test(h == nil);
-    h = [HttpRequestOrResponse tryExtractFromPartialData:[@"HTTP/1.1 200 OK\r\n" encodedAsUtf8] usedLengthOut:&len];
+    h = [HttpRequestOrResponse tryExtractFromPartialData:@"HTTP/1.1 200 OK\r\n".encodedAsUtf8 usedLengthOut:&len];
     test(h == nil);
 
-    h = [HttpRequestOrResponse tryExtractFromPartialData:[@"HTTP/1.1 200 OK\r\n\r\n" encodedAsUtf8] usedLengthOut:&len];
+    h = [HttpRequestOrResponse tryExtractFromPartialData:@"HTTP/1.1 200 OK\r\n\r\n".encodedAsUtf8 usedLengthOut:&len];
     test(h.isResponse);
     test([[h response] isOkResponse]);
     test(len == 19);
@@ -115,12 +115,12 @@
     test([[h response] isOkResponse]);
     test(len == 19);
 
-    h = [HttpRequestOrResponse tryExtractFromPartialData:[@"GET /index.html" encodedAsUtf8] usedLengthOut:&len];
+    h = [HttpRequestOrResponse tryExtractFromPartialData:@"GET /index.html".encodedAsUtf8 usedLengthOut:&len];
     test(h == nil);
-    h = [HttpRequestOrResponse tryExtractFromPartialData:[@"GET /index.html HTTP/1.0\r\n" encodedAsUtf8] usedLengthOut:&len];
+    h = [HttpRequestOrResponse tryExtractFromPartialData:@"GET /index.html HTTP/1.0\r\n".encodedAsUtf8 usedLengthOut:&len];
     test(h == nil);
     
-    h = [HttpRequestOrResponse tryExtractFromPartialData:[@"GET /index.html HTTP/1.0\r\n\r\n" encodedAsUtf8] usedLengthOut:&len];
+    h = [HttpRequestOrResponse tryExtractFromPartialData:@"GET /index.html HTTP/1.0\r\n\r\n".encodedAsUtf8 usedLengthOut:&len];
     test(h.isRequest);
     test([[[h request] method] isEqualToString:@"GET"]);
     test(len == 28);
@@ -130,7 +130,7 @@
     test([[[h request] method] isEqualToString:@"GET"]);
     test(len == 28);
 
-    testThrows([HttpRequestOrResponse tryExtractFromPartialData:[@"GET\r\n\r\n" encodedAsUtf8] usedLengthOut:&len]);
-    testThrows([HttpRequestOrResponse tryExtractFromPartialData:[@"HTTP/1.1 200\r\n\r\n" encodedAsUtf8] usedLengthOut:&len]);
+    testThrows([HttpRequestOrResponse tryExtractFromPartialData:@"GET\r\n\r\n".encodedAsUtf8 usedLengthOut:&len]);
+    testThrows([HttpRequestOrResponse tryExtractFromPartialData:@"HTTP/1.1 200\r\n\r\n".encodedAsUtf8 usedLengthOut:&len]);
 }
 @end

--- a/Signal/test/network/rtp/zrtp/HandshakePacketTest.m
+++ b/Signal/test/network/rtp/zrtp/HandshakePacketTest.m
@@ -17,8 +17,8 @@
 -(void) testHelloPacket {
     [Environment setCurrent:testEnv];
     HashChain* h = [HashChain hashChainWithSeed:[NSData dataWithLength:32]];
-    HelloPacket* p = [HelloPacket helloPacketWithVersion:[@"1.10" encodedAsUtf8]
-                                             andClientId:[@"RedPhone 019    " encodedAsAscii]
+    HelloPacket* p = [HelloPacket helloPacketWithVersion:@"1.10".encodedAsUtf8
+                                             andClientId:@"RedPhone 019    ".encodedAsAscii
                                           andHashChainH3:[h h3]
                                                   andZid:[Zid zidWithData:increasingData(12)]
                                             andFlags0SMP:0
@@ -77,7 +77,7 @@
     [p verifyMacWithHashChainH2:h.h2];
     test(rtp.wasAdjustedDueToInteropIssues);
     test([p.hashChainH3 isEqual:h.h3]);
-    test([p.clientId isEqual:[@"RedPhone 019    " encodedAsAscii]]);
+    test([p.clientId isEqual:@"RedPhone 019    ".encodedAsAscii]);
 }
 -(void) testHandshakeMacAuthenticationSucceeds{
     NSData* type = [@"0f0f0f0f0f0f0f0f" decodedAsHexString];

--- a/Signal/test/network/rtp/zrtp/ZrtpTest.m
+++ b/Signal/test/network/rtp/zrtp/ZrtpTest.m
@@ -33,7 +33,7 @@ bool pm(HandshakePacket* p1, HandshakePacket* p2) {
 }
 
 -(void) testPerturbedZrtpHandshake {
-    IpEndPoint* receiver = [IpEndPoint ipEndPointAtAddress:[IpAddress localhost]
+    IpEndPoint* receiver = [IpEndPoint ipEndPointAtAddress:IpAddress.localhost
                                                     onPort:10000 + (in_port_t)arc4random_uniform(20000)];
     
     UdpSocket* u1 = [UdpSocket udpSocketToFirstSenderOnLocalPort:receiver.port];
@@ -59,7 +59,7 @@ bool pm(HandshakePacket* p1, HandshakePacket* p2) {
 }
 
 -(void) testPerturbedZrtpHandshakeWithoutConfAck {
-    IpEndPoint* receiver = [IpEndPoint ipEndPointAtAddress:[IpAddress localhost]
+    IpEndPoint* receiver = [IpEndPoint ipEndPointAtAddress:IpAddress.localhost
                                                     onPort:10000 + (in_port_t)arc4random_uniform(20000)];
     [Environment setCurrent:testEnvWith(ENVIRONMENT_TESTING_OPTION_LOSE_CONF_ACK_ON_PURPOSE)];
     
@@ -103,7 +103,7 @@ bool pm(HandshakePacket* p1, HandshakePacket* p2) {
 -(void) testDhHandshake {
     [Environment setCurrent:testEnvWith(TESTING_OPTION_USE_DH_FOR_HANDSHAKE)];
 
-    IpEndPoint* receiver = [IpEndPoint ipEndPointAtAddress:[IpAddress localhost]
+    IpEndPoint* receiver = [IpEndPoint ipEndPointAtAddress:IpAddress.localhost
                                                     onPort:10000 + (in_port_t)arc4random_uniform(20000)];
     
     UdpSocket* u1 = [UdpSocket udpSocketToFirstSenderOnLocalPort:receiver.port];

--- a/Signal/test/network/udp/UdpSocketTest.m
+++ b/Signal/test/network/udp/UdpSocketTest.m
@@ -24,8 +24,8 @@
     in_port_t port1 = (in_port_t)(arc4random_uniform(40000) + 10000);
     in_port_t port2 = port1 + (in_port_t)1;
     
-    UdpSocket* receiver = [UdpSocket udpSocketFromLocalPort:port1 toRemoteEndPoint:[IpEndPoint ipEndPointAtAddress:[IpAddress localhost] onPort:port2]];
-    UdpSocket* sender = [UdpSocket udpSocketFromLocalPort:port2 toRemoteEndPoint:[IpEndPoint ipEndPointAtAddress:[IpAddress localhost] onPort:port1]];
+    UdpSocket* receiver = [UdpSocket udpSocketFromLocalPort:port1 toRemoteEndPoint:[IpEndPoint ipEndPointAtAddress:IpAddress.localhost onPort:port2]];
+    UdpSocket* sender = [UdpSocket udpSocketFromLocalPort:port2 toRemoteEndPoint:[IpEndPoint ipEndPointAtAddress:IpAddress.localhost onPort:port1]];
     [receiver startWithHandler:[PacketHandler packetHandler:^(id packet) {
         received = packet;
     } withErrorHandler:^(id error, id relatedInfo, bool causedTermination) {
@@ -40,9 +40,9 @@
     }] untilCancelled:senderLife.token];
     
     test(receiver.isLocalPortKnown);
-    test([receiver localPort] == port1);
+    test(receiver.localPort == port1);
     test(sender.isLocalPortKnown);
-    test([sender localPort] == port2);
+    test(sender.localPort == port2);
 
     testChurnAndConditionMustStayTrue(received == nil, 0.1);
     
@@ -74,7 +74,7 @@
     
     in_port_t unusedPort = (in_port_t)(arc4random_uniform(40000) + 10000);
     
-    UdpSocket* receiver = [UdpSocket udpSocketTo:[IpEndPoint ipEndPointAtAddress:[IpAddress localhost]
+    UdpSocket* receiver = [UdpSocket udpSocketTo:[IpEndPoint ipEndPointAtAddress:IpAddress.localhost
                                                                           onPort:unusedPort]];
     [receiver startWithHandler:[PacketHandler packetHandler:^(id packet) {
         @synchronized (churnLock()) {
@@ -86,8 +86,8 @@
     
     __block bool failed = false;
     UdpSocket* sender = [UdpSocket udpSocketFromLocalPort:unusedPort
-                                         toRemoteEndPoint:[IpEndPoint ipEndPointAtAddress:[IpAddress localhost]
-                                                                                   onPort:[receiver localPort]]];
+                                         toRemoteEndPoint:[IpEndPoint ipEndPointAtAddress:IpAddress.localhost
+                                                                                   onPort:receiver.localPort]];
     [sender startWithHandler:[PacketHandler packetHandler:^(NSData* packet) {
         // there's a length check here because when the destination is unreachable the sender sometimes gets a superfluous empty data callback... no idea why.
         senderReceivedData |= packet.length > 0;
@@ -135,7 +135,7 @@
         test(false);
     }] untilCancelled:receiverLife.token];
     
-    IpEndPoint* e = [IpEndPoint ipEndPointAtAddress:[IpAddress localhost] onPort:port];
+    IpEndPoint* e = [IpEndPoint ipEndPointAtAddress:IpAddress.localhost onPort:port];
     UdpSocket* client = [UdpSocket udpSocketTo:e];
     [client startWithHandler:[PacketHandler packetHandler:^(NSData* packet) {
         clientReceiveCount += 1;
@@ -174,7 +174,7 @@
     TOCCancelTokenSource* life = [TOCCancelTokenSource new];
     
     in_port_t unusedPort = 10000 + (in_port_t)arc4random_uniform(30000);
-    UdpSocket* udp = [UdpSocket udpSocketTo:[IpEndPoint ipEndPointAtAddress:[IpAddress localhost] onPort:unusedPort]];
+    UdpSocket* udp = [UdpSocket udpSocketTo:[IpEndPoint ipEndPointAtAddress:IpAddress.localhost onPort:unusedPort]];
     __block bool failed = false;
     [udp startWithHandler:[PacketHandler packetHandler:^(id packet) {
         test(false);

--- a/Signal/test/phone/signaling/SessionDescriptorTest.m
+++ b/Signal/test/phone/signaling/SessionDescriptorTest.m
@@ -20,7 +20,7 @@
     test([[d relayServerName] isEqualToString:@"example.com"]);
     
     // roundtrip
-    InitiatorSessionDescriptor* d2 = [InitiatorSessionDescriptor initiatorSessionDescriptorFromJson:[d toJson]];
+    InitiatorSessionDescriptor* d2 = [InitiatorSessionDescriptor initiatorSessionDescriptorFromJson:d.toJson];
     test([d2 sessionId] == 5);
     test([d2 relayUdpPort] == 6);
     test([[d2 relayServerName] isEqualToString:@"example.com"]);
@@ -53,7 +53,7 @@
 //    test(d.relayUdpPort == 11235);
 //    test(d.sessionId == 2357);
 //    test([d.relayServerName isEqualToString:@"Test"]);
-//    test([[d.initiatorNumber toE164] isEqualToString:@"+19027777777"]);
+//    test([d.initiatorNumber.toE164 isEqualToString:@"+19027777777"]);
 }
 
 @end

--- a/Signal/test/util/UtilTest.m
+++ b/Signal/test/util/UtilTest.m
@@ -243,29 +243,29 @@
     test([d isEqualToData:[(@[@1, @2, @1, @1, @2, @3]) toUint8Data]]);
 }
 -(void) testStringEncodedAsUtf8 {
-    test([[@"ab" encodedAsUtf8] isEqualToData:[(@[@97, @98]) toUint8Data]]);
+    test([@"ab".encodedAsUtf8 isEqualToData:[(@[@97, @98]) toUint8Data]]);
 }
 -(void) testStringEncodedAsAscii {
-    test([[@"ab" encodedAsAscii] isEqualToData:[(@[@97, @98]) toUint8Data]]);
-    testThrows([@"√" encodedAsAscii]);
+    test([@"ab".encodedAsAscii isEqualToData:[(@[@97, @98]) toUint8Data]]);
+    testThrows(@"√".encodedAsAscii);
 }
 -(void) testBase64EncodeKnown {
-    test([[[@"" encodedAsUtf8] encodedAsBase64] isEqualToString:@""]);
-    test([[[@"f" encodedAsUtf8] encodedAsBase64] isEqualToString:@"Zg=="]);
-    test([[[@"fo" encodedAsUtf8] encodedAsBase64] isEqualToString:@"Zm8="]);
-    test([[[@"foo" encodedAsUtf8] encodedAsBase64] isEqualToString:@"Zm9v"]);
-    test([[[@"foob" encodedAsUtf8] encodedAsBase64] isEqualToString:@"Zm9vYg=="]);
-    test([[[@"fooba" encodedAsUtf8] encodedAsBase64] isEqualToString:@"Zm9vYmE="]);
-    test([[[@"foobar" encodedAsUtf8] encodedAsBase64] isEqualToString:@"Zm9vYmFy"]);
+    test([@"".encodedAsUtf8.encodedAsBase64 isEqualToString:@""]);
+    test([@"f".encodedAsUtf8.encodedAsBase64 isEqualToString:@"Zg=="]);
+    test([@"fo".encodedAsUtf8.encodedAsBase64 isEqualToString:@"Zm8="]);
+    test([@"foo".encodedAsUtf8.encodedAsBase64 isEqualToString:@"Zm9v"]);
+    test([@"foob".encodedAsUtf8.encodedAsBase64 isEqualToString:@"Zm9vYg=="]);
+    test([@"fooba".encodedAsUtf8.encodedAsBase64 isEqualToString:@"Zm9vYmE="]);
+    test([@"foobar".encodedAsUtf8.encodedAsBase64 isEqualToString:@"Zm9vYmFy"]);
 }
 -(void) testBase64DecodeKnown {
-    test([[@"" encodedAsUtf8] isEqualToData:[@"" decodedAsBase64Data]]);
-    test([[@"f" encodedAsUtf8] isEqualToData:[@"Zg==" decodedAsBase64Data]]);
-    test([[@"fo" encodedAsUtf8] isEqualToData:[@"Zm8=" decodedAsBase64Data]]);
-    test([[@"foo" encodedAsUtf8] isEqualToData:[@"Zm9v" decodedAsBase64Data]]);
-    test([[@"foob" encodedAsUtf8] isEqualToData:[@"Zm9vYg==" decodedAsBase64Data]]);
-    test([[@"fooba" encodedAsUtf8] isEqualToData:[@"Zm9vYmE=" decodedAsBase64Data]]);
-    test([[@"foobar" encodedAsUtf8] isEqualToData:[@"Zm9vYmFy" decodedAsBase64Data]]);
+    test([@"".encodedAsUtf8 isEqualToData:[@"" decodedAsBase64Data]]);
+    test([@"f".encodedAsUtf8 isEqualToData:[@"Zg==" decodedAsBase64Data]]);
+    test([@"fo".encodedAsUtf8 isEqualToData:[@"Zm8=" decodedAsBase64Data]]);
+    test([@"foo".encodedAsUtf8 isEqualToData:[@"Zm9v" decodedAsBase64Data]]);
+    test([@"foob".encodedAsUtf8 isEqualToData:[@"Zm9vYg==" decodedAsBase64Data]]);
+    test([@"fooba".encodedAsUtf8 isEqualToData:[@"Zm9vYmE=" decodedAsBase64Data]]);
+    test([@"foobar".encodedAsUtf8 isEqualToData:[@"Zm9vYmFy" decodedAsBase64Data]]);
 }
 -(void) testBase64Perturbed {
     for (NSUInteger i = 0; i < 100; i++) {
@@ -273,7 +273,7 @@
         uint8_t data[n];
         arc4random_buf(data, sizeof(data));
         NSData* d = [NSData dataWithBytes:data length:sizeof(data)];
-        NSString* b = [d encodedAsBase64];
+        NSString* b = d.encodedAsBase64;
         NSData* d2 = [b decodedAsBase64Data];
         if (![d isEqualToData:d2]) {
             XCTFail(@"%@",[d description]);
@@ -281,8 +281,8 @@
     }
 }
 -(void) testToRegex {
-    testThrows([@"(" toRegularExpression]);
-    NSRegularExpression* r = [@"a+b" toRegularExpression];
+    testThrows(@"(".toRegularExpression);
+    NSRegularExpression* r = @"a+b".toRegularExpression;
     test([r numberOfMatchesInString:@"a" options:NSMatchingAnchored range:NSMakeRange(0, 1)] == 0);
     test([r numberOfMatchesInString:@"b" options:NSMatchingAnchored range:NSMakeRange(0, 1)] == 0);
     test([r numberOfMatchesInString:@"ba" options:NSMatchingAnchored range:NSMakeRange(0, 1)] == 0);
@@ -293,8 +293,8 @@
 }
 -(void) testWithMatchesAgainstReplacedBy {
     test([[@"(555)-555-5555" withMatchesAgainst:[@"[^0-9+]" toRegularExpression] replacedBy:@""] isEqualToString:@"5555555555"]);
-    test([[@"aaaaaa" withMatchesAgainst:[@"a" toRegularExpression] replacedBy:@""] isEqualToString:@""]);
-    test([[@"aabaabaa" withMatchesAgainst:[@"b" toRegularExpression] replacedBy:@"wonder"] isEqualToString:@"aawonderaawonderaa"]);
+    test([[@"aaaaaa" withMatchesAgainst:@"a".toRegularExpression replacedBy:@""] isEqualToString:@""]);
+    test([[@"aabaabaa" withMatchesAgainst:@"b".toRegularExpression replacedBy:@"wonder"] isEqualToString:@"aawonderaawonderaa"]);
 }
 -(void) testContainsAnyMatches {
     NSRegularExpression* r = [@"^\\+[0-9]{10,}" toRegularExpression];
@@ -317,12 +317,12 @@
     testThrows([@"test" withPrefixRemovedElseNull:nil]);
 }
 -(void) testToJson {
-    test([[@{} encodedAsJson] isEqualToString:@"{}"]);
+    test([@{}.encodedAsJson isEqualToString:@"{}"]);
     test([[@{@"a":@"b"} encodedAsJson] isEqualToString:@"{\"a\":\"b\"}"]);
     test([[@{@"c":@5} encodedAsJson] isEqualToString:@"{\"c\":5}"]);
     test([[(@{@"a":@5,@"b":@YES}) encodedAsJson] isEqualToString:@"{\"a\":5,\"b\":true}"]);
     
-    testThrows([@{@"ev": [@"a+b" toRegularExpression]} encodedAsJson]);
+    testThrows([@{@"ev": @"a+b".toRegularExpression} encodedAsJson]);
 }
 -(void) testFromJson {
     test([[@"{}" decodedAsJsonIntoDictionary] isEqualToDictionary:@{}]);
@@ -336,8 +336,8 @@
 }
 -(void) testRepresentedAsHexString {
     test([[[NSData data] encodedAsHexString] isEqualToString:@""]);
-    test([[increasingData(17) encodedAsHexString] isEqualToString:@"000102030405060708090a0b0c0d0e0f10"]);
-    test([[increasingDataFrom(256-16,16) encodedAsHexString] isEqualToString:@"f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff"]);
+    test([increasingData(17).encodedAsHexString isEqualToString:@"000102030405060708090a0b0c0d0e0f10"]);
+    test([increasingDataFrom(256-16,16).encodedAsHexString isEqualToString:@"f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff"]);
 }
 -(void) testDecodedAsHexData {
     test([[@"" decodedAsHexString] isEqualToData:[NSData data]]);


### PR DESCRIPTION
A whole bunch of regex search-replaces of the style `\[([^\*\]\[\:]+) (full[a-z0-9_]*)\]` -> `\1.\2`

Also includes a few indentation fixes, and a `digitsOnly` invoke. I scanned over the changes 2-3 times, and all the tests pass, but standard massive trivial change danger applies.

Ideally this change should go before other pending pull requests I have, because it's easier to merge these fixes into those pulls than the opposite.

FREEBIE
