### PR TITLE
Update Building to note non-operational.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Signal allows you to make private phone calls and we are working on bringing sec
 
 ## Building
 
+While you can build Signal from this repo it will not be possible to use it without your code being signed using the Whisper Systems certificate (which is only available to core devs). The reason for this is that the (currently) required push notifications can only be sent to apps which have been signed by the key owned by the sender. There is currently no workaround. If you want to use rather than study Signal then please download from the App Store.
+
 1) Clone the repo to a working directory
 
 2) [CocoaPods](http://cocoapods.org) is used to manage dependencies. Pods are setup easily and are distributed via a ruby gem. Follow the simple instructions on the website to setup. After setup, run the following command from the toplevel directory of Signal-iOS to download the dependencies for Signal-iOS:


### PR DESCRIPTION
Currently if you build your own version of Signals from source it cannot be used as it can't receive the Push notification. This should be noted in the Readme.

Please note that this commit is not code and will not be included in the App Store distribution so I suspect CLA agreement is unnecessary but I grant permission for Whisper Systems to use and relicense the submitted text as they wish.
