### PR TITLE
More dot syntax //FREEBIE

### DIFF
--- a/Signal/src/AppDelegate.m
+++ b/Signal/src/AppDelegate.m
@@ -69,15 +69,15 @@
     NSError *error;
     
     NSDictionary *attrs = @{NSFileProtectionKey: NSFileProtectionCompleteUntilFirstUserAuthentication};
-    [[NSFileManager defaultManager] setAttributes:attrs ofItemAtPath:preferencesPath error:&error];
+    [NSFileManager.defaultManager setAttributes:attrs ofItemAtPath:preferencesPath error:&error];
     
     [pathsToExclude addObject:[[preferencesPath stringByAppendingString:NSBundle.mainBundle.bundleIdentifier] stringByAppendingString:@".plist"]];
     
     NSString *logPath    = [NSHomeDirectory() stringByAppendingString:@"/Library/Caches/Logs/"];
-    NSArray  *logsFiles  = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:logPath error:&error];
+    NSArray  *logsFiles  = [NSFileManager.defaultManager contentsOfDirectoryAtPath:logPath error:&error];
     
     attrs = @{NSFileProtectionKey: NSFileProtectionCompleteUntilFirstUserAuthentication};
-    [[NSFileManager defaultManager] setAttributes:attrs ofItemAtPath:logPath error:&error];
+    [NSFileManager.defaultManager setAttributes:attrs ofItemAtPath:logPath error:&error];
     
     for (NSUInteger i = 0; i < logsFiles.count; i++) {
         [pathsToExclude addObject:[logPath stringByAppendingString:logsFiles[i]]];

--- a/Signal/src/NotificationTracker.m
+++ b/Signal/src/NotificationTracker.m
@@ -43,7 +43,7 @@
 // Uniquely Identify a notification by the hash of the message payload.
 -(NSData*) getIdForNotification:(NSDictionary*) notification {
     NSData* data = [notification[NOTIFICATION_PAYLOAD_KEY] dataUsingEncoding:NSUTF8StringEncoding];
-    NSData* notificationHash = [data hashWithSha256];
+    NSData* notificationHash = data.hashWithSha256;
     return notificationHash;
 }
 

--- a/Signal/src/audio/incall_audio/AudioSocket.m
+++ b/Signal/src/audio/incall_audio/AudioSocket.m
@@ -19,8 +19,8 @@
     PacketHandlerBlock valueHandler = ^(RtpPacket* rtpPacket) {
         require(rtpPacket != nil);
         require([rtpPacket isKindOfClass:[RtpPacket class]]);
-        [handler handlePacket:[EncodedAudioPacket encodedAudioPacketWithAudioData:[rtpPacket payload]
-                                                                andSequenceNumber:[rtpPacket sequenceNumber]]];
+        [handler handlePacket:[EncodedAudioPacket encodedAudioPacketWithAudioData:rtpPacket.payload
+                                                                andSequenceNumber:rtpPacket.sequenceNumber]];
     };
     
     [srtpSocket startWithHandler:[PacketHandler packetHandler:valueHandler
@@ -30,8 +30,8 @@
 -(void) send:(EncodedAudioPacket*)audioPacket {
     require(audioPacket != nil);
     
-    RtpPacket* rtpPacket = [RtpPacket rtpPacketWithDefaultsAndSequenceNumber:[audioPacket sequenceNumber]
-                                                                  andPayload:[audioPacket audioData]];
+    RtpPacket* rtpPacket = [RtpPacket rtpPacketWithDefaultsAndSequenceNumber:audioPacket.sequenceNumber
+                                                                  andPayload:audioPacket.audioData];
     [srtpSocket secureAndSendRtpPacket:rtpPacket];
 }
 

--- a/Signal/src/audio/incall_audio/SpeexCodec.m
+++ b/Signal/src/audio/incall_audio/SpeexCodec.m
@@ -47,7 +47,7 @@
     speex_encode_int(encodingState, (spx_int16_t*)[rawData bytes], &encodingBits);
     
     NSMutableData* outputBuffer = [NSMutableData dataWithLength:encodingBufferSizeInBytes];
-    int outputSizeInBytes = speex_bits_write(&encodingBits, [outputBuffer mutableBytes], (int)encodingBufferSizeInBytes);
+    int outputSizeInBytes = speex_bits_write(&encodingBits, outputBuffer.mutableBytes, (int)encodingBufferSizeInBytes);
     checkOperation(outputSizeInBytes > 0);
     [outputBuffer setLength:(NSUInteger)outputSizeInBytes];
     

--- a/Signal/src/audio/incall_audio/processing/AudioStretcher.m
+++ b/Signal/src/audio/incall_audio/processing/AudioStretcher.m
@@ -28,7 +28,7 @@
     int16_t* input = (int16_t*)[audioData bytes];
     
     NSMutableData* d = [NSMutableData dataWithLength:(NSUInteger)maxOutputSampleCount*sizeof(int16_t)];
-    int outputSampleCount = time_scale(&timeScaleState, [d mutableBytes], input, inputSampleCount);
+    int outputSampleCount = time_scale(&timeScaleState, d.mutableBytes, input, inputSampleCount);
     checkOperationDescribe(outputSampleCount >= 0 && outputSampleCount <= maxOutputSampleCount, @"Scaling audio");
     
     return [d take:(NSUInteger)outputSampleCount*sizeof(int16_t)];

--- a/Signal/src/call/RecentCallManager.m
+++ b/Signal/src/call/RecentCallManager.m
@@ -174,7 +174,7 @@ typedef BOOL (^SearchTermConditionalBlock)(RecentCall*, NSUInteger, BOOL*);
         return !recentCall.userNotified;
     };
 
-    return [[_allRecents indexesOfObjectsPassingTest:missedCallBlock] count];
+    return [_allRecents indexesOfObjectsPassingTest:missedCallBlock].count;
 }
 
 -(BOOL) isPhoneNumberPresentInRecentCalls:(PhoneNumber*) phoneNumber {

--- a/Signal/src/contact/ContactsManager.m
+++ b/Signal/src/contact/ContactsManager.m
@@ -61,7 +61,7 @@ typedef BOOL (^ContactSearchBlock)(id, NSUInteger, BOOL*);
 
 #pragma mark - Notification Handlers
 -(void) registerNotificationHandlers{
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(updatedDirectoryHandler:) name:NOTIFICATION_DIRECTORY_UPDATE object:nil];
+    [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(updatedDirectoryHandler:) name:NOTIFICATION_DIRECTORY_UPDATE object:nil];
 }
 
 -(void) updatedDirectoryHandler:(NSNotification*) notification {
@@ -457,7 +457,7 @@ void onAddressBookChanged(ABAddressBookRef notifyAddressBook, CFDictionaryRef in
             [self addContactsToKnownWhisperUsers:unacknowledgedUsers];
         }else{
             NSDictionary *payload = @{NOTIFICATION_DATAKEY_NEW_USERS: unacknowledgedUsers};
-            [[NSNotificationCenter defaultCenter] postNotificationName:NOTIFICATION_NEW_USERS_AVAILABLE object:self userInfo:payload];
+            [NSNotificationCenter.defaultCenter postNotificationName:NOTIFICATION_NEW_USERS_AVAILABLE object:self userInfo:payload];
         }
     }
     return newUsers.count;
@@ -470,7 +470,7 @@ void onAddressBookChanged(ABAddressBookRef notifyAddressBook, CFDictionaryRef in
 
 -(NSUInteger) getNumberOfUnacknowledgedCurrentUsers{
     NSArray *currentUsers = [self getWhisperUsersFromContactsArray:latestContactsById.allValues];
-    return [[self getUnacknowledgedUsersFrom:currentUsers] count];
+    return [self getUnacknowledgedUsersFrom:currentUsers].count;
 }
 
 -(NSArray*) getWhisperUsersFromContactsArray:(NSArray*) contacts {

--- a/Signal/src/crypto/CryptoTools.m
+++ b/Signal/src/crypto/CryptoTools.m
@@ -12,7 +12,7 @@
 
 +(NSData*)generateSecureRandomData:(NSUInteger)length {
     NSMutableData* d = [NSMutableData dataWithLength:length];
-    SecRandomCopyBytes(kSecRandomDefault, length, [d mutableBytes]);
+    SecRandomCopyBytes(kSecRandomDefault, length, d.mutableBytes);
     return d;
 }
 

--- a/Signal/src/environment/DebugLogger.m
+++ b/Signal/src/environment/DebugLogger.m
@@ -48,10 +48,10 @@ MacrosSingletonImplemention
     
     NSError *error;
     NSString *logPath    = [NSHomeDirectory() stringByAppendingString:@"/Library/Caches/Logs/"];
-    NSArray  *logsFiles  = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:logPath error:&error];
+    NSArray  *logsFiles  = [NSFileManager.defaultManager contentsOfDirectoryAtPath:logPath error:&error];
 
     for (NSUInteger i = 0; i < logsFiles.count; i++) {
-        [[NSFileManager defaultManager] removeItemAtPath:[logPath stringByAppendingString:logsFiles[i]] error:&error];
+        [NSFileManager.defaultManager removeItemAtPath:[logPath stringByAppendingString:logsFiles[i]] error:&error];
     }
     
     if (error) {

--- a/Signal/src/environment/Environment.m
+++ b/Signal/src/environment/Environment.m
@@ -159,7 +159,7 @@ phoneDirectoryManager;
 }
 
 +(void)setRegistered:(BOOL)status{
-    [NSUserDefaults.standardUserDefaults setObject:status?@YES:@NO forKey:isRegisteredUserDefaultString];
+    [NSUserDefaults.standardUserDefaults setObject:@(status) forKey:isRegisteredUserDefaultString];
 }
 
 +(PropertyListPreferences*)preferences{

--- a/Signal/src/environment/PreferencesUtil.m
+++ b/Signal/src/environment/PreferencesUtil.m
@@ -53,7 +53,7 @@
 }
 
 -(void) sendDirectoryUpdateNotification{
-    [[NSNotificationCenter defaultCenter] postNotificationName:NOTIFICATION_DIRECTORY_UPDATE object:nil];
+    [NSNotificationCenter.defaultCenter postNotificationName:NOTIFICATION_DIRECTORY_UPDATE object:nil];
 }
 
 -(NSTimeInterval) getCachedOrDefaultDesiredBufferDepth {

--- a/Signal/src/environment/VersionMigrations.m
+++ b/Signal/src/environment/VersionMigrations.m
@@ -18,7 +18,7 @@
     NSString* documentsDirectory = [NSHomeDirectory() stringByAppendingPathComponent:@"/Documents/"];
     NSString *path = [NSString stringWithFormat:@"%@/%@.plist", documentsDirectory, @"RedPhone-Data"];
     
-    if ([[NSFileManager defaultManager] fileExistsAtPath:path]) {
+    if ([NSFileManager.defaultManager fileExistsAtPath:path]) {
         NSData *plistData = [NSData dataWithContentsOfFile:path];
         
         NSError *error;
@@ -35,7 +35,7 @@
         
         [defaults synchronize];
         
-        [[NSFileManager defaultManager]removeItemAtPath:path error:&error];
+        [NSFileManager.defaultManager removeItemAtPath:path error:&error];
         
         if (error) {
             DDLogError(@"Error while migrating data: %@", error.description);
@@ -49,7 +49,7 @@
             DDLogError(@"Error re-registering on migration from 1.0.2");
         }];
         
-        [[NSFileManager defaultManager] removeItemAtPath:path error:&error];
+        [NSFileManager.defaultManager removeItemAtPath:path error:&error];
         
         if (error) {
             DDLogError(@"Error upgrading from 1.0.2 : %@", error.description);

--- a/Signal/src/network/IpAddress.m
+++ b/Signal/src/network/IpAddress.m
@@ -94,13 +94,13 @@
         struct sockaddr_in s = ipv4Data;
         s.sin_port = htons(port);
         NSMutableData* d = [NSMutableData dataWithLength:sizeof(struct sockaddr_in)];
-        memcpy([d mutableBytes], &s, sizeof(struct sockaddr_in));
+        memcpy(d.mutableBytes, &s, sizeof(struct sockaddr_in));
         return d;
     } else {
         struct sockaddr_in6 s = ipv6Data;
         s.sin6_port = htons(port);
         NSMutableData* d = [NSMutableData dataWithLength:sizeof(struct sockaddr_in6)];
-        memcpy([d mutableBytes], &s, sizeof(struct sockaddr_in6));
+        memcpy(d.mutableBytes, &s, sizeof(struct sockaddr_in6));
         return d;
     }
 }

--- a/Signal/src/network/rtp/RtpPacket.m
+++ b/Signal/src/network/rtp/RtpPacket.m
@@ -349,16 +349,16 @@ andSynchronizationSourceIdentifier:(uint32_t)synchronizedSourceIdentifier
     if (padding != [other padding]) return false;
     if (hasExtensionHeader != other.hasExtensionHeader) return false;
     if (isMarkerBitSet != other.isMarkerBitSet) return false;
-    if (payloadType != [other payloadType]) return false;
+    if (payloadType != other.payloadType) return false;
     if (timeStamp != [other timeStamp]) return false;
     if (synchronizationSourceIdentifier != [other synchronizationSourceIdentifier]) return false;
     if (sequenceNumber != [other sequenceNumber]) return false;
     
-    if (![payload isEqualToData:[other payload]]) return false;
+    if (![payload isEqualToData:other.payload]) return false;
     if (![contributingSourceIdentifiers isEqualToArray:[other contributingSourceIdentifiers]]) return false;
     if (hasExtensionHeader) {
-        if (extensionHeaderIdentifier != [other extensionHeaderIdentifier]) return false;
-        if (![extensionHeaderData isEqualToData:[other extensionHeaderData]]) return false;
+        if (extensionHeaderIdentifier != other.extensionHeaderIdentifier) return false;
+        if (![extensionHeaderData isEqualToData:other.extensionHeaderData]) return false;
     }
     
     if (![[self rawPacketDataUsingInteropOptions:@[]] isEqualToData:[other rawPacketDataUsingInteropOptions:@[]]]) return false;

--- a/Signal/src/network/rtp/srtp/SrtpStream.m
+++ b/Signal/src/network/rtp/srtp/SrtpStream.m
@@ -23,7 +23,7 @@
 
 -(RtpPacket*) encryptAndAuthenticateNormalRtpPacket:(RtpPacket*)normalRtpPacket {
     require(normalRtpPacket != nil);
-    NSData* payload = [normalRtpPacket payload];
+    NSData* payload = normalRtpPacket.payload;
 
     NSData* iv = [self getIvForSequenceNumber:[normalRtpPacket sequenceNumber] andSynchronizationSourceIdentifier:[normalRtpPacket synchronizationSourceIdentifier]];
     NSData* encryptedPayload = [payload encryptWithAesInCounterModeWithKey:cipherKey andIv:iv];
@@ -37,7 +37,7 @@
 
 -(RtpPacket*) verifyAuthenticationAndDecryptSecuredRtpPacket:(RtpPacket*)securedRtpPacket {
     require(securedRtpPacket != nil);
-    checkOperationDescribe([[securedRtpPacket payload] length] >= HMAC_LENGTH, @"Payload not long enough to include hmac");
+    checkOperationDescribe(securedRtpPacket.payload.length >= HMAC_LENGTH, @"Payload not long enough to include hmac");
 
     NSData* authenticatedData = [securedRtpPacket rawPacketDataUsingInteropOptions:nil];
     NSData* includedHmac = [authenticatedData takeLastVolatile:HMAC_LENGTH];
@@ -46,7 +46,7 @@
     checkOperationDescribe([includedHmac isEqualToData_TimingSafe:expectedHmac], @"Authentication failed.");
 
     NSData* iv = [self getIvForSequenceNumber:[securedRtpPacket sequenceNumber] andSynchronizationSourceIdentifier:[securedRtpPacket synchronizationSourceIdentifier]];
-    NSData* encryptedPayload = [[securedRtpPacket payload] skipLastVolatile:HMAC_LENGTH];
+    NSData* encryptedPayload = [securedRtpPacket.payload skipLastVolatile:HMAC_LENGTH];
     NSData* decryptedPayload = [encryptedPayload decryptWithAesInCounterModeWithKey:cipherKey andIv:iv];
 
     return [securedRtpPacket withPayload:decryptedPayload];

--- a/Signal/src/network/rtp/zrtp/HashChain.m
+++ b/Signal/src/network/rtp/zrtp/HashChain.m
@@ -11,9 +11,9 @@
     require(seed.length == HASH_CHAIN_ITEM_LENGTH);
     HashChain* s = [HashChain new];
     s->h0 = seed;
-    s->h1 = [s->h0 hashWithSha256];
-    s->h2 = [s->h1 hashWithSha256];
-    s->h3 = [s->h2 hashWithSha256];
+    s->h1 = s->h0.hashWithSha256;
+    s->h2 = s->h1.hashWithSha256;
+    s->h3 = s->h2.hashWithSha256;
     return s;
 }
 +(HashChain*) hashChainWithSecureGeneratedData {

--- a/Signal/src/network/rtp/zrtp/MasterSecret.m
+++ b/Signal/src/network/rtp/zrtp/MasterSecret.m
@@ -88,7 +88,7 @@
                     
                     ] concatDatas];
     
-    return [data hashWithSha256];
+    return data.hashWithSha256;
 }
 
 +(NSData*) calculateTotalHashFromResponderHello:(HelloPacket*)responderHello
@@ -100,16 +100,16 @@
     require(dhPart1 != nil);
     require(dhPart2 != nil);
     
-    NSData* data = [@[
+    NSData* data = @[
                     
-                    [[responderHello embeddedIntoHandshakePacket] dataUsedForAuthentication],
-                    [[commit embeddedIntoHandshakePacket] dataUsedForAuthentication],
-                    [[dhPart1 embeddedIntoHandshakePacket] dataUsedForAuthentication],
-                    [[dhPart2 embeddedIntoHandshakePacket] dataUsedForAuthentication]
+                    responderHello.embeddedIntoHandshakePacket.dataUsedForAuthentication,
+                    commit.embeddedIntoHandshakePacket.dataUsedForAuthentication,
+                    dhPart1.embeddedIntoHandshakePacket.dataUsedForAuthentication,
+                    dhPart2.embeddedIntoHandshakePacket.dataUsedForAuthentication
                     
-                    ] concatDatas];
+                    ].concatDatas;
     
-    return [data hashWithSha256];
+    return data.hashWithSha256;
     
 }
 

--- a/Signal/src/network/rtp/zrtp/ZrtpManager.m
+++ b/Signal/src/network/rtp/zrtp/ZrtpManager.m
@@ -53,7 +53,7 @@
     manager->rtpSocketToSecure              = rtpSocket;
     manager->handshakeSocket                = handshakeSocket;
     manager->cancelTokenSource              = [TOCCancelTokenSource new];
-    [[callController untilCancelledToken] whenCancelledTerminate:manager];
+    [callController.untilCancelledToken whenCancelledTerminate:manager];
     
     [manager->futureHandshakeResultSource.future catchDo:^(id error) {
         [callController terminateWithReason:CallTerminationType_HandshakeFailed
@@ -82,7 +82,7 @@
         // (the RFC says to treat this as implying a Conf2Ack)
         if ([zrtpRole isAuthenticatedAudioDataImplyingConf2Ack:relatedInfo]) {
             // low-priority todo: Can we cache this bit of audio data, so that when the srtp socket is started the data comes out?
-            [self handleHandshakePacket:[[ConfirmAckPacket confirmAckPacket] embeddedIntoHandshakePacket]];
+            [self handleHandshakePacket:ConfirmAckPacket.confirmAckPacket.embeddedIntoHandshakePacket];
         }
     };
     

--- a/Signal/src/network/rtp/zrtp/packets/CommitPacket.m
+++ b/Signal/src/network/rtp/zrtp/packets/CommitPacket.m
@@ -35,8 +35,8 @@
     require(hello != nil);
     require(dhPart2 != nil);
     
-    NSData* dhPart2Data = [[dhPart2 embeddedIntoHandshakePacket] dataUsedForAuthentication];
-    NSData* helloData = [[hello embeddedIntoHandshakePacket] dataUsedForAuthentication];
+    NSData* dhPart2Data = dhPart2.embeddedIntoHandshakePacket.dataUsedForAuthentication;
+    NSData* helloData = hello.embeddedIntoHandshakePacket.dataUsedForAuthentication;
     return [CommitPacket commitPacketWithHashChainH2:hashChain.h2
                                               andZid:zid
                                        andHashSpecId:COMMIT_DEFAULT_HASH_SPEC_ID
@@ -118,13 +118,13 @@
     require(dhPart2 != nil);
     
     NSData* expected = [[@[
-                         [[dhPart2 embeddedIntoHandshakePacket] dataUsedForAuthentication],
-                         [[hello embeddedIntoHandshakePacket] dataUsedForAuthentication]]
+                         dhPart2.embeddedIntoHandshakePacket.dataUsedForAuthentication,
+                         hello.embeddedIntoHandshakePacket.dataUsedForAuthentication]
                          concatDatas] hashWithSha256];
     checkOperation([dhPart2HelloCommitment isEqualToData_TimingSafe:expected]);
 }
 -(void) verifyMacWithHashChainH1:(NSData*)hashChainH1 {
-    checkOperation([[hashChainH1 hashWithSha256] isEqualToData_TimingSafe:h2]);
+    checkOperation([hashChainH1.hashWithSha256 isEqualToData_TimingSafe:h2]);
     [embedding withHmacVerifiedAndRemoved:hashChainH1];
 }
 
@@ -155,7 +155,7 @@
 +(CommitPacket*) commitPacketParsedFromHandshakePacket:(HandshakePacket*)handshakePacket {
     require(handshakePacket != nil);
     checkOperation([[handshakePacket typeId] isEqualToData:HANDSHAKE_TYPE_COMMIT]);
-    NSData* payload = [handshakePacket payload];
+    NSData* payload = handshakePacket.payload;
     checkOperation(payload.length == COMMIT_OFFSET + COMMIT_LENGTH + HANDSHAKE_TRUNCATED_HMAC_LENGTH);
     
     CommitPacket* p = [CommitPacket new];

--- a/Signal/src/network/rtp/zrtp/packets/ConfirmAckPacket.m
+++ b/Signal/src/network/rtp/zrtp/packets/ConfirmAckPacket.m
@@ -9,8 +9,8 @@
 }
 
 +(ConfirmAckPacket*)confirmAckPacketParsedFromHandshakePacket:(HandshakePacket*)handshakePacket {
-    checkOperation([[handshakePacket typeId] isEqualToData:HANDSHAKE_TYPE_CONFIRM_ACK]);
-    checkOperation([[handshakePacket payload] length] == 0);
+    checkOperation([handshakePacket.typeId isEqualToData:HANDSHAKE_TYPE_CONFIRM_ACK]);
+    checkOperation(handshakePacket.payload.length == 0);
     
     ConfirmAckPacket* h = [ConfirmAckPacket new];
     h->embedding = handshakePacket;

--- a/Signal/src/network/rtp/zrtp/packets/ConfirmPacket.m
+++ b/Signal/src/network/rtp/zrtp/packets/ConfirmPacket.m
@@ -45,16 +45,16 @@
     require(cipherKey != nil);
     NSData* expectedConfirmTypeId = isPart1 ? HANDSHAKE_TYPE_CONFIRM_1 : HANDSHAKE_TYPE_CONFIRM_2;
     
-    checkOperation([[handshakePacket typeId] isEqualToData:expectedConfirmTypeId]);
-    checkOperation([[handshakePacket payload] length] == TRUNCATED_HMAC_LENGTH + CONFIRM_IV_LENGTH + HASH_CHAIN_ITEM_LENGTH + WORD_LENGTH + WORD_LENGTH);
-    NSData* decryptedData = [self getDecryptedDataFromPayload:[handshakePacket payload] withMacKey:macKey andCipherKey:cipherKey];
+    checkOperation([handshakePacket.typeId isEqualToData:expectedConfirmTypeId]);
+    checkOperation(handshakePacket.payload.length == TRUNCATED_HMAC_LENGTH + CONFIRM_IV_LENGTH + HASH_CHAIN_ITEM_LENGTH + WORD_LENGTH + WORD_LENGTH);
+    NSData* decryptedData = [self getDecryptedDataFromPayload:handshakePacket.payload withMacKey:macKey andCipherKey:cipherKey];
     
     return [ConfirmPacket confirmPacketParsedFrom:handshakePacket
                                   withHashChainH0:[self getHashChainH0FromDecryptedData:decryptedData]
               andUnusedAndSignatureLengthAndFlags:[self getUnusedAndSignatureLengthAndFlagsFromDecryptedData:decryptedData]
                        andCacheExpirationInterval:[self getCacheExpirationIntervalFromDecryptedData:decryptedData]
-                                  andIncludedHmac:[self getIncludedHmacFromPayload:[handshakePacket payload]]
-                                            andIv:[self getIvFromPayload:[handshakePacket payload]]
+                                  andIncludedHmac:[self getIncludedHmacFromPayload:handshakePacket.payload]
+                                            andIv:[self getIvFromPayload:handshakePacket.payload]
                                        andIsPart1:isPart1];
 }
 +(ConfirmPacket*) confirmPacketWithHashChainH0:(NSData*)hashChainH0

--- a/Signal/src/network/rtp/zrtp/packets/DhPacket.m
+++ b/Signal/src/network/rtp/zrtp/packets/DhPacket.m
@@ -56,7 +56,7 @@
     
     DhPacket* p = [DhPacket new];
     p->isPart1 = isPart1;
-    p->hashChainH1 = [hashChainH0 hashWithSha256];
+    p->hashChainH1 = hashChainH0.hashWithSha256;
     p->sharedSecretHashes = sharedSecretHashes;
     p->publicKeyData = publicKeyData;
     p->embedding = [p embedIntoHandshakePacketAuthenticatedWithMacKey:hashChainH0];
@@ -64,7 +64,7 @@
 }
 
 -(void) verifyMacWithHashChainH0:(NSData*)hashChainH0 {
-    checkOperation([[hashChainH0 hashWithSha256] isEqualToData_TimingSafe:hashChainH1]);
+    checkOperation([hashChainH0.hashWithSha256 isEqualToData_TimingSafe:hashChainH1]);
     [embedding withHmacVerifiedAndRemoved:hashChainH0];
 }
 
@@ -90,7 +90,7 @@
     
     require(handshakePacket != nil);
     NSData* expectedTypeIdDhPacket = isPart1 ? HANDSHAKE_TYPE_DH_1 : HANDSHAKE_TYPE_DH_2;
-    NSData* payload = [handshakePacket payload];
+    NSData* payload = handshakePacket.payload;
     
     checkOperation([[handshakePacket typeId] isEqualToData:expectedTypeIdDhPacket]);
     checkOperation(payload.length >= MIN_DH_PKT_LENGTH);

--- a/Signal/src/network/rtp/zrtp/packets/HandshakePacket.m
+++ b/Signal/src/network/rtp/zrtp/packets/HandshakePacket.m
@@ -36,21 +36,21 @@
 }
 
 +(NSData*) getHandshakeTypeIdFromRtp:(RtpPacket*)rtpPacket {
-    return [[rtpPacket extensionHeaderData] take:HANDSHAKE_TYPE_ID_LENGTH];
+    return [rtpPacket.extensionHeaderData take:HANDSHAKE_TYPE_ID_LENGTH];
 }
 +(NSData*) getHandshakePayloadFromRtp:(RtpPacket*)rtpPacket {
-    return [[[rtpPacket extensionHeaderData] skip:HANDSHAKE_TYPE_ID_LENGTH] skipLast:HANDSHAKE_CRC_LENGTH];
+    return [[rtpPacket.extensionHeaderData skip:HANDSHAKE_TYPE_ID_LENGTH] skipLast:HANDSHAKE_CRC_LENGTH];
 }
 +(uint32_t) getIncludedHandshakeCrcFromRtp:(RtpPacket*)rtpPacket {
-    return [[[rtpPacket extensionHeaderData] takeLast:HANDSHAKE_CRC_LENGTH] bigEndianUInt32At:0];
+    return [[rtpPacket.extensionHeaderData takeLast:HANDSHAKE_CRC_LENGTH] bigEndianUInt32At:0];
 }
 +(HandshakePacket*) handshakePacketParsedFromRtpPacket:(RtpPacket*)rtpPacket {
     require(rtpPacket != nil);
     checkOperation([rtpPacket timeStamp] == HANDSHAKE_PACKET_TIMESTAMP_COOKIE);
     checkOperation([rtpPacket version] == 0);
     checkOperation(rtpPacket.hasExtensionHeader);
-    checkOperation([rtpPacket extensionHeaderIdentifier] == HANDSHAKE_PACKET_EXTENSION_IDENTIFIER);
-    checkOperation([[rtpPacket extensionHeaderData] length] >= HEADER_FOOTER_LENGTH_WITHOUT_HMAC);
+    checkOperation(rtpPacket.extensionHeaderIdentifier == HANDSHAKE_PACKET_EXTENSION_IDENTIFIER);
+    checkOperation([rtpPacket.extensionHeaderData length] >= HEADER_FOOTER_LENGTH_WITHOUT_HMAC);
     
     NSData* handshakeTypeId = [self getHandshakeTypeIdFromRtp:rtpPacket];
     NSData* handshakePayload = [self getHandshakePayloadFromRtp:rtpPacket];

--- a/Signal/src/network/rtp/zrtp/packets/HelloAckPacket.m
+++ b/Signal/src/network/rtp/zrtp/packets/HelloAckPacket.m
@@ -9,8 +9,8 @@
 }
 
 +(HelloAckPacket*)helloAckPacketParsedFromHandshakePacket:(HandshakePacket*)handshakePacket {
-    checkOperation([[handshakePacket typeId] isEqualToData:HANDSHAKE_TYPE_HELLO_ACK]);
-    checkOperation([[handshakePacket payload] length] == 0);
+    checkOperation([handshakePacket.typeId isEqualToData:HANDSHAKE_TYPE_HELLO_ACK]);
+    checkOperation(handshakePacket.payload.length == 0);
     
     HelloAckPacket* h = [HelloAckPacket new];
     h->embedding = handshakePacket;

--- a/Signal/src/network/rtp/zrtp/packets/HelloPacket.m
+++ b/Signal/src/network/rtp/zrtp/packets/HelloPacket.m
@@ -163,7 +163,7 @@
 }
 
 -(void) verifyMacWithHashChainH2:(NSData*)hashChainH2 {
-    checkOperationDescribe([[hashChainH2 hashWithSha256] isEqualToData_TimingSafe:hashChainH3], @"Invalid preimage");
+    checkOperationDescribe([hashChainH2.hashWithSha256 isEqualToData_TimingSafe:hashChainH3], @"Invalid preimage");
     [embedding withHmacVerifiedAndRemoved:hashChainH2];
 }
 +(NSData*) getVersionIdFromPayload:(NSData*)payload {
@@ -222,7 +222,7 @@
     require(handshakePacket != nil);
     checkOperationDescribe([[handshakePacket typeId] isEqualToData:HANDSHAKE_TYPE_HELLO], @"Not a hello packet");
     
-    NSData* payload = [handshakePacket payload];
+    NSData* payload = handshakePacket.payload;
     checkOperation(payload.length >= SPEC_IDS_OFFSET);
     
     HelloPacket* p = [HelloPacket new];

--- a/Signal/src/network/tcp/tls/NetworkStream.m
+++ b/Signal/src/network/tcp/tls/NetworkStream.m
@@ -70,7 +70,7 @@
 }
 -(void) tryWriteBufferedData {
     if (!futureConnectedAndWritableSource.future.hasResult) return;
-    if (![[futureConnectedAndWritableSource.future forceGetResult] isEqual:@YES]) return;
+    if (![futureConnectedAndWritableSource.future.forceGetResult isEqual:@YES]) return;
     NSStreamStatus status = [outputStream streamStatus];
     if (status < NSStreamStatusOpen) return;
     if (status >= NSStreamStatusAtEnd) {
@@ -184,7 +184,7 @@
     if (![futureConnectedAndWritableSource.future.forceGetResult isEqual:@YES]) return;
     
     while (inputStream.hasBytesAvailable) {
-        NSInteger numRead = [inputStream read:[readBuffer mutableBytes] maxLength:readBuffer.length];
+        NSInteger numRead = [inputStream read:readBuffer.mutableBytes maxLength:readBuffer.length];
         
         if (numRead < 0) [self onErrorOccurred:@"Read Error"];
         if (numRead <= 0) break;

--- a/Signal/src/phone/PhoneManager.m
+++ b/Signal/src/phone/PhoneManager.m
@@ -57,7 +57,7 @@
                                                                          remote:remoteNumber
                                                                 optionalContact:contact];
     [callController acceptCall]; // initiator implicitly accepts call
-    TOCCancelToken* lifetime = [callController untilCancelledToken];
+    TOCCancelToken* lifetime = callController.untilCancelledToken;
         
     TOCFuture* futureConnected = [CallConnectUtil asyncInitiateCallToRemoteNumber:remoteNumber
                                                                 andCallController:callController];
@@ -82,7 +82,7 @@
     int64_t prevSession = lastIncomingSessionId;
     lastIncomingSessionId = session.sessionId;
 
-    if ([currentCallControllerObservable.currentValue callState].futureTermination.isIncomplete) {
+    if (((CallController*)currentCallControllerObservable.currentValue).callState.futureTermination.isIncomplete) {
         if (session.sessionId == prevSession) {
             Environment.errorNoter(@"Ignoring duplicate incoming call signal.", session, false);
             return;
@@ -101,7 +101,7 @@
                                                                          remote:session.initiatorNumber
                                                                 optionalContact:callingContact];
 
-    TOCCancelToken* lifetime = [callController untilCancelledToken];
+    TOCCancelToken* lifetime = callController.untilCancelledToken;
     
     TOCFuture* futureConnected = [CallConnectUtil asyncRespondToCallWithSessionDescriptor:session
                                                                         andCallController:callController];

--- a/Signal/src/phone/signaling/CallConnectUtil_Initiator.m
+++ b/Signal/src/phone/signaling/CallConnectUtil_Initiator.m
@@ -44,11 +44,11 @@
         
         [httpManager startWithRequestHandler:serverRequestHandler
                              andErrorHandler:callController.errorHandler
-                              untilCancelled:[callController untilCancelledToken]];
+                              untilCancelled:callController.untilCancelledToken];
         
         HttpRequest* initiateRequest = [HttpRequest httpRequestToInitiateToRemoteNumber:callController.callState.remoteNumber];
         TOCFuture* futureResponseToInitiate = [httpManager asyncOkResponseForRequest:initiateRequest
-                                                                     unlessCancelled:[callController untilCancelledToken]];
+                                                                     unlessCancelled:callController.untilCancelledToken];
         TOCFuture* futureResponseToInitiateWithInterpretedFailures = [futureResponseToInitiate catchTry:^(id error) {
             if ([error isKindOfClass:HttpResponse.class]) {
                 HttpResponse* badResponse = error;
@@ -112,7 +112,8 @@
                              andRelatedInfo:request];
         return [HttpResponse httpResponse500InternalServerError];
     }
-    int64_t sessionId = [[futureInitiatorSessionDescriptor forceGetResult] sessionId];
+
+    int64_t sessionId = ((InitiatorSessionDescriptor*)futureInitiatorSessionDescriptor.forceGetResult).sessionId;
     
     // hangup?
     if ([request isHangupForSession:sessionId]) {

--- a/Signal/src/phone/signaling/CallConnectUtil_Responder.m
+++ b/Signal/src/phone/signaling/CallConnectUtil_Responder.m
@@ -37,7 +37,7 @@
     require(callController != nil);
     
     TOCFuture* futureSignalConnection = [CallConnectUtil_Server asyncConnectToSignalingServerNamed:sessionDescriptor.relayServerName
-                                                                                    untilCancelled:[callController untilCancelledToken]];
+                                                                                    untilCancelled:callController.untilCancelledToken];
     
     return [futureSignalConnection thenTry:^id(HttpManager* httpManager) {
         require([httpManager isKindOfClass:httpManager.class]);
@@ -50,11 +50,11 @@
         
         [httpManager startWithRequestHandler:serverRequestHandler
                              andErrorHandler:Environment.errorNoter
-                              untilCancelled:[callController untilCancelledToken]];
+                              untilCancelled:callController.untilCancelledToken];
         
         HttpRequest* ringRequest = [HttpRequest httpRequestToRingWithSessionId:sessionDescriptor.sessionId];
         TOCFuture* futureResponseToRing = [httpManager asyncOkResponseForRequest:ringRequest
-                                                                 unlessCancelled:[callController untilCancelledToken]];
+                                                                 unlessCancelled:callController.untilCancelledToken];
         TOCFuture* futureResponseToRingWithInterpretedFailures = [futureResponseToRing catchTry:^(id error) {
             if ([error isKindOfClass:HttpResponse.class]) {
                 HttpResponse* badResponse = error;

--- a/Signal/src/phone/signaling/CallConnectUtil_Server.m
+++ b/Signal/src/phone/signaling/CallConnectUtil_Server.m
@@ -102,7 +102,7 @@
                                               upToNTimes:MAX_TRY_COUNT
                                          withBaseTimeout:BASE_TIMEOUT_SECONDS
                                           andRetryFactor:RETRY_TIMEOUT_FACTOR
-                                          untilCancelled:[callController untilCancelledToken]];
+                                          untilCancelled:callController.untilCancelledToken];
     
     return [futureRelayedUdpSocket catchTry:^(id error) {
         return [TOCFuture futureWithFailure:[CallTermination callTerminationOfType:CallTerminationType_BadInteractionWithServer

--- a/Signal/src/phone/signaling/InitiateSignal.pb.m
+++ b/Signal/src/phone/signaling/InitiateSignal.pb.m
@@ -192,7 +192,7 @@ static InitiateSignal* defaultInitiateSignalInstance = nil;
   return [InitiateSignal builderWithPrototype:result];
 }
 - (InitiateSignal*) defaultInstance {
-  return [InitiateSignal defaultInstance];
+  return InitiateSignal.defaultInstance;
 }
 - (InitiateSignal*) build {
   [self checkInitialized];
@@ -204,7 +204,7 @@ static InitiateSignal* defaultInitiateSignalInstance = nil;
   return returnMe;
 }
 - (InitiateSignal_Builder*) mergeFrom:(InitiateSignal*) other {
-  if (other == [InitiateSignal defaultInstance]) {
+  if (other == InitiateSignal.defaultInstance) {
     return self;
   }
   if (other.hasInitiator) {

--- a/Signal/src/phone/signaling/number directory/PhoneNumberDirectoryFilterManager.m
+++ b/Signal/src/phone/signaling/number directory/PhoneNumberDirectoryFilterManager.m
@@ -106,7 +106,7 @@
             phoneNumberDirectoryFilter = directory;
         }
         [Environment.preferences setSavedPhoneNumberDirectory:directory];
-        [[NSNotificationCenter defaultCenter] postNotificationName:NOTIFICATION_DIRECTORY_WAS_UPDATED object:nil];
+        [NSNotificationCenter.defaultCenter postNotificationName:NOTIFICATION_DIRECTORY_WAS_UPDATED object:nil];
         [self scheduleUpdate];
     }];
 }

--- a/Signal/src/util/ArrayUtil.m
+++ b/Signal/src/util/ArrayUtil.m
@@ -15,11 +15,11 @@
     NSUInteger t = 0;
     for (id d in self) {
         require([d isKindOfClass:NSData.class]);
-        t += [(NSData*)d length];
+        t += ((NSData*)d).length;
     }
     
     NSMutableData* result = [NSMutableData dataWithLength:t];
-    uint8_t* dst = [result mutableBytes];
+    uint8_t* dst = result.mutableBytes;
     for (NSData* d in self) {
         memcpy(dst, [d bytes], d.length);
         dst += d.length;

--- a/Signal/src/util/DataUtil.m
+++ b/Signal/src/util/DataUtil.m
@@ -181,7 +181,7 @@
 @implementation NSMutableData (Util)
 -(void) setUint8At:(NSUInteger)offset to:(uint8_t)newValue {
     require(offset < self.length);
-    ((uint8_t*)[self mutableBytes])[offset] = newValue;
+    ((uint8_t*)self.mutableBytes)[offset] = newValue;
 }
 -(void) replaceBytesStartingAt:(NSUInteger)offset withData:(NSData*)data {
     require(data != nil);

--- a/Signal/src/view controllers/CallLogViewController.m
+++ b/Signal/src/view controllers/CallLogViewController.m
@@ -43,12 +43,12 @@ typedef NSComparisonResult (^CallComparator)(RecentCall*, RecentCall*);
 }
 
 - (void)observeKeyboardNotifications {
-    [[NSNotificationCenter defaultCenter] addObserver:self
+    [NSNotificationCenter.defaultCenter addObserver:self
                                              selector:@selector(keyboardWillShow:)
                                                  name:UIKeyboardWillShowNotification
                                                object:nil];
 
-    [[NSNotificationCenter defaultCenter] addObserver:self
+    [NSNotificationCenter.defaultCenter addObserver:self
                                              selector:@selector(keyboardWillHide:)
                                                  name:UIKeyboardWillHideNotification
                                                object:nil];

--- a/Signal/src/view controllers/ContactBrowseViewController.m
+++ b/Signal/src/view controllers/ContactBrowseViewController.m
@@ -33,7 +33,7 @@ static NSString *const CONTACT_BROWSE_TABLE_CELL_IDENTIFIER = @"ContactTableView
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(contactsDidRefresh) name:NOTIFICATION_DIRECTORY_WAS_UPDATED object:nil];
+    [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(contactsDidRefresh) name:NOTIFICATION_DIRECTORY_WAS_UPDATED object:nil];
     UIRefreshControl *refreshControl = [[UIRefreshControl alloc]
                                         init];
     [refreshControl addTarget:self action:@selector(refreshContacts) forControlEvents:UIControlEventValueChanged];
@@ -70,7 +70,7 @@ static NSString *const CONTACT_BROWSE_TABLE_CELL_IDENTIFIER = @"ContactTableView
 }
 
 - (void)dealloc {
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
+    [NSNotificationCenter.defaultCenter removeObserver:self];
 }
 
 - (void)onSearchOrContactChange:(NSString *)searchTerm {
@@ -85,12 +85,12 @@ static NSString *const CONTACT_BROWSE_TABLE_CELL_IDENTIFIER = @"ContactTableView
 }
 
 - (void)observeKeyboardNotifications {
-    [[NSNotificationCenter defaultCenter] addObserver:self
+    [NSNotificationCenter.defaultCenter addObserver:self
                                              selector:@selector(keyboardWillShow:)
                                                  name:UIKeyboardWillShowNotification
                                                object:nil];
 
-    [[NSNotificationCenter defaultCenter] addObserver:self
+    [NSNotificationCenter.defaultCenter addObserver:self
                                              selector:@selector(keyboardWillHide:)
                                                  name:UIKeyboardWillHideNotification
                                                object:nil];
@@ -174,7 +174,7 @@ static NSString *const CONTACT_BROWSE_TABLE_CELL_IDENTIFIER = @"ContactTableView
 #pragma mark - UITableViewDelegate
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
-    return (NSInteger)[[self contactsForSectionIndex:(NSUInteger)section] count];
+    return (NSInteger)[self contactsForSectionIndex:(NSUInteger)section].count;
 }
 
 - (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section {
@@ -182,7 +182,7 @@ static NSString *const CONTACT_BROWSE_TABLE_CELL_IDENTIFIER = @"ContactTableView
 }
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
-    return (NSInteger)[[_latestAlphabeticalContacts allKeys] count];
+    return (NSInteger)[_latestAlphabeticalContacts allKeys].count;
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {

--- a/Signal/src/view controllers/ContactDetailViewController.m
+++ b/Signal/src/view controllers/ContactDetailViewController.m
@@ -87,7 +87,7 @@ static NSString *const FAVOURITE_FALSE_ICON_NAME = @"favourite_false_icon";
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
     [tableView deselectRowAtIndexPath:indexPath animated:YES];
 
-    if (indexPath.row < (NSInteger)[[_contact userTextPhoneNumbers] count]) {
+    if (indexPath.row < (NSInteger)[_contact userTextPhoneNumbers].count) {
 
         NSString *numberString = _contact.userTextPhoneNumbers[(NSUInteger)indexPath.row];
         PhoneNumber *number = [PhoneNumber tryParsePhoneNumberFromUserSpecifiedText:numberString];
@@ -107,7 +107,7 @@ static NSString *const FAVOURITE_FALSE_ICON_NAME = @"favourite_false_icon";
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {
 
-    BOOL cellNeedsHeightForText = indexPath.row == (NSInteger)[[_contact userTextPhoneNumbers] count] + (NSInteger)[[_contact emails] count];
+    BOOL cellNeedsHeightForText = indexPath.row == (NSInteger)(_contact.userTextPhoneNumbers.count + _contact.emails.count);
 
     if (cellNeedsHeightForText) {
         CGSize size = [_contact.notes sizeWithAttributes:@{NSFontAttributeName:[UIUtil helveticaRegularWithSize:17]}];

--- a/Signal/src/view controllers/FavouritesViewController.m
+++ b/Signal/src/view controllers/FavouritesViewController.m
@@ -29,7 +29,7 @@ static NSString *const CONTACT_TABLE_VIEW_CELL_IDENTIFIER = @"ContactTableViewCe
 }
 
 - (void)dealloc {
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
+    [NSNotificationCenter.defaultCenter removeObserver:self];
 }
 
 - (void)viewWillAppear:(BOOL)animated {
@@ -67,12 +67,12 @@ static NSString *const CONTACT_TABLE_VIEW_CELL_IDENTIFIER = @"ContactTableViewCe
 }
 
 - (void)observeKeyboardNotifications {
-    [[NSNotificationCenter defaultCenter] addObserver:self
+    [NSNotificationCenter.defaultCenter addObserver:self
                                              selector:@selector(keyboardWillShow:)
                                                  name:UIKeyboardWillShowNotification
                                                object:nil];
 
-    [[NSNotificationCenter defaultCenter] addObserver:self
+    [NSNotificationCenter.defaultCenter addObserver:self
                                              selector:@selector(keyboardWillHide:)
                                                  name:UIKeyboardWillHideNotification
                                                object:nil];

--- a/Signal/src/view controllers/InboxFeedViewController.m
+++ b/Signal/src/view controllers/InboxFeedViewController.m
@@ -71,7 +71,7 @@ static NSString *const FOOTER_TABLE_CELL_IDENTIFIER = @"InboxFeedFooterCell";
 }
 
 - (void)dealloc {
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
+    [NSNotificationCenter.defaultCenter removeObserver:self];
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {
@@ -104,12 +104,12 @@ static NSString *const FOOTER_TABLE_CELL_IDENTIFIER = @"InboxFeedFooterCell";
 }
 
 - (void)observeKeyboardNotifications {
-    [[NSNotificationCenter defaultCenter] addObserver:self
+    [NSNotificationCenter.defaultCenter addObserver:self
                                              selector:@selector(keyboardWillShow:)
                                                  name:UIKeyboardWillShowNotification
                                                object:nil];
 
-    [[NSNotificationCenter defaultCenter] addObserver:self
+    [NSNotificationCenter.defaultCenter addObserver:self
                                              selector:@selector(keyboardWillHide:)
                                                  name:UIKeyboardWillHideNotification
                                                object:nil];

--- a/Signal/src/view controllers/InviteContactsViewController.m
+++ b/Signal/src/view controllers/InviteContactsViewController.m
@@ -55,16 +55,16 @@ static NSString *const INVITE_CONTACTS_TABLE_CELL_IDENTIFIER = @"ContactTableVie
 }
 
 - (void)dealloc {
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
+    [NSNotificationCenter.defaultCenter removeObserver:self];
 }
 
 - (void)observeKeyboardNotifications {
-    [[NSNotificationCenter defaultCenter] addObserver:self
+    [NSNotificationCenter.defaultCenter addObserver:self
                                              selector:@selector(keyboardWillShow:)
                                                  name:UIKeyboardWillShowNotification
                                                object:nil];
     
-    [[NSNotificationCenter defaultCenter] addObserver:self
+    [NSNotificationCenter.defaultCenter addObserver:self
                                              selector:@selector(keyboardWillHide:)
                                                  name:UIKeyboardWillHideNotification
                                                object:nil];

--- a/Signal/src/view controllers/RegisterViewController.m
+++ b/Signal/src/view controllers/RegisterViewController.m
@@ -314,12 +314,12 @@
 }
 
 - (void)observeKeyboardNotifications {
-    [[NSNotificationCenter defaultCenter] addObserver:self
+    [NSNotificationCenter.defaultCenter addObserver:self
                                              selector:@selector(keyboardWillShow:)
                                                  name:UIKeyboardWillShowNotification
                                                object:nil];
 
-    [[NSNotificationCenter defaultCenter] addObserver:self
+    [NSNotificationCenter.defaultCenter addObserver:self
                                              selector:@selector(keyboardWillHide:)
                                                  name:UIKeyboardWillHideNotification
                                                object:nil];

--- a/Signal/src/view controllers/TabBarParentViewController.m
+++ b/Signal/src/view controllers/TabBarParentViewController.m
@@ -60,7 +60,7 @@
         [self updateMissedCallCountLabel];		
     } onThread:NSThread.mainThread untilCancelled:nil];
     
-    [[NSNotificationCenter defaultCenter] addObserver:self
+    [NSNotificationCenter.defaultCenter addObserver:self
                                              selector:@selector(newUsersDetected:)
                                                  name:NOTIFICATION_NEW_USERS_AVAILABLE
                                                object:nil];

--- a/Signal/src/views/InboxFeedFooterCell.m
+++ b/Signal/src/views/InboxFeedFooterCell.m
@@ -9,7 +9,7 @@
     if (self) {
         ObservableValue *recentCallObserver = Environment.getCurrent.recentCallManager.getObservableRecentCalls;
         [recentCallObserver watchLatestValue:^(id latestValue) {
-            NSUInteger inboxCount = [[Environment.getCurrent.recentCallManager recentsForSearchString:nil andExcludeArchived:YES] count];
+            NSUInteger inboxCount = [Environment.getCurrent.recentCallManager recentsForSearchString:nil andExcludeArchived:YES].count;
             if (inboxCount == 0) {
                 _inboxCountLabel.text = @"";
                 _inboxMessageLabelFirst.text = HOME_FOOTER_FIRST_MESSAGE_CALLS_NIL;

--- a/Signal/test/TestUtil.m
+++ b/Signal/test/TestUtil.m
@@ -41,7 +41,7 @@ NSData* sineWave(double frequency, double sampleRate, NSUInteger sampleCount) {
 NSData* generatePseudoRandomData(NSUInteger length) {
     NSMutableData* r = [NSMutableData dataWithLength:length];
     for (int i = 0; i < 16; i++) {
-        ((uint8_t*)[r mutableBytes])[i] = (uint8_t)arc4random_uniform(256);
+        ((uint8_t*)r.mutableBytes)[i] = (uint8_t)arc4random_uniform(256);
     }
     return r;
 }

--- a/Signal/test/network/dns/DnsManagerTest.m
+++ b/Signal/test/network/dns/DnsManagerTest.m
@@ -22,7 +22,7 @@
     TOCFuture* f1 = [DnsManager asyncQueryAddressesForDomainName:reliableHostName
                                                  unlessCancelled:nil];
     testChurnUntil(f1.hasResult, 5.0);
-    test(f1.hasResult && [(NSArray*)[f1 forceGetResult] count] > 0);
+    test(f1.hasResult && ((NSArray*)f1.forceGetResult).count > 0);
     
     TOCFuture* f2 = [DnsManager asyncQueryAddressesForDomainName:invalidHostname
                                                  unlessCancelled:nil];
@@ -35,7 +35,7 @@
     TOCFuture* f4 = [DnsManager asyncQueryAddressesForDomainName:infrastructureTestHostName
                                                  unlessCancelled:nil];
     testChurnUntil(f4.hasResult, 5.0);
-    test(f4.hasResult && [(NSArray*)[f4 forceGetResult] count] > 0);
+    test(f4.hasResult && ((NSArray*)f4.forceGetResult).count > 0);
     
 }
 
@@ -50,8 +50,8 @@
                                                  unlessCancelled:nil];
     
     testChurnUntil(f1.hasResult && f2.hasFailed && f3.hasFailed && f4.hasResult, 5.0);
-    test(f1.hasResult && [(NSArray*)[f1 forceGetResult] count] > 0);
-    test(f4.hasResult && [(NSArray*)[f4 forceGetResult] count] > 0);
+    test(f1.hasResult && ((NSArray*)f1.forceGetResult).count > 0);
+    test(f4.hasResult && ((NSArray*)f4.forceGetResult).count > 0);
 }
 
 -(void) testQueryAddresses_Cancel {

--- a/Signal/test/network/http/HttpRequestResponseTest.m
+++ b/Signal/test/network/http/HttpRequestResponseTest.m
@@ -50,21 +50,21 @@
     HttpRequest* h0 = [HttpRequest httpRequestFromData:[@"GET /index.html HTTP/1.0\r\nContent-Length: 0\r\n\r\n" encodedAsUtf8]];
     test([[h0 method] isEqualToString:@"GET"]);
     test([[h0 location] isEqualToString:@"/index.html"]);
-    test([[h0 headers] count] == 1);
+    test([h0 headers].count == 1);
     test([[h0 headers][@"Content-Length"] isEqualToString:@"0"]);
     test([[h0 optionalBody] isEqualToString:@""]);
 
     HttpRequest* h1 = [HttpRequest httpRequestFromData:[@"GET /index.html HTTP/1.0\r\nContent-Length: 10\r\n\r\nabcdefghij" encodedAsUtf8]];
     test([[h1 method] isEqualToString:@"GET"]);
     test([[h1 location] isEqualToString:@"/index.html"]);
-    test([[h1 headers] count] == 1);
+    test([h1 headers].count == 1);
     test([[h1 headers][@"Content-Length"] isEqualToString:@"10"]);
     test([[h1 optionalBody] isEqualToString:@"abcdefghij"]);
     
     HttpRequest* h = [HttpRequest httpRequestFromData:@"GET /index.html HTTP/1.0\r\n\r\n".encodedAsUtf8];
     test([[h method] isEqualToString:@"GET"]);
     test([[h location] isEqualToString:@"/index.html"]);
-    test([[h headers] count] == 0);
+    test([h headers].count == 0);
     test([h optionalBody] == nil);
     
     testThrows([HttpRequest httpRequestFromData:@"GET /index.html HTTP/1.0\r\n".encodedAsUtf8]);
@@ -75,7 +75,7 @@
     HttpResponse* h = [HttpResponse httpResponse200Ok];
     test(h.getStatusCode == 200);
     test(h.getOptionalBodyText == nil);
-    test([h.getHeaders count] == 0);
+    test(h.getHeaders.count == 0);
 }
 -(void) testResponseFromData {
     HttpResponse* h = [HttpResponse httpResponseFromData:@"HTTP/1.1 200 OK\r\n\r\n".encodedAsUtf8];
@@ -83,14 +83,14 @@
     test(h.getStatusCode == 200);
     test([h.getStatusText isEqualToString: @"OK"]);
     test(h.getOptionalBodyText == nil);
-    test([h.getHeaders count] == 0);
+    test(h.getHeaders.count == 0);
     
     HttpResponse* h2 = [HttpResponse httpResponseFromData:@"HTTP/1.1 404 Not Found\r\n\r\n".encodedAsUtf8];
     test(!h2.isOkResponse);
     test(h2.getStatusCode == 404);
     test([h2.getStatusText isEqualToString:@"Not Found"]);
     test(h2.getOptionalBodyText == nil);
-    test([h2.getHeaders count] == 0);
+    test(h2.getHeaders.count == 0);
 
     testThrows([HttpResponse httpResponseFromData:@"HTTP/1.1 200 OK\r\n".encodedAsUtf8]);
     testThrows([HttpResponse httpResponseFromData:@"HTTP/1.1 200\r\n\r\n".encodedAsUtf8]);

--- a/Signal/test/network/rtp/RtpPacketTests.m
+++ b/Signal/test/network/rtp/RtpPacketTests.m
@@ -27,13 +27,13 @@
     test([r version] == 2);
     test([r padding] == 0);
     test(r.hasExtensionHeader == false);
-    test([[r contributingSourceIdentifiers] count] == 0);
+    test([r contributingSourceIdentifiers].count == 0);
     test([r synchronizationSourceIdentifier] == 0);
     test(r.isMarkerBitSet == false);
-    test([r payloadType] == 0);
+    test(r.payloadType == 0);
     test([r sequenceNumber] == 5);
     test([r timeStamp] == 0);
-    test([[r payload] isEqualToData:increasingData(5)]);
+    test([r.payload isEqualToData:increasingData(5)]);
 
     // equivalent to simplified constructor
     test([r isEqualToRtpPacket:[RtpPacket rtpPacketWithDefaultsAndSequenceNumber:5 andPayload:increasingData(5)]]);
@@ -68,10 +68,10 @@
     test([[r contributingSourceIdentifiers] isEqualToArray:(@[@101, @102])]);
     test([r synchronizationSourceIdentifier] == 0x45645645);
     test(r.isMarkerBitSet == true);
-    test([r payloadType] == 0x77);
+    test(r.payloadType == 0x77);
     test([r sequenceNumber] == 0x2122);
     test([r timeStamp] == 0xABCDEFAB);
-    test([[r payload] isEqualToData:increasingData(6)]);
+    test([r.payload isEqualToData:increasingData(6)]);
 
     NSData* expectedData = [@[
                             @0xA2,@0xF7,@0x21,@0x22,
@@ -103,15 +103,15 @@
     test([r version] == 2);
     test([r padding] == 0);
     test(r.hasExtensionHeader == true);
-    test([r extensionHeaderIdentifier] == 0xFEAB);
-    test([[r extensionHeaderData] isEqualToData:increasingDataFrom(10, 5)]);
-    test([[r contributingSourceIdentifiers] count] == 0);
+    test(r.extensionHeaderIdentifier == 0xFEAB);
+    test([r.extensionHeaderData isEqualToData:increasingDataFrom(10, 5)]);
+    test([r contributingSourceIdentifiers].count == 0);
     test([r synchronizationSourceIdentifier] == 0);
     test(r.isMarkerBitSet == false);
-    test([r payloadType] == 0);
+    test(r.payloadType == 0);
     test([r sequenceNumber] == 5);
     test([r timeStamp] == 0);
-    test([[r payload] isEqualToData:increasingData(5)]);
+    test([r.payload isEqualToData:increasingData(5)]);
     
     NSData* expectedData = [@[
                             @0x90,@0,@0,@5,

--- a/Signal/test/network/rtp/srtp/SecureStreamTest.m
+++ b/Signal/test/network/rtp/srtp/SecureStreamTest.m
@@ -43,7 +43,7 @@
     // authenticated then bit flip
     RtpPacket* r = [RtpPacket rtpPacketWithDefaultsAndSequenceNumber:5 andPayload:generatePseudoRandomData(40)];
     RtpPacket* s = [ss encryptAndAuthenticateNormalRtpPacket:r];
-    NSMutableData* m = [[s payload] mutableCopy];
+    NSMutableData* m = s.payload.mutableCopy;
     [m setUint8At:0 to:[m uint8At:0]^1];
     RtpPacket* sm = [r withPayload:m];
     testThrows([ss verifyAuthenticationAndDecryptSecuredRtpPacket:sm]);

--- a/Signal/test/network/rtp/zrtp/HandshakePacketTest.m
+++ b/Signal/test/network/rtp/zrtp/HandshakePacketTest.m
@@ -30,7 +30,7 @@
                                          andAgreeSpecIds:@[]
                                            andSasSpecIds:@[]
                                 authenticatedWithHmacKey:[h h2]];
-    NSData* data = [[[p embeddedIntoHandshakePacket] embeddedIntoRtpPacketWithSequenceNumber:0x25 usingInteropOptions:@[]] rawPacketDataUsingInteropOptions:@[]];
+    NSData* data = [[p.embeddedIntoHandshakePacket embeddedIntoRtpPacketWithSequenceNumber:0x25 usingInteropOptions:@[]] rawPacketDataUsingInteropOptions:@[]];
     uint8_t expectedData[] = {
         0x10,0x0,
         0x00,0x25, // sequence number
@@ -91,10 +91,10 @@
     HandshakePacket* withHMAC = [p withHmacAppended:key];
     HandshakePacket* strippedOfValidHMAC = [withHMAC withHmacVerifiedAndRemoved:key];
     
-    test([[p payload] isEqualToData:[strippedOfValidHMAC payload]]);
+    test([p.payload isEqualToData:strippedOfValidHMAC.payload]);
     
-    test([untouchedPayload isEqualToData:[p payload]]);
-    test([untouchedPayload isEqualToData:[strippedOfValidHMAC payload]]);
+    test([untouchedPayload isEqualToData:p.payload]);
+    test([untouchedPayload isEqualToData:strippedOfValidHMAC.payload]);
 }
 -(void) testHandshakeMacAuthenticationFails{
     NSData* type = [@"0f0f0f0f0f0f0f0f" decodedAsHexString];
@@ -114,10 +114,10 @@
     
     HandshakePacket* strippedOfValidHMAC = [withHMAC withHmacVerifiedAndRemoved:key];
     
-    test([[p payload] isEqualToData:[strippedOfValidHMAC payload]]);
+    test([p.payload isEqualToData:strippedOfValidHMAC.payload]);
     
-    test([untouchedPayload isEqualToData:[p payload]]);
-    test([untouchedPayload isEqualToData:[strippedOfValidHMAC payload]]);
+    test([untouchedPayload isEqualToData:p.payload]);
+    test([untouchedPayload isEqualToData:strippedOfValidHMAC.payload]);
     
 }
 @end

--- a/Signal/test/network/rtp/zrtp/HashChainTest.m
+++ b/Signal/test/network/rtp/zrtp/HashChainTest.m
@@ -13,8 +13,8 @@
     testThrows([HashChain hashChainWithSeed:nil]);
     NSData* d0 = [NSMutableData dataWithLength:32];
     NSData* d1 = [@[@0x66,@0x68,@0x7A,@0xAD,@0xF8,@0x62,@0xBD,@0x77,@0x6C,@0x8F,@0xC1,@0x8B,@0x8E,@0x9F,@0x8E,@0x20,@0x08,@0x97,@0x14,@0x85,@0x6E,@0xE2,@0x33,@0xB3,@0x90,@0x2A,@0x59,@0x1D,@0x0D,@0x5F,@0x29,@0x25] toUint8Data];
-    NSData* d2 = [d1 hashWithSha256];
-    NSData* d3 = [d2 hashWithSha256];
+    NSData* d2 = d1.hashWithSha256;
+    NSData* d3 = d2.hashWithSha256;
     
     HashChain* h = [HashChain hashChainWithSeed:d0];
     test([[h h0] isEqualToData:d0]);
@@ -23,10 +23,10 @@
     test([[h h3] isEqualToData:d3]);
 }
 -(void) testHashChainRandom {
-    HashChain* h = [HashChain hashChainWithSecureGeneratedData];
+    HashChain* h = HashChain.hashChainWithSecureGeneratedData;
     
     // maybe we'll find a collision! ... maybe not
-    test(![[h h1] isEqualToData:[h h3]]);
-    test(![[[HashChain hashChainWithSecureGeneratedData] h2] isEqualToData:[[HashChain hashChainWithSecureGeneratedData] h2]]);
+    test(![h.h1 isEqualToData:h.h3]);
+    test(![HashChain.hashChainWithSecureGeneratedData.h2 isEqualToData:HashChain.hashChainWithSecureGeneratedData.h2]);
 }
 @end

--- a/Signal/test/network/rtp/zrtp/MasterSecretTest.m
+++ b/Signal/test/network/rtp/zrtp/MasterSecretTest.m
@@ -30,13 +30,13 @@
     // the expected data here was obtained from the android redphone implementation
     MasterSecret* m = [MasterSecret masterSecretFromSharedSecret:sharedSecret andTotalHash:totalHash andInitiatorZid:initiatorZid andResponderZid:responderZid];
     test([[m shortAuthenticationStringData] isEqualToData:[(@[@241,@140,@246,@102]) toUint8Data]]);
-    test([[m initiatorSrtpKey] isEqualToData:[(@[@202,@139,@183,@119,@244,@164,@247,@11,@232,@161,@199,@120,@229,@49,@239,@141]) toUint8Data]]);
-    test([[m responderSrtpKey] isEqualToData:[(@[@35,@126,@130,@159,@156,@218,@64,@6,@59,@170,@139,@77,@250,@103,@84,@152]) toUint8Data]]);
-    test([[m initiatorSrtpSalt] isEqualToData:[(@[@92,@22,@129,@225,@169,@155,@6,@157,@34,@49,@76,@15,@196,@180]) toUint8Data]]);
-    test([[m responderSrtpSalt] isEqualToData:[(@[@151,@124,@181,@201,@203,@218,@192,@141,@244,@247,@249,@144,@213,@133]) toUint8Data]]);
-    test([[m initiatorMacKey] isEqualToData:[(@[@215,@167,@226,@196,@14,@124,@137,@75,@48,@110,@159,@47,@243,@238,@171,@213,@103,@181,@70,@206]) toUint8Data]]);
-    test([[m responderMacKey] isEqualToData:[(@[@215,@225,@180,@37,@18,@248,@122,@2,@24,@12,@149,@241,@8,@193,@103,@102,@117,@50,@27,@138]) toUint8Data]]);
-    test([[m initiatorZrtpKey] isEqualToData:[(@[@182,@239,@29,@23,@42,@7,@231,@48,@45,@244,@177,@84,@77,@62,@56,@48]) toUint8Data]]);
-    test([[m responderZrtpKey] isEqualToData:[(@[@59,@57,@33,@50,@121,@161,@218,@19,@255,@246,@98,@228,@68,@142,@50,@175]) toUint8Data]]);
+    test([m.initiatorSrtpKey isEqualToData:[(@[@202,@139,@183,@119,@244,@164,@247,@11,@232,@161,@199,@120,@229,@49,@239,@141]) toUint8Data]]);
+    test([m.responderSrtpKey isEqualToData:[(@[@35,@126,@130,@159,@156,@218,@64,@6,@59,@170,@139,@77,@250,@103,@84,@152]) toUint8Data]]);
+    test([m.initiatorSrtpSalt isEqualToData:[(@[@92,@22,@129,@225,@169,@155,@6,@157,@34,@49,@76,@15,@196,@180]) toUint8Data]]);
+    test([m.responderSrtpSalt isEqualToData:[(@[@151,@124,@181,@201,@203,@218,@192,@141,@244,@247,@249,@144,@213,@133]) toUint8Data]]);
+    test([m.initiatorMacKey isEqualToData:[(@[@215,@167,@226,@196,@14,@124,@137,@75,@48,@110,@159,@47,@243,@238,@171,@213,@103,@181,@70,@206]) toUint8Data]]);
+    test([m.responderMacKey isEqualToData:[(@[@215,@225,@180,@37,@18,@248,@122,@2,@24,@12,@149,@241,@8,@193,@103,@102,@117,@50,@27,@138]) toUint8Data]]);
+    test([m.initiatorZrtpKey isEqualToData:[(@[@182,@239,@29,@23,@42,@7,@231,@48,@45,@244,@177,@84,@77,@62,@56,@48]) toUint8Data]]);
+    test([m.responderZrtpKey isEqualToData:[(@[@59,@57,@33,@50,@121,@161,@218,@19,@255,@246,@98,@228,@68,@142,@50,@175]) toUint8Data]]);
 }
 @end

--- a/Signal/test/network/rtp/zrtp/ZrtpTest.m
+++ b/Signal/test/network/rtp/zrtp/ZrtpTest.m
@@ -83,11 +83,11 @@ bool pm(HandshakePacket* p1, HandshakePacket* p2) {
     
     // send authenticated data to signal end of handshake
     if (f2.hasResult) {
-        ZrtpHandshakeResult* result = [f2 forceGetResult];
+        ZrtpHandshakeResult* result = f2.forceGetResult;
         SrtpSocket* socket = [result secureRtpSocket];
         [socket startWithHandler:[PacketHandler packetHandler:^(id packet) { test(false); }
                                              withErrorHandler:^(id error, id relatedInfo, bool causedTermination) { test(!causedTermination); }]
-                  untilCancelled:[cc1 untilCancelledToken]];
+                  untilCancelled:cc1.untilCancelledToken];
         [socket secureAndSendRtpPacket:[RtpPacket rtpPacketWithDefaultsAndSequenceNumber:1 andPayload:[NSData data]]];
     }
     

--- a/Signal/test/network/tcp/LowLatencyConnectorTest.m
+++ b/Signal/test/network/tcp/LowLatencyConnectorTest.m
@@ -26,7 +26,7 @@
     
     testChurnUntil(!f.isIncomplete, 5.0);
     
-    LowLatencyCandidate* r = [f forceGetResult];
+    LowLatencyCandidate* r = f.forceGetResult;
     NetworkStream* channel = [r networkStream];
     
     // --- attempt to actually use the streams ---
@@ -57,7 +57,7 @@
     
     testChurnUntil(!f.isIncomplete, 5.0);
     
-    LowLatencyCandidate* r = [f forceGetResult];
+    LowLatencyCandidate* r = f.forceGetResult;
     NetworkStream* channel = [r networkStream];
     
     // --- attempt to actually use the streams ---

--- a/Signal/test/network/tcp/tls/NetworkStreamTest.m
+++ b/Signal/test/network/tcp/tls/NetworkStreamTest.m
@@ -93,7 +93,7 @@
     
     testChurnUntil(!f.isIncomplete, 5.0);
     
-    test(f.hasResult && [[f forceGetResult] isEqual:@YES]);
+    test(f.hasResult && [f.forceGetResult isEqual:@YES]);
     
     [s terminate];
 }

--- a/Signal/test/util/CryptoToolsTest.m
+++ b/Signal/test/util/CryptoToolsTest.m
@@ -50,14 +50,14 @@
     char* valText = "The quick brown fox jumps over the lazy dog";
     NSData* val = [NSMutableData dataWithBytes:valText length:strlen(valText)];
     NSData* expected = [@"d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592" decodedAsHexString];
-    NSData* actual = [val hashWithSha256];
+    NSData* actual = val.hashWithSha256;
     test([actual isEqualToData:expected]);
 }
 -(void) testRandomForVariance {
     NSData* d = [CryptoTools generateSecureRandomData:8];
     NSData* d2 = [CryptoTools generateSecureRandomData:8];
     
-    test(5 == [[CryptoTools generateSecureRandomData:5] length]);
+    test(5 == [CryptoTools generateSecureRandomData:5].length);
     test(8 == d.length);
     
     // extremely unlikely to fail if any reasonable amount of entropy is going into d and d2

--- a/Signal/test/util/FutureUtilTest.m
+++ b/Signal/test/util/FutureUtilTest.m
@@ -67,7 +67,7 @@
     test(repeat == 3 || repeat == 4);
     test(evalCount == 1);
     test(f.hasResult);
-    test([[f forceGetResult] isEqual:@YES]);
+    test([f.forceGetResult isEqual:@YES]);
 }
 -(void) testRetry_fail {
     __block NSUInteger repeat = 0;


### PR DESCRIPTION
The war on square brackets continues. A lot fewer chain reactions now, where I spot candidates as I fix candidates.

As usual, using regex replaces like `\[([^\[\]]*) (mutable[^ :\]]*)\]` to `$1.$2` (interestingly, `\1.\2` no longer works in the latest version of xcode) combined with manual checking.
