### PR TITLE
Fixing registration not letting simulator through

### DIFF
--- a/Signal/src/AppDelegate.m
+++ b/Signal/src/AppDelegate.m
@@ -79,14 +79,14 @@
     attrs = @{NSFileProtectionKey: NSFileProtectionCompleteUntilFirstUserAuthentication};
     [[NSFileManager defaultManager] setAttributes:attrs ofItemAtPath:logPath error:&error];
     
-    for (NSUInteger i = 0; i < logsFiles.count; i++) {
-        [pathsToExclude addObject:[logPath stringByAppendingString:logsFiles[i]]];
+    for (NSString* logsFile in logsFiles) {
+        [pathsToExclude addObject:[logPath stringByAppendingString:logsFile]];
     }
     
-    for (NSUInteger i = 0; i < pathsToExclude.count; i++) {
-        [[NSURL fileURLWithPath:pathsToExclude[i]] setResourceValue:@YES
-                                                             forKey:NSURLIsExcludedFromBackupKey
-                                                              error:&error];
+    for (NSString* pathToExclude in pathsToExclude) {
+        [[NSURL fileURLWithPath:pathToExclude] setResourceValue:@YES
+                                                         forKey:NSURLIsExcludedFromBackupKey
+                                                          error:&error];
     }
     
     if (error) {
@@ -175,15 +175,15 @@
 }
 
 - (void)application:(UIApplication*)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData*)deviceToken {
-    [[PushManager sharedManager].pushNotificationFutureSource trySetResult:deviceToken];
+    [PushManager.sharedManager.pushNotificationFutureSource trySetResult:deviceToken];
 }
 
 - (void)application:(UIApplication*)application didFailToRegisterForRemoteNotificationsWithError:(NSError*)error {
-    [[PushManager sharedManager].pushNotificationFutureSource trySetFailure:error];
+    [PushManager.sharedManager.pushNotificationFutureSource trySetFailure:error];
 }
 
 - (void)application:(UIApplication *)application didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings{
-    [[PushManager sharedManager].userNotificationFutureSource trySetResult:notificationSettings];
+    [PushManager.sharedManager.userNotificationFutureSource trySetResult:notificationSettings];
 }
 
 -(void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo {
@@ -223,7 +223,7 @@
     [self removeScreenProtection];
     
     if (Environment.isRegistered) {
-        [PushManager.sharedManager verifyPushPermissions];
+        [PushManager.sharedManager checkAndTryToFixNotificationPermissionsWithAlertsOnFailure];
         [AppAudioManager.sharedInstance requestRequiredPermissionsIfNeeded];
     }
 }

--- a/Signal/src/environment/VersionMigrations.m
+++ b/Signal/src/environment/VersionMigrations.m
@@ -18,7 +18,7 @@
     NSString* documentsDirectory = [NSHomeDirectory() stringByAppendingPathComponent:@"/Documents/"];
     NSString *path = [NSString stringWithFormat:@"%@/%@.plist", documentsDirectory, @"RedPhone-Data"];
     
-    if ([[NSFileManager defaultManager] fileExistsAtPath:path]) {
+    if ([NSFileManager.defaultManager fileExistsAtPath:path]) {
         NSData *plistData = [NSData dataWithContentsOfFile:path];
         
         NSError *error;
@@ -35,7 +35,7 @@
         
         [defaults synchronize];
         
-        [[NSFileManager defaultManager]removeItemAtPath:path error:&error];
+        [NSFileManager.defaultManager removeItemAtPath:path error:&error];
         
         if (error) {
             DDLogError(@"Error while migrating data: %@", error.description);
@@ -43,13 +43,11 @@
         
         // Some users push IDs were not correctly registered, by precaution, we are going to re-register all of them
         
-        [PushManager.sharedManager registrationWithSuccess:^{
-            
-        } failure:^{
+        [[PushManager.sharedManager asyncRegisterForPushAndUserNotificationsWithAlertsOnFailure] catchDo:^(id failure) {
             DDLogError(@"Error re-registering on migration from 1.0.2");
         }];
         
-        [[NSFileManager defaultManager] removeItemAtPath:path error:&error];
+        [NSFileManager.defaultManager removeItemAtPath:path error:&error];
         
         if (error) {
             DDLogError(@"Error upgrading from 1.0.2 : %@", error.description);

--- a/Signal/src/network/PushManager.h
+++ b/Signal/src/network/PushManager.h
@@ -26,16 +26,13 @@
  *  Therefore, we check on startup if mandatory permissions are granted.
  */
 
-- (void)verifyPushPermissions;
+- (void) checkAndTryToFixNotificationPermissionsWithAlertsOnFailure;
 
 /**
- *  Push notification registration method
- *
- *  @param success Block to execute after succesful push notification registration
- *  @param failure Block to executre if push notification registration fails
+ *  Push notification registration method.
  */
 
-- (void)registrationWithSuccess:(void (^)())success failure:(void (^)())failure;
+- (TOCFuture*) asyncRegisterForPushAndUserNotificationsWithAlertsOnFailure;
 
 /**
  *  The pushNotification and userNotificationFutureSource are accessed by the App Delegate after requested permissions.

--- a/Signal/src/network/http/CallServerRequestsManager.m
+++ b/Signal/src/network/http/CallServerRequestsManager.m
@@ -44,8 +44,9 @@ MacrosSingletonImplemention
     return self;
 }
 
-- (void)registerPushToken:(NSData*)deviceToken success:(void (^)(NSURLSessionDataTask *task, id responseObject))success
-failure:(void (^)(NSURLSessionDataTask *task, NSError *error))failure{
+- (void)registerPushToken:(NSData*)deviceToken
+                  success:(void (^)(NSURLSessionDataTask *task, id responseObject))success
+                  failure:(void (^)(NSURLSessionDataTask *task, NSError *error))failure{
     self.operationManager.requestSerializer = [self basicAuthenticationSerializer];
     
     [self.operationManager PUT:[NSString stringWithFormat:@"/apn/%@",deviceToken.encodedAsHexString] parameters:@{} success:success failure:failure];


### PR DESCRIPTION
When I still get false positives about push notification registration. Not sure if this is because I don't have the production certificate, or if it's because my phone doesn't have a number (I use my actual phone's number and get the code that way), or if it's a mistake. Please check that out before merging.
- Added push notification registration exception for simulator
- Modified PushManager methods to return futures
- Renamed methods to include details like "shows alerts"
- Fixed the register view not progressing past number verification when alert verification fails
- Moved ios-version checks inside utility methods instead of having multiple utility methods with lots of high-level paths choosing which one to call
