### PR TITLE
bugfix, ordering compare; changes how those which have Lastname, firstna...

### DIFF
--- a/Signal/src/Storyboard/Storyboard.storyboard
+++ b/Signal/src/Storyboard/Storyboard.storyboard
@@ -145,7 +145,7 @@
                                     <rect key="frame" x="0.0" y="0.0" width="240" height="128"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="BC9AB2BC-7643-4107-A2B0-6B7CAC594992" translatesAutoresizingMaskIntoConstraints="NO" id="Yg7-KF-hVR">
+                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="7AF439CD-5821-4A34-8D88-66B469CF3326" translatesAutoresizingMaskIntoConstraints="NO" id="Yg7-KF-hVR">
                                             <rect key="frame" x="0.0" y="0.0" width="240" height="128"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="40" id="50e-Dx-c2x"/>
@@ -3310,7 +3310,7 @@ Licensed under the GPLv3</string>
         </scene>
     </scenes>
     <resources>
-        <image name="BC9AB2BC-7643-4107-A2B0-6B7CAC594992" width="100" height="100">
+        <image name="7AF439CD-5821-4A34-8D88-66B469CF3326" width="100" height="100">
             <mutableData key="keyedArchiveRepresentation">
 YnBsaXN0MDDUAQIDBAUGPj9YJHZlcnNpb25YJG9iamVjdHNZJGFyY2hpdmVyVCR0b3ASAAGGoK4HCBMU
 GR4fIyQsLzI4O1UkbnVsbNUJCgsMDQ4PEBESVk5TU2l6ZVYkY2xhc3NcTlNJbWFnZUZsYWdzVk5TUmVw

--- a/Signal/src/contact/ContactsManager.m
+++ b/Signal/src/contact/ContactsManager.m
@@ -398,7 +398,7 @@ void onAddressBookChanged(ABAddressBookRef notifyAddressBook, CFDictionaryRef in
         if (firstNameOrdering) {
             return [contact1.firstName compare:contact2.firstName];
         } else {
-            return [contact2.lastName compare:contact2.lastName];
+            return [contact1.lastName compare:contact2.lastName];
         }
     }];
 }


### PR DESCRIPTION
-bugfix in how sort is done for compose view re:
" Fix ordering in compose view of address book. Apparently if your setting is "Lastname, Firstname” ordering, it’s not adapting correctly"

we actually probably want to append the firstname to this search (and the last name to the search done if settings is Firstname, Lastname). this was the minimal change to get rid of a fundamental bug. 
