### PR TITLE
Added new settings menu for web browser selection.

### DIFF
--- a/Signal.xcodeproj/project.pbxproj
+++ b/Signal.xcodeproj/project.pbxproj
@@ -81,6 +81,12 @@
 		45F2B1971D9CA207000D2C69 /* OWSIncomingMessageCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45F2B1951D9CA207000D2C69 /* OWSIncomingMessageCollectionViewCell.xib */; };
 		45F2B1981D9CA207000D2C69 /* OWSOutgoingMessageCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45F2B1961D9CA207000D2C69 /* OWSOutgoingMessageCollectionViewCell.xib */; };
 		4CE0E3771B954546007210CF /* TSAnimatedAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 4CE0E3761B954546007210CF /* TSAnimatedAdapter.m */; };
+		6636D9001E2311FA00EF5F16 /* WebBrowser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6636D8FF1E2311FA00EF5F16 /* WebBrowser.swift */; };
+		6636D9031E2318F900EF5F16 /* OpenInThirdPartyBrowserControllerObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 6636D9021E2318F900EF5F16 /* OpenInThirdPartyBrowserControllerObjC.m */; };
+		6636D9051E234B0F00EF5F16 /* WebBrowsers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6636D9041E234B0F00EF5F16 /* WebBrowsers.swift */; };
+		663A13511E0C8567006FFFF8 /* MessageTextViewDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 663A13501E0C8567006FFFF8 /* MessageTextViewDelegate.m */; };
+		663A135B1E0CEDB7006FFFF8 /* OpenInChromeController.m in Sources */ = {isa = PBXBuildFile; fileRef = 663A135A1E0CEDB7006FFFF8 /* OpenInChromeController.m */; };
+		663A13631E0CFC72006FFFF8 /* OpenLinksWithTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 663A13621E0CFC72006FFFF8 /* OpenLinksWithTableViewController.swift */; };
 		701231B518ECAA4500D456C4 /* EvpMessageDigest.m in Sources */ = {isa = PBXBuildFile; fileRef = 701231B418ECAA4500D456C4 /* EvpMessageDigest.m */; };
 		70377AAB1918450100CAF501 /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 70377AAA1918450100CAF501 /* MobileCoreServices.framework */; };
 		7038632718F70C0700D4A43F /* CryptoTools.m in Sources */ = {isa = PBXBuildFile; fileRef = 7038632418F70C0700D4A43F /* CryptoTools.m */; };
@@ -644,6 +650,15 @@
 		45F2B1961D9CA207000D2C69 /* OWSOutgoingMessageCollectionViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = OWSOutgoingMessageCollectionViewCell.xib; sourceTree = "<group>"; };
 		4CE0E3751B95453C007210CF /* TSAnimatedAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TSAnimatedAdapter.h; sourceTree = "<group>"; };
 		4CE0E3761B954546007210CF /* TSAnimatedAdapter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TSAnimatedAdapter.m; sourceTree = "<group>"; };
+		6636D8FF1E2311FA00EF5F16 /* WebBrowser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebBrowser.swift; sourceTree = "<group>"; };
+		6636D9011E2318F900EF5F16 /* OpenInThirdPartyBrowserControllerObjC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OpenInThirdPartyBrowserControllerObjC.h; sourceTree = "<group>"; };
+		6636D9021E2318F900EF5F16 /* OpenInThirdPartyBrowserControllerObjC.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OpenInThirdPartyBrowserControllerObjC.m; sourceTree = "<group>"; };
+		6636D9041E234B0F00EF5F16 /* WebBrowsers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebBrowsers.swift; sourceTree = "<group>"; };
+		663A134F1E0C8567006FFFF8 /* MessageTextViewDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MessageTextViewDelegate.h; sourceTree = "<group>"; };
+		663A13501E0C8567006FFFF8 /* MessageTextViewDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MessageTextViewDelegate.m; sourceTree = "<group>"; };
+		663A13591E0CEDB7006FFFF8 /* OpenInChromeController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OpenInChromeController.h; sourceTree = "<group>"; };
+		663A135A1E0CEDB7006FFFF8 /* OpenInChromeController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OpenInChromeController.m; sourceTree = "<group>"; };
+		663A13621E0CFC72006FFFF8 /* OpenLinksWithTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenLinksWithTableViewController.swift; sourceTree = "<group>"; };
 		701231B318ECAA4500D456C4 /* EvpMessageDigest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EvpMessageDigest.h; sourceTree = "<group>"; };
 		701231B418ECAA4500D456C4 /* EvpMessageDigest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EvpMessageDigest.m; sourceTree = "<group>"; };
 		70377AAA1918450100CAF501 /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
@@ -1254,6 +1269,8 @@
 				45666EC81D994C0D008FE134 /* OWSGroupAvatarBuilder.m */,
 				45CD81EE1DC030E7004C9430 /* AccountManager.swift */,
 				45DF5DF11DDB843F00C936C7 /* CompareSafetyNumbersActivity.swift */,
+				6636D8FF1E2311FA00EF5F16 /* WebBrowser.swift */,
+				6636D9041E234B0F00EF5F16 /* WebBrowsers.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1885,6 +1902,8 @@
 				4531C9C31DD8E6D800F08304 /* JSQMessagesCollectionViewCell+OWS.m */,
 				45E1F3A21DEF1DF000852CF1 /* NoSignalContactsView.xib */,
 				45E1F3A41DEF20A100852CF1 /* NoSignalContactsView.swift */,
+				663A134F1E0C8567006FFFF8 /* MessageTextViewDelegate.h */,
+				663A13501E0C8567006FFFF8 /* MessageTextViewDelegate.m */,
 			);
 			name = Views;
 			path = views;
@@ -2417,6 +2436,7 @@
 				458E38331D66873D0094BD24 /* OWSLinkDeviceViewController.m */,
 				45EB32CD1D7465C900735B2E /* OWSLinkedDevicesTableViewController.h */,
 				45EB32CE1D7465C900735B2E /* OWSLinkedDevicesTableViewController.m */,
+				663A13621E0CFC72006FFFF8 /* OpenLinksWithTableViewController.swift */,
 			);
 			name = Settings;
 			sourceTree = "<group>";
@@ -2424,6 +2444,10 @@
 		FC3196321A08142D0094C78E /* Signals */ = {
 			isa = PBXGroup;
 			children = (
+				6636D9011E2318F900EF5F16 /* OpenInThirdPartyBrowserControllerObjC.h */,
+				6636D9021E2318F900EF5F16 /* OpenInThirdPartyBrowserControllerObjC.m */,
+				663A13591E0CEDB7006FFFF8 /* OpenInChromeController.h */,
+				663A135A1E0CEDB7006FFFF8 /* OpenInChromeController.m */,
 				FC3196281A067D8F0094C78E /* MessageComposeTableViewController.h */,
 				FC3196291A067D8F0094C78E /* MessageComposeTableViewController.m */,
 				FCAC963A19FEF9280046DFC5 /* SignalsViewController.h */,
@@ -2729,7 +2753,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		3465F381B1856CC06933B3A8 /* [CP] Copy Pods Resources */ = {
@@ -2804,7 +2828,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		B4E9B04E862FB64FC9A8F79B /* [CP] Embed Pods Frameworks */ = {
@@ -2904,6 +2928,7 @@
 				E197B61918BBEC1A00F073E5 /* RemoteIOBufferListWrapper.m in Sources */,
 				76EB05A618170B33006006FC /* RtpPacket.m in Sources */,
 				76EB064218170B33006006FC /* StringUtil.m in Sources */,
+				6636D9031E2318F900EF5F16 /* OpenInThirdPartyBrowserControllerObjC.m in Sources */,
 				45BFFFA81D898AF0004A12A7 /* OWSStaleNotificationObserver.m in Sources */,
 				45C681B71D305A580050903A /* OWSCall.m in Sources */,
 				76EB062618170B33006006FC /* Queue.m in Sources */,
@@ -2988,6 +3013,7 @@
 				E16E5BF018AAC40200B7C403 /* EvpKeyAgreement.m in Sources */,
 				FCFD25821A154B3800F4C644 /* CodeVerificationViewController.m in Sources */,
 				B65EDA1219E1BE6400AAA7CB /* RPAPICall.m in Sources */,
+				663A135B1E0CEDB7006FFFF8 /* OpenInChromeController.m in Sources */,
 				453D28B71D32BA5F00D523F0 /* OWSDisplayedMessage.m in Sources */,
 				76EB05DC18170B33006006FC /* StreamPair.m in Sources */,
 				76EB064618170B33006006FC /* TimeUtil.m in Sources */,
@@ -3031,11 +3057,14 @@
 				B63761E319E1F487005735D1 /* AFHTTPSessionManager+SignalMethods.m in Sources */,
 				76EB05CC18170B33006006FC /* ShortAuthenticationStringGenerator.m in Sources */,
 				E16E5BEF18AAC40200B7C403 /* EC25KeyAgreementProtocol.m in Sources */,
+				663A13511E0C8567006FFFF8 /* MessageTextViewDelegate.m in Sources */,
 				45C681BC1D305C080050903A /* OWSCallCollectionViewCell.m in Sources */,
+				663A13631E0CFC72006FFFF8 /* OpenLinksWithTableViewController.swift in Sources */,
 				76EB064018170B33006006FC /* AnonymousTerminator.m in Sources */,
 				76EB058818170B33006006FC /* PropertyListPreferences.m in Sources */,
 				76EB05B218170B33006006FC /* DH3KKeyAgreementProtocol.m in Sources */,
 				B63761EC19E1FBE8005735D1 /* HttpRequest.m in Sources */,
+				6636D9001E2311FA00EF5F16 /* WebBrowser.swift in Sources */,
 				45666F7B1D9C0533008FE134 /* OWSDatabaseMigration.m in Sources */,
 				76EB060818170B33006006FC /* ResponderSessionDescriptor.m in Sources */,
 				B90418E6183E9DD40038554A /* DateUtil.m in Sources */,
@@ -3048,6 +3077,7 @@
 				76EB064818170B33006006FC /* Zid.m in Sources */,
 				459311FC1D75C948008DD4F0 /* OWSDeviceTableViewCell.m in Sources */,
 				76EB05E218170B33006006FC /* SecureEndPoint.m in Sources */,
+				6636D9051E234B0F00EF5F16 /* WebBrowsers.swift in Sources */,
 				76EB05DE18170B33006006FC /* Certificate.m in Sources */,
 				76EB05B818170B33006006FC /* NegotiationFailed.m in Sources */,
 				76EB05D818170B33006006FC /* LowLatencyCandidate.m in Sources */,

--- a/Signal.xcodeproj/xcshareddata/xcschemes/Signal.xcscheme
+++ b/Signal.xcodeproj/xcshareddata/xcschemes/Signal.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -28,7 +28,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "A17C67DE5BCCF5991DAF479D127CE09E"
+               BlueprintIdentifier = "67EEE5C28C29FF38DA320F2E9F2B8666"
                BuildableName = "libSignalServiceKit.a"
                BlueprintName = "SignalServiceKit"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">

--- a/Signal/Signal-Info.plist
+++ b/Signal/Signal-Info.plist
@@ -47,6 +47,13 @@
 	<string>https://github.com/WhisperSystems/Signal-iOS/issues</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.social-networking</string>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>googlechrome</string>
+		<string>googlechromes</string>
+		<string>firefox</string>
+		<string>brave</string>
+	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/Signal/src/Models/WebBrowser.swift
+++ b/Signal/src/Models/WebBrowser.swift
@@ -1,0 +1,34 @@
+//
+//  WebBrowser.swift
+//  Signal
+//
+//  Created by Adam Kunicki on 1/8/17.
+//  Copyright © 2017 Open Whisper Systems. All rights reserved.
+//
+
+import Foundation
+
+@objc
+class WebBrowser : NSObject {
+    // class instead of struct so that it's accessible from objc code
+    let label: String
+    let scheme: String
+    let index: Int
+    
+    init(label: String, scheme: String, index: Int) {
+        self.label = label
+        self.scheme = scheme
+        self.index = index
+    }
+    
+    func isInstalled() -> Bool {
+        return schemeAvailable(scheme: scheme)
+    }
+    
+    private func schemeAvailable(scheme: String) -> Bool {
+        if let url = URL(string: scheme) {
+            return UIApplication.shared.canOpenURL(url)
+        }
+        return false
+    }
+}

--- a/Signal/src/Models/WebBrowsers.swift
+++ b/Signal/src/Models/WebBrowsers.swift
@@ -1,0 +1,44 @@
+//
+//  WebBrowsers.swift
+//  Signal
+//
+//  Created by Adam Kunicki on 1/8/17.
+//  Copyright © 2017 Open Whisper Systems. All rights reserved.
+//
+
+import Foundation
+
+let Safari = WebBrowser(label: "Safari", scheme: "http://", index: 0)
+let Chrome = WebBrowser(label: "Google Chrome", scheme: "googlechrome://", index: 1)
+let Firefox = WebBrowser(label: "Firefox", scheme: "firefox://", index: 2)
+let Brave = WebBrowser(label: "Brave", scheme: "brave://", index: 3)
+
+@objc
+class WebBrowsers : NSObject {
+    override private init() {}
+    
+    class func all() -> [WebBrowser] {
+        return [
+            Safari,
+            Chrome,
+            Firefox,
+            Brave
+        ]
+    }
+    
+    class func safari() -> WebBrowser {
+        return Safari
+    }
+    
+    class func chrome() -> WebBrowser {
+        return Chrome
+    }
+    
+    class func firefox() -> WebBrowser {
+        return Firefox
+    }
+    
+    class func brave() -> WebBrowser {
+        return Brave
+    }
+}

--- a/Signal/src/Storyboard/Main.storyboard
+++ b/Signal/src/Storyboard/Main.storyboard
@@ -1,11 +1,11 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11542" systemVersion="15G1108" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="tuk-0x-yCb">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="tuk-0x-yCb">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11524"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
@@ -174,10 +174,10 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lA7-b4-o6C" userLabel="QR Frame">
-                                        <rect key="frame" x="61" y="72" width="254" height="254"/>
+                                        <rect key="frame" x="60.5" y="72" width="254" height="254"/>
                                         <subviews>
                                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="btnQRShow--white" highlightedImage="btnQRShow--white-1" translatesAutoresizingMaskIntoConstraints="NO" id="YOs-e5-ee3" userLabel="Privacy Verification QR">
-                                                <rect key="frame" x="42" y="43" width="169" height="169"/>
+                                                <rect key="frame" x="42.5" y="43" width="169" height="169"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="YOs-e5-ee3" secondAttribute="height" multiplier="1:1" id="lN0-BE-w2c"/>
                                                 </constraints>
@@ -904,6 +904,48 @@
             </objects>
             <point key="canvasLocation" x="-3434" y="-1541"/>
         </scene>
+        <!--Open Links With-->
+        <scene sceneID="FQW-TQ-D1A">
+            <objects>
+                <tableViewController id="DLv-r9-TZL" userLabel="Open Links With" customClass="OpenLinksWithTableViewController" customModule="Signal" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="bna-fV-J9X" customClass="OpenLinksWithViewController">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <prototypes>
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="BrowserCell" textLabel="CUP-uX-BR4" style="IBUITableViewCellStyleDefault" id="Ggc-pK-T0r" userLabel="Safari">
+                                <rect key="frame" x="0.0" y="28" width="375" height="44"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Ggc-pK-T0r" id="JQA-jo-1AB">
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Safari" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="CUP-uX-BR4">
+                                            <rect key="frame" x="15" y="0.0" width="345" height="43"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="DLv-r9-TZL" id="cwX-hA-cEF"/>
+                            <outlet property="delegate" destination="DLv-r9-TZL" id="llt-35-QGA"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" title="Open Links With" id="IC1-nT-szZ"/>
+                    <connections>
+                        <segue destination="Akn-5e-MMD" kind="unwind" identifier="unwindFromOpenLinksWith" unwindAction="unwindFromOpenLinksWith:" id="tgD-9P-WLr"/>
+                    </connections>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="vTe-25-2x8" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <exit id="Akn-5e-MMD" userLabel="Exit" sceneMemberID="exit"/>
+            </objects>
+            <point key="canvasLocation" x="-2405" y="-3968"/>
+        </scene>
         <!--Linked Devices-->
         <scene sceneID="R59-ey-Ucx">
             <objects>
@@ -921,19 +963,19 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Signal on Chrome" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="57o-uV-YOg">
-                                            <rect key="frame" x="17" y="8" width="136" height="20"/>
+                                            <rect key="frame" x="17" y="8" width="136" height="19.5"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Linked: Jun 12, 2016" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uL2-wj-OZr">
-                                            <rect key="frame" x="17" y="28" width="124" height="18"/>
+                                            <rect key="frame" x="17" y="27.5" width="124" height="18"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Last Seen: Aug 25, 2016" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kek-MK-oLy">
-                                            <rect key="frame" x="17" y="46" width="148" height="17"/>
+                                            <rect key="frame" x="17" y="45.5" width="148" height="17.5"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
@@ -1072,7 +1114,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Network Status" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uNq-FV-lwt">
-                                                    <rect key="frame" x="15" y="-1" width="200" height="45"/>
+                                                    <rect key="frame" x="15" y="-0.5" width="200" height="44"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="44" id="nOw-0c-lAd"/>
                                                         <constraint firstAttribute="width" constant="200" id="q6L-Sa-lrA"/>
@@ -1082,7 +1124,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Connected" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsLetterSpacingToFitWidth="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tg3-dQ-odw">
-                                                    <rect key="frame" x="260" y="-1" width="100" height="45"/>
+                                                    <rect key="frame" x="260" y="-0.5" width="100" height="44"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="100" id="Lw2-Fv-sOC"/>
                                                         <constraint firstAttribute="height" constant="44" id="uvH-QZ-iUw"/>
@@ -1192,8 +1234,35 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="qeN-f1-cIQ" style="IBUITableViewCellStyleDefault" id="EI4-kQ-MMA" userLabel="About Cell">
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="g5i-e7-TlN" detailTextLabel="HYE-6O-lP4" style="IBUITableViewCellStyleValue1" id="u1w-fh-HAQ" userLabel="Open Links With Cell">
                                         <rect key="frame" x="0.0" y="360" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="u1w-fh-HAQ" id="pOr-UG-TR2">
+                                            <rect key="frame" x="0.0" y="0.0" width="342" height="43"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Open Links With" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="g5i-e7-TlN">
+                                                    <rect key="frame" x="15" y="11" width="126" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Safari" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="HYE-6O-lP4">
+                                                    <rect key="frame" x="296" y="11" width="44" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="DLv-r9-TZL" kind="push" identifier="pushOpenLinksWith" id="fbd-0E-EBg"/>
+                                        </connections>
+                                    </tableViewCell>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="qeN-f1-cIQ" style="IBUITableViewCellStyleDefault" id="EI4-kQ-MMA" userLabel="About Cell">
+                                        <rect key="frame" x="0.0" y="404" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="EI4-kQ-MMA" id="czg-5p-aVz">
                                             <rect key="frame" x="0.0" y="0.0" width="342" height="43"/>
@@ -1214,7 +1283,7 @@
                             <tableViewSection id="FdD-MV-PUQ">
                                 <cells>
                                     <tableViewCell autoresizesSubviews="NO" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="100" id="R82-FT-SEA" userLabel="Destroy Account Cell">
-                                        <rect key="frame" x="0.0" y="404" width="375" height="100"/>
+                                        <rect key="frame" x="0.0" y="448" width="375" height="100"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="R82-FT-SEA" id="Ok9-fE-WhB">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="99"/>
@@ -1270,6 +1339,8 @@
                         <outlet property="networkStatusHeader" destination="uNq-FV-lwt" id="vca-cC-nXG"/>
                         <outlet property="networkStatusLabel" destination="tg3-dQ-odw" id="l6J-8y-maW"/>
                         <outlet property="notificationsLabel" destination="tRQ-1p-6aT" id="sbi-Q3-Mge"/>
+                        <outlet property="openLinksWithDetail" destination="HYE-6O-lP4" id="GQU-yG-tCi"/>
+                        <outlet property="openLinksWithLabel" destination="g5i-e7-TlN" id="Tql-hA-qhk"/>
                         <outlet property="privacyLabel" destination="i1f-DT-7rL" id="vsz-Rp-jjQ"/>
                         <outlet property="registeredName" destination="3Pu-Cs-0K2" id="9av-hR-AZO"/>
                         <outlet property="registeredNumber" destination="ipE-BI-sLL" id="uQB-V6-ooY"/>
@@ -1293,28 +1364,28 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6B0-ZZ-d6K" userLabel="Instructions">
-                                <rect key="frame" x="16" y="344" width="343" height="279"/>
+                                <rect key="frame" x="16" y="343.5" width="343" height="279.5"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Oqf-fj-8Va" userLabel="Spacer">
-                                        <rect key="frame" x="0.0" y="0.0" width="343" height="64"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="343" height="64.5"/>
                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="16" id="Xq5-fV-fUr"/>
                                         </constraints>
                                     </view>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ic_devices_ios" translatesAutoresizingMaskIntoConstraints="NO" id="zl7-KG-ma4">
-                                        <rect key="frame" x="86" y="64" width="171" height="114"/>
+                                        <rect key="frame" x="86" y="64.5" width="171" height="114"/>
                                         <color key="tintColor" red="0.67450980392156867" green="0.67450980392156867" blue="0.67450980392156867" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="zl7-KG-ma4" secondAttribute="height" multiplier="3:2" id="RKt-hc-iWB"/>
                                         </constraints>
                                     </imageView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GMf-cM-kQN" userLabel="Spacer">
-                                        <rect key="frame" x="0.0" y="215" width="343" height="64"/>
+                                        <rect key="frame" x="0.0" y="215.5" width="343" height="64"/>
                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Scan the QR code displayed on the device to link." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="3D8-yn-TJ8">
-                                        <rect key="frame" x="0.0" y="194" width="343" height="21"/>
+                                        <rect key="frame" x="0.0" y="194.5" width="343" height="21"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
@@ -1340,7 +1411,7 @@
                                 </constraints>
                             </view>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eF5-us-VJe">
-                                <rect key="frame" x="0.0" y="64" width="375" height="280"/>
+                                <rect key="frame" x="0.0" y="64" width="375" height="279.5"/>
                                 <color key="backgroundColor" red="0.66666666666666663" green="0.66666666666666663" blue="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <connections>
                                     <segue destination="xDh-Mk-Yo9" kind="embed" identifier="embedDeviceQRScanner" id="mve-0t-D0g"/>
@@ -1623,7 +1694,7 @@
                         <viewControllerLayoutGuide type="bottom" id="s4y-gf-WU5"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="aYO-nF-lxB">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="280"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="279.5"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
@@ -1676,7 +1747,7 @@
         <simulatedScreenMetrics key="destination" type="retina4_7.fullscreen"/>
     </simulatedMetricsContainer>
     <inferredMetricsTieBreakers>
-        <segue reference="wgA-Oo-kKq"/>
+        <segue reference="tfr-ZV-qWs"/>
         <segue reference="E8S-Yc-X7E"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/Signal/src/environment/PropertyListPreferences.h
+++ b/Signal/src/environment/PropertyListPreferences.h
@@ -53,6 +53,9 @@ typedef NS_ENUM(NSUInteger, TSImageQuality) {
 - (nullable NSString *)lastRanVersion;
 - (NSString *)setAndGetCurrentVersion;
 
+- (NSUInteger)getOpenLinksWith;
+- (void)setOpenLinksWith:(NSNumber *)browser;
+
 #pragma mark - Block on Identity Change
 
 - (BOOL)shouldBlockOnIdentityChange;

--- a/Signal/src/environment/PropertyListPreferences.m
+++ b/Signal/src/environment/PropertyListPreferences.m
@@ -19,6 +19,7 @@ NSString *const PropertyListPreferencesKeyPlaySoundInForeground = @"Notification
 NSString *const PropertyListPreferencesKeyHasRegisteredVoipPush = @"VOIPPushEnabled";
 NSString *const PropertyListPreferencesKeyLastRecordedPushToken = @"LastRecordedPushToken";
 NSString *const PropertyListPreferencesKeyLastRecordedVoipToken = @"LastRecordedVoipToken";
+NSString *const PropertyListPreferencesKeyOpenLinksWith = @"OpenLinksWith";
 
 @implementation PropertyListPreferences
 
@@ -158,6 +159,22 @@ NSString *const PropertyListPreferencesKeyLastRecordedVoipToken = @"LastRecorded
                                             forKey:PropertyListPreferencesKeyLastRunSignalVersion];
     [NSUserDefaults.standardUserDefaults synchronize];
     return currentVersion;
+}
+
+- (void)setOpenLinksWith:(NSNumber *)browser
+{
+    [self setValueForKey:PropertyListPreferencesKeyOpenLinksWith toValue:browser];
+}
+
+- (NSUInteger)getOpenLinksWith
+{
+    NSNumber *preference = [self tryGetValueForKey:PropertyListPreferencesKeyOpenLinksWith];
+    if (preference) {
+        return [preference unsignedIntegerValue];
+    } else {
+        [self setValueForKey:PropertyListPreferencesKeyOpenLinksWith toValue:[NSNumber numberWithInteger:0]];
+        return 0;
+    }
 }
 
 #pragma mark Notification Preferences

--- a/Signal/src/view controllers/OpenInChromeController.h
+++ b/Signal/src/view controllers/OpenInChromeController.h
@@ -1,0 +1,65 @@
+// Copyright 2012, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#import <Foundation/Foundation.h>
+
+// Values for the open in chrome user preference.
+typedef enum {
+  kOpenInChromeNone,       // The value is not set.
+  kOpenInChromeAsk,        // Ask which browser to use every time.
+  kOpenInChromeAlways,     // Always use Chrome to open links.
+} OpenInChromePreference;
+
+// This class is used to check if Google Chrome is installed in the system and
+// to open a URL in Google Chrome either with or without a callback URL.
+@interface OpenInChromeController : NSObject
+
+// Returns a shared instance of the OpenInChromeController.
++ (OpenInChromeController *)sharedInstance;
+
+// Returns YES if Google Chrome is installed in the user's system.
+- (BOOL)isChromeInstalled;
+
+// Opens a URL in Google Chrome.
+- (BOOL)openInChrome:(NSURL *)url;
+
+// Open a URL in Google Chrome providing a |callbackURL| to return to the app.
+// URLs from the same app will be opened in the same tab unless |createNewTab|
+// is set to YES.
+// |callbackURL| can be nil.
+// The return value of this method is YES if the URL is successfully opened.
+- (BOOL)openInChrome:(NSURL *)url
+     withCallbackURL:(NSURL *)callbackURL
+        createNewTab:(BOOL)createNewTab;
+
+// Returns the user preference regarding whether or not to always open links
+// in Google Chrome.
+- (OpenInChromePreference)openInChromePreference;
+
+@end

--- a/Signal/src/view controllers/OpenInChromeController.m
+++ b/Signal/src/view controllers/OpenInChromeController.m
@@ -1,0 +1,192 @@
+#if !defined(__has_feature) || !__has_feature(objc_arc)
+#error "This file requires ARC support."
+#endif
+
+// Copyright 2012, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#import <UIKit/UIKit.h>
+
+#import "OpenInChromeController.h"
+
+static NSString * const kGoogleChromeHTTPScheme = @"googlechrome:";
+static NSString * const kGoogleChromeHTTPSScheme = @"googlechromes:";
+static NSString * const kGoogleChromeCallbackScheme =
+    @"googlechrome-x-callback:";
+
+// Name of the shared UIPasteboard used to store the Chrome preferences.
+static NSString * const kChromePasteboardName =
+    @"com.google.preferences.chrome";
+
+// Key of the OpenInChrome preference.
+static NSString * const kOpenInChromePreferenceKey =
+    @"com.google.preferences.chrome.openinchrome";
+
+// Name of the shared UIPasteboard representation type.
+static NSString * const kPasteboardType = @"com.google.data";
+
+// Key for the Data content of the pasteboard.
+static NSString * const kDataDictionaryKey = @"Data";
+
+// String for the version key in the main dictionary.
+static NSString * const kVersionKey = @"Version-1";
+
+static NSString * encodeByAddingPercentEscapes(NSString *input) {
+  NSString *encodedValue =
+      (NSString *)CFBridgingRelease(CFURLCreateStringByAddingPercentEscapes(
+          kCFAllocatorDefault,
+          (CFStringRef)input,
+          NULL,
+          (CFStringRef)@"!*'();:@&=+$,/?%#[]",
+          kCFStringEncodingUTF8));
+  return encodedValue;
+}
+
+@implementation OpenInChromeController
+
++ (OpenInChromeController *)sharedInstance {
+  static OpenInChromeController *sharedInstance;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    sharedInstance = [[self alloc] init];
+  });
+  return sharedInstance;
+}
+
+- (BOOL)isChromeInstalled {
+  NSURL *simpleURL = [NSURL URLWithString:kGoogleChromeHTTPScheme];
+  NSURL *callbackURL = [NSURL URLWithString:kGoogleChromeCallbackScheme];
+  return  [[UIApplication sharedApplication] canOpenURL:simpleURL] ||
+      [[UIApplication sharedApplication] canOpenURL:callbackURL];
+}
+
+- (BOOL)openInChrome:(NSURL *)url {
+  return [self openInChrome:url withCallbackURL:nil createNewTab:NO];
+}
+
+- (BOOL)openInChrome:(NSURL *)url
+     withCallbackURL:(NSURL *)callbackURL
+        createNewTab:(BOOL)createNewTab {
+  NSURL *chromeSimpleURL = [NSURL URLWithString:kGoogleChromeHTTPScheme];
+  NSURL *chromeCallbackURL = [NSURL URLWithString:kGoogleChromeCallbackScheme];
+  if ([[UIApplication sharedApplication] canOpenURL:chromeCallbackURL]) {
+    NSString *appName =
+        [[NSBundle mainBundle]
+            objectForInfoDictionaryKey:@"CFBundleDisplayName"];
+
+    NSString *scheme = [url.scheme lowercaseString];
+
+    // Proceed only if scheme is http or https.
+    if ([scheme isEqualToString:@"http"] ||
+        [scheme isEqualToString:@"https"]) {
+
+      NSMutableString *chromeURLString = [NSMutableString string];
+      [chromeURLString appendFormat:
+          @"%@//x-callback-url/open/?x-source=%@&url=%@",
+          kGoogleChromeCallbackScheme,
+          encodeByAddingPercentEscapes(appName),
+          encodeByAddingPercentEscapes([url absoluteString])];
+      if (callbackURL) {
+        [chromeURLString appendFormat:@"&x-success=%@",
+            encodeByAddingPercentEscapes([callbackURL absoluteString])];
+      }
+      if (createNewTab) {
+        [chromeURLString appendString:@"&create-new-tab"];
+      }
+
+      NSURL *chromeURL = [NSURL URLWithString:chromeURLString];
+
+      // Open the URL with Google Chrome.
+      return [[UIApplication sharedApplication] openURL:chromeURL];
+    }
+  } else if ([[UIApplication sharedApplication] canOpenURL:chromeSimpleURL]) {
+    NSString *scheme = [url.scheme lowercaseString];
+
+    // Replace the URL Scheme with the Chrome equivalent.
+    NSString *chromeScheme = nil;
+    if ([scheme isEqualToString:@"http"]) {
+      chromeScheme = kGoogleChromeHTTPScheme;
+    } else if ([scheme isEqualToString:@"https"]) {
+      chromeScheme = kGoogleChromeHTTPSScheme;
+    }
+
+    // Proceed only if a valid Google Chrome URI Scheme is available.
+    if (chromeScheme) {
+      NSString *absoluteString = [url absoluteString];
+      NSRange rangeForScheme = [absoluteString rangeOfString:@":"];
+      NSString *urlNoScheme =
+          [absoluteString substringFromIndex:rangeForScheme.location + 1];
+      NSString *chromeURLString =
+          [chromeScheme stringByAppendingString:urlNoScheme];
+      NSURL *chromeURL = [NSURL URLWithString:chromeURLString];
+
+      // Open the URL with Google Chrome.
+      return [[UIApplication sharedApplication] openURL:chromeURL];
+    }
+  }
+  return NO;
+}
+
+- (OpenInChromePreference)openInChromePreference {
+  NSDictionary *pasteboardContent = [self pasteboardContent];
+  NSDictionary *pasteboardData =
+      [pasteboardContent objectForKey:kDataDictionaryKey];
+  NSDictionary *userPreferences =
+      [pasteboardData objectForKey:kVersionKey];
+  NSNumber *value =
+      [userPreferences objectForKey:kOpenInChromePreferenceKey];
+  return value ? (OpenInChromePreference)[value integerValue]
+               : kOpenInChromeNone;
+}
+
+#pragma mark - Private methods
+
+- (NSDictionary *)pasteboardContent {
+  UIPasteboard *pasteboard =
+      [UIPasteboard pasteboardWithName:kChromePasteboardName
+                                create:NO];
+
+  NSData *data = [pasteboard dataForPasteboardType:kPasteboardType];
+  id pasteboardContent = nil;
+  if (data) {
+    pasteboardContent =
+        [NSPropertyListSerialization propertyListWithData:data
+                                                  options:0
+                                                   format:nil
+                                                    error:nil];
+  }
+  if ([pasteboardContent isKindOfClass:[NSDictionary class]]) {
+    return (NSDictionary *)pasteboardContent;
+  }
+
+  return nil;
+}
+
+
+@end

--- a/Signal/src/view controllers/OpenInThirdPartyBrowserControllerObjC.h
+++ b/Signal/src/view controllers/OpenInThirdPartyBrowserControllerObjC.h
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#import <Foundation/Foundation.h>
+
+typedef enum {
+    ThirdPartyBrowserBrave,
+    ThirdPartyBrowserFirefox
+} ThirdPartyBrowser;
+
+// This class is used to check if Firefox is installed in the system and
+// to open a URL in Firefox either with or without a callback URL.
+@interface OpenInThirdPartyBrowserControllerObjC : NSObject 
+
+-(instancetype)initWithBrowser:(ThirdPartyBrowser)browser NS_DESIGNATED_INITIALIZER;
+
+// Returns YES if Firefox is installed in the user's system.
+- (BOOL)isInstalled;
+
+// Opens a URL in Firefox.
+- (BOOL)openInBrowser:(NSURL *)url;
+
+@end

--- a/Signal/src/view controllers/OpenInThirdPartyBrowserControllerObjC.m
+++ b/Signal/src/view controllers/OpenInThirdPartyBrowserControllerObjC.m
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#import <UIKit/UIKit.h>
+#import "OpenInThirdPartyBrowserControllerObjC.h"
+
+static NSString *const firefoxScheme = @"firefox:";
+
+@interface OpenInThirdPartyBrowserControllerObjC()
+@property NSString *scheme;
+@end
+
+@implementation OpenInThirdPartyBrowserControllerObjC
+
+// Custom function that does complete percent escape for constructing the URL.
+static NSString *encodeByAddingPercentEscapes(NSString *string) {
+    NSString *encodedString = (NSString *)CFBridgingRelease(CFURLCreateStringByAddingPercentEscapes(
+    kCFAllocatorDefault,
+    (CFStringRef)string,
+    NULL,
+    (CFStringRef)@"!*'();:@&=+$,/?%#[]",
+    kCFStringEncodingUTF8));
+    return encodedString;
+}
+
+-(instancetype)initWithBrowser:(ThirdPartyBrowser)browser
+{
+    if (self = [super init]) {
+        switch (browser) {
+            case ThirdPartyBrowserBrave:
+                self.scheme = @"brave://";
+                break;
+            case ThirdPartyBrowserFirefox:
+                self.scheme = @"firefox://";
+                break;
+        }
+    }
+    return self;
+}
+
+- (BOOL)isInstalled {
+    NSURL *url = [NSURL URLWithString:self.scheme];
+    return [[UIApplication sharedApplication] canOpenURL:url];
+}
+
+- (BOOL)openInBrowser:(NSURL *)url {
+    if (![self isInstalled]) {
+        return NO;
+    }
+
+    NSString *scheme = [url.scheme lowercaseString];
+    if (![scheme isEqualToString:@"http"] && ![scheme isEqualToString:@"https"]) {
+        return NO;
+    }
+
+    NSString *urlString = [NSString stringWithFormat:@"%@open-url?url=%@",
+                           self.scheme,
+                           encodeByAddingPercentEscapes([url absoluteString])];
+
+    // Open the URL with Firefox.
+    return [UIApplication.sharedApplication openURL:[NSURL URLWithString: urlString]];
+}
+
+@end

--- a/Signal/src/view controllers/OpenLinksWithTableViewController.swift
+++ b/Signal/src/view controllers/OpenLinksWithTableViewController.swift
@@ -1,0 +1,97 @@
+//
+//  OpenLinksWithTableViewController.swift
+//  Signal
+//
+//  Created by Adam Kunicki on 12/22/16.
+//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+//
+
+import UIKit
+
+@objc
+class OpenLinksWithTableViewController: UITableViewController {
+    private let browsers = WebBrowsers.all()
+    private var selectedBrowser: WebBrowser = WebBrowsers.safari()
+    
+    override func viewDidLoad() {
+        selectedBrowser = getSelectedBrowserFromPreferences()
+        
+        let selectedIndexPath = IndexPath(row: selectedBrowser.index, section: 0)
+        tableView.selectRow(at: selectedIndexPath, animated: false, scrollPosition: .none)
+
+    }
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return 1
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return browsers.count
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "BrowserCell", for: indexPath)
+
+        cell.textLabel?.text = browsers[indexPath.row].label
+        cell.selectionStyle = .none
+        
+        if !(selectedBrowser.isInstalled() ?? false) {
+            tableView.deselectRow(at: indexPath, animated: false)
+            revertToSafari()
+        }
+        
+        if (selectedBrowser.index == indexPath.row) {
+            cell.accessoryType = .checkmark
+        } else {
+            cell.accessoryType = .none
+
+        }
+
+        return cell
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        selectedBrowser = browsers[indexPath.row]
+        Environment.preferences().setOpenLinksWith(selectedBrowser.index as NSNumber)
+        
+        let selectedCell = tableView.cellForRow(at: indexPath)
+        selectedCell?.accessoryType = .checkmark
+        
+        performSegue(withIdentifier: "unwindFromOpenLinksWith", sender: self)
+    }
+    
+    override func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
+        let deselectedCell = tableView.cellForRow(at: indexPath)
+        deselectedCell?.accessoryType = .none
+    }
+    
+    override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        // hide browser cell if not installed
+        let browserForCell = browsers[indexPath.row]
+        if (browserForCell.isInstalled()) {
+            return super.tableView(tableView, heightForRowAt: indexPath)
+        }
+        
+        return 0.0
+    }
+    
+    private func revertToSafari() {
+        selectedBrowser = WebBrowsers.safari()
+        tableView.selectRow(at: IndexPath(row: 0, section: 0), animated: false, scrollPosition: .none)
+    }
+    
+    private func getSelectedBrowserFromPreferences() -> WebBrowser {
+        let selectedBrowserIndex = Int(Environment.preferences().getOpenLinksWith())
+        return browsers[selectedBrowserIndex]
+    }
+    
+    // MARK: public methods
+    
+    func getSelectedBrowser() -> WebBrowser {
+        // Check if browser is still valid
+        if (!selectedBrowser.isInstalled()) {
+            revertToSafari()
+        }
+        return selectedBrowser
+    }
+}

--- a/Signal/src/view controllers/SettingsTableViewController.h
+++ b/Signal/src/view controllers/SettingsTableViewController.h
@@ -18,6 +18,8 @@
 @property (strong, nonatomic) IBOutlet UILabel *notificationsLabel;
 @property (strong, nonatomic) IBOutlet UILabel *linkedDevicesLabel;
 @property (strong, nonatomic) IBOutlet UILabel *advancedLabel;
+@property (strong, nonatomic) IBOutlet UILabel *openLinksWithLabel;
+@property (strong, nonatomic) IBOutlet UILabel *openLinksWithDetail;
 @property (strong, nonatomic) IBOutlet UILabel *aboutLabel;
 @property (strong, nonatomic) IBOutlet UILabel *inviteLabel;
 @property (strong, nonatomic) IBOutlet UIButton *destroyAccountButton;

--- a/Signal/src/view controllers/SettingsTableViewController.m
+++ b/Signal/src/view controllers/SettingsTableViewController.m
@@ -36,14 +36,15 @@
 #define kNotificationRow 2
 #define kLinkedDevices 3 // we don't actually use this, instead we segue via Interface Builder
 #define kAdvancedRow 4
-#define kAboutRow 5
+#define kOpenLinksWith 5 // we don't actually use this, instead we segue via Interface Builder
+#define kAboutRow 6
 
 #define kNetworkRow 0
 #define kUnregisterRow 0
 
 typedef enum {
     kRegisteredRows = 1,
-    kGeneralRows = 6,
+    kGeneralRows = 7,
     kNetworkStatusRows = 1,
     kUnregisterRows = 1,
 } kRowsForSection;
@@ -106,6 +107,12 @@ typedef enum {
     self.networkStatusHeader.text = NSLocalizedString(@"NETWORK_STATUS_HEADER", @"");
     self.privacyLabel.text = NSLocalizedString(@"SETTINGS_PRIVACY_TITLE", @"");
     self.advancedLabel.text = NSLocalizedString(@"SETTINGS_ADVANCED_TITLE", @"");
+    self.openLinksWithLabel.text = NSLocalizedString(@"SETTINGS_OPEN_LINKS_WITH", @"");
+    
+    WebBrowser *selectedBrowser = [[WebBrowsers all] objectAtIndex:[Environment.preferences getOpenLinksWith]];
+    self.openLinksWithDetail.text = [selectedBrowser isInstalled] ? selectedBrowser.label :
+        [WebBrowsers safari].label;
+    
     self.aboutLabel.text = NSLocalizedString(@"SETTINGS_ABOUT", @"");
     self.notificationsLabel.text = NSLocalizedString(@"SETTINGS_NOTIFICATIONS", nil);
     self.linkedDevicesLabel.text
@@ -268,6 +275,15 @@ typedef enum {
                                              cancelButtonTitle:NSLocalizedString(@"OK", @"")
                                              otherButtonTitles:nil];
         [info show];
+    }
+}
+
+- (IBAction)unwindFromOpenLinksWith:(UIStoryboardSegue *)segue
+{
+    if ([segue.identifier isEqualToString:@"unwindFromOpenLinksWith"]) {
+        OpenLinksWithTableViewController *controller =
+            (OpenLinksWithTableViewController *) segue.sourceViewController;
+        self.openLinksWithDetail.text = [controller getSelectedBrowser].label;
     }
 }
 

--- a/Signal/src/views/MessageTextViewDelegate.h
+++ b/Signal/src/views/MessageTextViewDelegate.h
@@ -1,0 +1,28 @@
+//
+//  OWSMessageTextViewDelegate.h
+//  Signal
+//
+//  Created by Adam Kunicki on 12/22/16.
+//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import "../view controllers/OpenInChromeController.h"
+#import "../view controllers/OpenInThirdPartyBrowserControllerObjC.h"
+
+@interface MessageTextViewDelegate : UIViewController <UITextViewDelegate>
+
+@property (nonatomic, strong) OpenInThirdPartyBrowserControllerObjC *openInFirefox;
+@property (nonatomic, strong) OpenInThirdPartyBrowserControllerObjC *openInBrave;
+
+// Deprecated in iOS 10
+- (BOOL)textView:(UITextView *)textView
+    shouldInteractWithURL:(NSURL *)URL
+    inRange:(NSRange)characterRange;
+
+- (BOOL)textView:(UITextView *)textView
+    shouldInteractWithURL:(NSURL *)URL
+    inRange:(NSRange)characterRange
+    interaction:(UITextItemInteraction)interaction;
+
+@end

--- a/Signal/src/views/MessageTextViewDelegate.m
+++ b/Signal/src/views/MessageTextViewDelegate.m
@@ -1,0 +1,61 @@
+//
+//  OWSMessageTextViewDelegate.m
+//  Signal
+//
+//  Created by Adam Kunicki on 12/22/16.
+//  Copyright © 2016 Open Whisper Systems. All rights reserved.
+//
+
+#import "Environment.h"
+#import "MessageTextViewDelegate.h"
+
+#define kIndexSafari 0
+#define kIndexGoogleChrome 1
+#define kIndexFirefox 2
+#define kIndexBrave 3
+
+@implementation MessageTextViewDelegate
+
+- (BOOL)textView:(UITextView *)textView shouldInteractWithURL:(NSURL *)URL inRange:(NSRange)characterRange
+{
+    NSUInteger selectedBrowser = [Environment.preferences getOpenLinksWith];
+    
+    OpenInChromeController *openInChrome = [OpenInChromeController sharedInstance];
+    if (self.openInFirefox == nil) {
+        self.openInFirefox = [[OpenInThirdPartyBrowserControllerObjC alloc] initWithBrowser:ThirdPartyBrowserFirefox];
+    }
+    
+    if (self.openInBrave == nil) {
+        self.openInBrave = [[OpenInThirdPartyBrowserControllerObjC alloc] initWithBrowser:ThirdPartyBrowserBrave];
+    }
+    
+    switch (selectedBrowser) {
+        case kIndexGoogleChrome:
+            if ([openInChrome isChromeInstalled]) {
+                [openInChrome openInChrome:URL];
+            }
+            break;
+        case kIndexFirefox:
+            if ([self.openInFirefox isInstalled]) {
+                [self.openInFirefox openInBrowser:URL];
+            }
+            break;
+        case kIndexBrave:
+            if ([self.openInBrave isInstalled]) {
+                [self.openInBrave openInBrowser:URL];
+            }
+            break;
+        case kIndexSafari:
+        default:
+            break;
+    }
+    
+    return YES;
+}
+
+- (BOOL)textView:(UITextView *)textView shouldInteractWithURL:(NSURL *)URL inRange:(NSRange)characterRange interaction:(UITextItemInteraction)interaction
+{
+    return [self textView:textView shouldInteractWithURL:URL inRange:characterRange];
+}
+
+@end

--- a/Signal/src/views/OWSOutgoingMessageCollectionViewCell.h
+++ b/Signal/src/views/OWSOutgoingMessageCollectionViewCell.h
@@ -3,11 +3,14 @@
 
 #import "JSQMessagesCollectionViewCell+OWS.h"
 #import "OWSExpirableMessageView.h"
+#import "MessageTextViewDelegate.h"
 #import <JSQMessagesViewController/JSQMessagesCollectionViewCellOutgoing.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface OWSOutgoingMessageCollectionViewCell : JSQMessagesCollectionViewCellOutgoing <OWSExpirableMessageView>
+
+@property (nonatomic, strong) MessageTextViewDelegate *textViewDelegate;
 
 @end
 

--- a/Signal/src/views/OWSOutgoingMessageCollectionViewCell.m
+++ b/Signal/src/views/OWSOutgoingMessageCollectionViewCell.m
@@ -19,6 +19,8 @@ NS_ASSUME_NONNULL_BEGIN
 {
     [super awakeFromNib];
     self.expirationTimerViewWidthConstraint.constant = 0.0;
+    self.textViewDelegate = [[MessageTextViewDelegate alloc] init];
+    self.textView.delegate = self.textViewDelegate;
 }
 
 - (void)prepareForReuse

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -721,6 +721,9 @@
 /* No comment provided by engineer. */
 "SETTINGS_ADVANCED_TITLE" = "Advanced";
 
+/* Settings for selecting web browser to use for opening links */
+"SETTINGS_OPEN_LINKS_WITH" = "Open Links With";
+
 /* User settings section footer, a detailed explanation */
 "SETTINGS_BLOCK_ON_IDENITY_CHANGE_DETAIL" = "Requires your approval before communicating with someone who has a new safety number, commonly from a reinstall of Signal.";
 


### PR DESCRIPTION
### Contributor checklist
- [X] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [X] My commits are rebased on the latest master branch
- [X] My commits are in nice logical chunks
- [X] My contribution is fully baked and is ready to be merged as is
- [X] I have tested my contribution on these devices:
 * iPhone 7, iOS 10.2
 * Simulator, iOS 8.4 (cannot install third party browsers, so only choice is Safari)
- [X] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

- - - - - - - - - -

### Description
Adds a new Open Links With settings menu which allows the user to choose from the following browsers to open links in messages with:
* Safari
* Google Chrome
* Firefox
* Brave

Resolves #1514 

Tested by installing all 4 supported browsers and verifying links are opened in them. Uninstalling the selected browser will default back to Safari automatically. It is simple enough to add additional browsers to this patch if there are any additional requests.

Note: There are a couple of MPL 2.0 licensed files (unmodified) that should be compatible with the GPLv3 license of Signal, but please let me know if this is an issue.