### PR TITLE
Fix image insets to preserve aspect ratio. #1663

### DIFF
--- a/Signal/src/view controllers/MessageComposeTableViewController.m
+++ b/Signal/src/view controllers/MessageComposeTableViewController.m
@@ -267,7 +267,7 @@ NSString *const MessageComposeTableViewControllerCellContact = @"ContactTableVie
                                              style:UIBarButtonItemStylePlain
                                             target:self
                                             action:@selector(refreshContacts)];
-        self.navigationItem.rightBarButtonItem.imageInsets = UIEdgeInsetsMake(8, 8, 8, 8);
+        self.navigationItem.rightBarButtonItem.imageInsets = UIEdgeInsetsMake(8, 6.5, 8, 6.5);
 
 
         self.inviteCell.hidden = YES;


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone Simulator
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

- - - - - - - - - -

### Description
Fixes an alignment issue on a button -- here are the before and after shots:
![before](https://cloud.githubusercontent.com/assets/114075/22448588/494c0bf8-e70f-11e6-9f19-28e4f7b7f1b6.png)
![after](https://cloud.githubusercontent.com/assets/114075/22448594/55e06fd0-e70f-11e6-8316-cd238a091b66.png)
