### PR TITLE
Add avatar bubbles to group conversations FREEBIE

### DIFF
--- a/Signal/src/view controllers/MessagesViewController.m
+++ b/Signal/src/view controllers/MessagesViewController.m
@@ -12,6 +12,7 @@
 #import "NewGroupViewController.h"
 #import "OWSCall.h"
 #import "OWSCallCollectionViewCell.h"
+#import "OWSContactAvatarBuilder.h"
 #import "OWSContactsManager.h"
 #import "OWSConversationSettingsTableViewController.h"
 #import "OWSDisappearingMessagesJob.h"
@@ -39,12 +40,15 @@
 #import "UIViewController+CameraPermissions.h"
 #import <AddressBookUI/AddressBookUI.h>
 #import <ContactsUI/CNContactViewController.h>
+#import <JSQMessagesViewController/JSQMessagesAvatarImage.h>
+#import <JSQMessagesViewController/JSQMessagesAvatarImageFactory.h>
 #import <JSQMessagesViewController/JSQMessagesBubbleImage.h>
 #import <JSQMessagesViewController/JSQMessagesBubbleImageFactory.h>
 #import <JSQMessagesViewController/JSQMessagesCollectionViewFlowLayoutInvalidationContext.h>
 #import <JSQMessagesViewController/JSQMessagesTimestampFormatter.h>
 #import <JSQMessagesViewController/JSQSystemSoundPlayer+JSQMessages.h>
 #import <JSQMessagesViewController/UIColor+JSQMessages.h>
+
 #import <JSQSystemSoundPlayer.h>
 #import <MobileCoreServices/UTCoreTypes.h>
 #import <SignalServiceKit/ContactsUpdater.h>
@@ -128,6 +132,7 @@ typedef enum : NSUInteger {
 @property (nonatomic, readonly) OutboundCallInitiator *outboundCallInitiator;
 
 @property NSCache *messageAdapterCache;
+@property NSCache *avatarImageCache;
 
 @end
 
@@ -233,6 +238,14 @@ typedef enum : NSUInteger {
     [super viewDidLoad];
 
     [self.navigationController.navigationBar setTranslucent:NO];
+
+    [self.contactsManager
+     .getObservableContacts watchLatestValue:^(id latestValue) {
+            [self.avatarImageCache removeAllObjects];
+            [self.collectionView reloadData];
+        }
+                            onThread:[NSThread mainThread]
+                            untilCancelled:nil];
 
     self.messageAdapterCache = [[NSCache alloc] init];
 
@@ -592,7 +605,9 @@ typedef enum : NSUInteger {
 
     [self updateLoadEarlierVisible];
 
-    self.collectionView.collectionViewLayout.incomingAvatarViewSize = CGSizeZero;
+    if (!isGroupConversation) {
+        self.collectionView.collectionViewLayout.incomingAvatarViewSize = CGSizeZero;
+    }
     self.collectionView.collectionViewLayout.outgoingAvatarViewSize = CGSizeZero;
 
     if ([UIDevice currentDevice].userInterfaceIdiom != UIUserInterfaceIdiomPad) {
@@ -750,7 +765,26 @@ typedef enum : NSUInteger {
 
 - (id<JSQMessageAvatarImageDataSource>)collectionView:(JSQMessagesCollectionView *)collectionView
                     avatarImageDataForItemAtIndexPath:(NSIndexPath *)indexPath {
-    return nil;
+    if (!isGroupConversation) {
+        return nil;
+    }
+    id<OWSMessageData> message = [self messageAtIndexPath:indexPath];
+
+    NSString* senderId = [message senderId];
+    JSQMessagesAvatarImage* jsqImage = [self.avatarImageCache objectForKey:senderId];
+    if (jsqImage != nil) {
+        return jsqImage;
+    }
+
+    NSString* displayName = [self.contactsManager displayNameForPhoneIdentifier:senderId];
+    OWSContactAvatarBuilder* avatarBuilder = [[OWSContactAvatarBuilder alloc] initWithContactId:senderId name:displayName contactsManager:self.contactsManager];
+    UIImage* avatarImage = [avatarBuilder build];
+
+    jsqImage = [JSQMessagesAvatarImageFactory avatarImageWithImage:avatarImage diameter:(NSUInteger)kJSQMessagesCollectionViewAvatarSizeDefault];
+
+    [self.avatarImageCache setObject:jsqImage forKey:senderId];
+
+    return jsqImage;
 }
 
 #pragma mark - UICollectionView DataSource


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 7 Simulator iOS 10.2
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

This PR adds avatar bubbles to group conversations, so it's much easier to discern who said what. It uses the same code for the avatars as the conversation index view, so it generates coloured avatars the same way if there is no avatar for the user in the contacts.

It should look something like this:

![image](https://cloud.githubusercontent.com/assets/97820/22473322/81fe6d1e-e7a6-11e6-9fff-cc03266b69ee.png)

I would really like it if the bubbles collapsed like in iMessage, but I don't think JSQMessagesViewController supports that

Fixes https://github.com/WhisperSystems/Signal-iOS/issues/736
fixes https://github.com/WhisperSystems/Signal-iOS/issues/321