### PR TITLE
Fix nav bar buttons being hidden during Create New Contact

### DIFF
--- a/Signal/src/view controllers/ShowGroupMembersViewController.m
+++ b/Signal/src/view controllers/ShowGroupMembersViewController.m
@@ -75,6 +75,15 @@ static NSString *const kUnwindToMessagesViewSegue = @"UnwindToMessagesViewSegue"
                                                   untilCancelled:nil];
 }
 
+- (void)viewWillAppear:(BOOL)animated
+{
+    [super viewWillAppear:animated];
+    
+    if (!self.isMovingToParentViewController) {
+        [UIUtil applySignalAppearence];
+    }
+}
+
 #pragma mark - Initializers
 
 - (void)initializeTableView {
@@ -154,6 +163,8 @@ static NSString *const kUnwindToMessagesViewSegue = @"UnwindToMessagesViewSegue"
         if (!anError && aContact) {
             view.displayedPerson           = aContact; // Assume person is already defined.
             view.allowsAddingToAddressBook = YES;
+            
+            [UIUtil applyDefaultSystemAppearence]; // Required to have nav bar buttons show in Create New Contact
             [self.navigationController pushViewController:view animated:YES];
         }
     }

--- a/Signal/src/view controllers/ShowGroupMembersViewController.m
+++ b/Signal/src/view controllers/ShowGroupMembersViewController.m
@@ -164,7 +164,11 @@ static NSString *const kUnwindToMessagesViewSegue = @"UnwindToMessagesViewSegue"
             view.displayedPerson           = aContact; // Assume person is already defined.
             view.allowsAddingToAddressBook = YES;
             
-            [UIUtil applyDefaultSystemAppearence]; // Required to have nav bar buttons show in Create New Contact
+            // Required to have nav bar buttons show in Create New Contact
+            [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleDefault];
+            [[UINavigationBar appearance] setBarStyle:UIBarStyleDefault];
+            [[UIBarButtonItem appearance] setTintColor:[UIColor blackColor]];
+            
             [self.navigationController pushViewController:view animated:YES];
         }
     }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iOS Simulator, iPhone 7, 10.2
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

- - - - - - - - - -

### Description
Fixes #1805 

`ABUnknownPersonViewController`'s subsequent Create New Contact controller cannot display correctly when `[UINavigationBar appearance].tintColor` or `[UIBarButtonItem appearance].tintColor` is set. By setting these to their default values before pushing the instantiated `ABUnknownPersonViewController`, we allow the appropriate buttons to display.

### Screenshots
![screen shot 2017-02-23 at 1 19 20 am](https://cloud.githubusercontent.com/assets/518673/23252974/a5619006-f967-11e6-8a98-9708e4bc21f2.png)
