### PR TITLE
Allow default browsers to be configured for links

### DIFF
--- a/Signal.xcodeproj/project.pbxproj
+++ b/Signal.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0773FC2A1E7D509700C1E683 /* OWSMessageViewCellDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 0773FC291E7D509700C1E683 /* OWSMessageViewCellDelegate.m */; };
+		0773FC301E7D5DB100C1E683 /* DefaultBrowserSelectionViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0773FC2F1E7D5DB100C1E683 /* DefaultBrowserSelectionViewController.m */; };
+		0773FC331E7D5FF800C1E683 /* BrowserUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 0773FC321E7D5FF800C1E683 /* BrowserUtil.m */; };
 		340757C21E5602D6001F15DD /* AttachmentSharing.m in Sources */ = {isa = PBXBuildFile; fileRef = 340757C11E5602D6001F15DD /* AttachmentSharing.m */; };
 		341BB7491DB727EE001E2975 /* JSQMediaItem+OWS.m in Sources */ = {isa = PBXBuildFile; fileRef = 341BB7481DB727EE001E2975 /* JSQMediaItem+OWS.m */; };
 		344F2F671E57A932000D9322 /* UIViewController+OWS.m in Sources */ = {isa = PBXBuildFile; fileRef = 344F2F661E57A932000D9322 /* UIViewController+OWS.m */; };
@@ -619,6 +622,12 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0773FC281E7D509700C1E683 /* OWSMessageViewCellDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OWSMessageViewCellDelegate.h; sourceTree = "<group>"; };
+		0773FC291E7D509700C1E683 /* OWSMessageViewCellDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OWSMessageViewCellDelegate.m; sourceTree = "<group>"; };
+		0773FC2E1E7D5DB100C1E683 /* DefaultBrowserSelectionViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DefaultBrowserSelectionViewController.h; sourceTree = "<group>"; };
+		0773FC2F1E7D5DB100C1E683 /* DefaultBrowserSelectionViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DefaultBrowserSelectionViewController.m; sourceTree = "<group>"; };
+		0773FC311E7D5FDA00C1E683 /* BrowserUtil.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BrowserUtil.h; sourceTree = "<group>"; };
+		0773FC321E7D5FF800C1E683 /* BrowserUtil.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BrowserUtil.m; sourceTree = "<group>"; };
 		1B5E7D6C9007F5E5761D79DD /* libPods-SignalTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-SignalTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		340757C01E5602D6001F15DD /* AttachmentSharing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AttachmentSharing.h; sourceTree = "<group>"; };
 		340757C11E5602D6001F15DD /* AttachmentSharing.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AttachmentSharing.m; sourceTree = "<group>"; };
@@ -2023,6 +2032,8 @@
 				45F170D51E315310003FC1F2 /* Weak.swift */,
 				45F170CB1E310E22003FC1F2 /* WeakTimer.swift */,
 				453201241E71100C00F20761 /* DisplayableTextFilter.swift */,
+				0773FC311E7D5FDA00C1E683 /* BrowserUtil.h */,
+				0773FC321E7D5FF800C1E683 /* BrowserUtil.m */,
 			);
 			path = util;
 			sourceTree = "<group>";
@@ -2061,6 +2072,8 @@
 		76EB04FE18170B33006006FC /* View Controllers */ = {
 			isa = PBXGroup;
 			children = (
+				0773FC281E7D509700C1E683 /* OWSMessageViewCellDelegate.h */,
+				0773FC291E7D509700C1E683 /* OWSMessageViewCellDelegate.m */,
 				340757C01E5602D6001F15DD /* AttachmentSharing.h */,
 				340757C11E5602D6001F15DD /* AttachmentSharing.m */,
 				451764261DE939F300EDB8B9 /* ContactsPicker.swift */,
@@ -2638,6 +2651,8 @@
 		FC3196311A08141D0094C78E /* Settings */ = {
 			isa = PBXGroup;
 			children = (
+				0773FC2E1E7D5DB100C1E683 /* DefaultBrowserSelectionViewController.h */,
+				0773FC2F1E7D5DB100C1E683 /* DefaultBrowserSelectionViewController.m */,
 				FC31962E1A0814130094C78E /* SettingsTableViewController.h */,
 				FC31962F1A0814130094C78E /* SettingsTableViewController.m */,
 				FCD274E01A5AFD8000202277 /* PrivacySettingsTableViewController.h */,
@@ -3139,6 +3154,7 @@
 				B6BADBE71B88D1AC0086A80D /* LockInteractionController.m in Sources */,
 				76EB061A18170B33006006FC /* DiscardingLog.m in Sources */,
 				45CD81F21DC03A22004C9430 /* OWSLogger.m in Sources */,
+				0773FC2A1E7D509700C1E683 /* OWSMessageViewCellDelegate.m in Sources */,
 				76EB05AC18170B33006006FC /* SrtpSocket.m in Sources */,
 				FCB11D931A12A4AA002F93FB /* FullImageViewController.m in Sources */,
 				B60C16651988999D00E97A6C /* VersionMigrations.m in Sources */,
@@ -3199,6 +3215,7 @@
 				76EB062618170B33006006FC /* Queue.m in Sources */,
 				D221A09A169C9E5E00537ABF /* main.m in Sources */,
 				45843D1F1D2236B30013E85A /* OWSContactsSearcher.m in Sources */,
+				0773FC301E7D5DB100C1E683 /* DefaultBrowserSelectionViewController.m in Sources */,
 				76EB061618170B33006006FC /* AnonymousOccurrenceLogger.m in Sources */,
 				450873C31D9D5149006B54F2 /* OWSExpirationTimerView.m in Sources */,
 				B6258B331C29E2E60014138E /* NotificationsManager.m in Sources */,
@@ -3213,6 +3230,7 @@
 				76EB05EE18170B33006006FC /* CallTermination.m in Sources */,
 				B66B9F7D1AEAF40500E2E609 /* NotificationSettingsOptionsViewController.m in Sources */,
 				E1CD329618BCFF9900B1A496 /* SoundInstance.m in Sources */,
+				0773FC331E7D5FF800C1E683 /* BrowserUtil.m in Sources */,
 				76EB05B418170B33006006FC /* HashChain.m in Sources */,
 				76EB05E418170B33006006FC /* UdpSocket.m in Sources */,
 				76EB058218170B33006006FC /* Environment.m in Sources */,

--- a/Signal/Signal-Info.plist
+++ b/Signal/Signal-Info.plist
@@ -110,5 +110,9 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>googlechromes</string>
+	</array>
 </dict>
 </plist>

--- a/Signal/src/environment/PropertyListPreferences.h
+++ b/Signal/src/environment/PropertyListPreferences.h
@@ -52,8 +52,12 @@ extern NSString *const PropertyListPreferencesKeyEnableDebugLog;
 - (BOOL)hasRegisteredVOIPPush;
 - (void)setHasRegisteredVOIPPush:(BOOL)enabled;
 
+- (NSString *)defaultBrowser;
+- (void)setDefaultBrowser:(NSString *)browserName;
+
 + (nullable NSString *)lastRanVersion;
 + (NSString *)setAndGetCurrentVersion;
+
 
 #pragma mark - Calling
 

--- a/Signal/src/environment/PropertyListPreferences.m
+++ b/Signal/src/environment/PropertyListPreferences.m
@@ -25,6 +25,7 @@ NSString *const PropertyListPreferencesKeyLastRecordedVoipToken = @"LastRecorded
 NSString *const PropertyListPreferencesKeyCallKitEnabled = @"CallKitEnabled";
 NSString *const PropertyListPreferencesKeyCallKitPrivacyEnabled = @"CallKitPrivacyEnabled";
 NSString *const PropertyListPreferencesKeyCallsHideIPAddress = @"CallsHideIPAddress";
+NSString *const PropertyListPreferencesKeyDefaultBrowser = @"DefaultBrowser";
 
 @implementation PropertyListPreferences
 
@@ -108,6 +109,19 @@ NSString *const PropertyListPreferencesKeyCallsHideIPAddress = @"CallsHideIPAddr
     } else {
         return YES;
     }
+}
+
+- (NSString *)defaultBrowser
+{
+    NSString *preference = [self tryGetValueForKey:PropertyListPreferencesKeyDefaultBrowser];
+    if (preference == nil) {
+        return @"Safari";
+    }
+    return preference;
+}
+
+- (void)setDefaultBrowser:(NSString *)browserName {
+    [self setValueForKey:PropertyListPreferencesKeyDefaultBrowser toValue:browserName];
 }
 
 - (void)setScreenSecurity:(BOOL)flag

--- a/Signal/src/util/BrowserUtil.h
+++ b/Signal/src/util/BrowserUtil.h
@@ -1,0 +1,15 @@
+//
+//  Copyright © 2017 Open Whisper Systems. All rights reserved.
+//
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface BrowserUtil : NSObject
+
++ (NSArray *)detectInstalledBrowserNames;
+
++ (NSDictionary *)schemesForBrowser:(NSString *)browserName;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Signal/src/util/BrowserUtil.m
+++ b/Signal/src/util/BrowserUtil.m
@@ -1,0 +1,36 @@
+//
+//  Copyright © 2017 Open Whisper Systems. All rights reserved.
+//
+
+#import "BrowserUtil.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation BrowserUtil
+
++ (NSArray *)detectInstalledBrowserNames {
+    NSArray *detected = @[ @"Safari" ];
+    if ([[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:@"googlechromes://whispersystems.org"]]) {
+        detected = [detected arrayByAddingObject:@"Chrome"];
+    }
+    return detected;
+}
+
++ (NSDictionary *)schemesForBrowser:(NSString *)browserName {
+    if ([browserName isEqualToString:@"Safari"]) {
+        return @{
+            @"http": @"http",
+            @"https": @"https",
+        };
+    } else if ([browserName isEqualToString:@"Chrome"]) {
+        return @{
+            @"http": @"googlechrome",
+            @"https": @"googlechromes",
+        };
+    }
+    return @{};
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Signal/src/view controllers/DefaultBrowserSelectionViewController.h
+++ b/Signal/src/view controllers/DefaultBrowserSelectionViewController.h
@@ -1,0 +1,9 @@
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface DefaultBrowserSelectionViewController : UITableViewController
+
+@end

--- a/Signal/src/view controllers/DefaultBrowserSelectionViewController.m
+++ b/Signal/src/view controllers/DefaultBrowserSelectionViewController.m
@@ -1,0 +1,59 @@
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
+
+#import "BrowserUtil.h"
+#import "DefaultBrowserSelectionViewController.h"
+#import "Environment.h"
+#import "PropertyListPreferences.h"
+#import "UIViewController+OWS.h"
+
+@interface DefaultBrowserSelectionViewController ()
+
+@property NSArray *options;
+
+@end
+
+@implementation DefaultBrowserSelectionViewController
+
+- (void)viewDidLoad {
+    self.options = [BrowserUtil detectInstalledBrowserNames];
+
+    [super viewDidLoad];
+
+    [self useOWSBackButton];
+}
+
+#pragma mark - Table view data source
+
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
+    return 1;
+}
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+    return (NSInteger)[self.options count];
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1
+                                                   reuseIdentifier:@"DefaultBrowserOption"];
+    PropertyListPreferences *prefs = [Environment preferences];
+    NSString* browserName = self.options[(NSUInteger)indexPath.row];
+    [[cell textLabel] setText:browserName];
+
+    NSString *selectedBrowser = [prefs defaultBrowser];
+
+    if ([selectedBrowser isEqualToString:browserName]) {
+        cell.accessoryType = UITableViewCellAccessoryCheckmark;
+    }
+
+    return cell;
+}
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    [Environment.preferences
+        setDefaultBrowser:[self.options objectAtIndex:(NSUInteger) indexPath.row]];
+    [self.navigationController popViewControllerAnimated:YES];
+}
+
+@end

--- a/Signal/src/view controllers/MessagesViewController.h
+++ b/Signal/src/view controllers/MessagesViewController.h
@@ -5,6 +5,7 @@
 #import <AVFoundation/AVFoundation.h>
 #import <MediaPlayer/MediaPlayer.h>
 #import <JSQMessagesViewController/JSQMessagesViewController.h>
+#import "OWSMessageViewCellDelegate.h"
 #import "TSGroupModel.h"
 @class TSThread;
 

--- a/Signal/src/view controllers/MessagesViewController.m
+++ b/Signal/src/view controllers/MessagesViewController.m
@@ -19,6 +19,7 @@
 #import "OWSExpirableMessageView.h"
 #import "OWSIncomingMessageCollectionViewCell.h"
 #import "OWSMessagesBubblesSizeCalculator.h"
+#import "OWSMessageViewCellDelegate.h"
 #import "OWSOutgoingMessageCollectionViewCell.h"
 #import "PhoneManager.h"
 #import "PropertyListPreferences.h"
@@ -214,6 +215,7 @@ typedef enum : NSUInteger {
 @property (nonatomic, readonly) TSMessagesManager *messagesManager;
 @property (nonatomic, readonly) TSNetworkManager *networkManager;
 @property (nonatomic, readonly) OutboundCallInitiator *outboundCallInitiator;
+@property (nonatomic, readonly) OWSMessageViewCellDelegate *viewCellTextViewDelegate;
 
 @property NSCache *messageAdapterCache;
 
@@ -271,6 +273,7 @@ typedef enum : NSUInteger {
     _disappearingMessagesJob = [[OWSDisappearingMessagesJob alloc] initWithStorageManager:_storageManager];
     _messagesManager = [TSMessagesManager sharedManager];
     _networkManager = [TSNetworkManager sharedManager];
+    _viewCellTextViewDelegate = [[OWSMessageViewCellDelegate alloc] init];
 }
 
 - (void)peekSetup {
@@ -1013,6 +1016,7 @@ typedef enum : NSUInteger {
         } break;
     }
     cell.delegate = collectionView;
+    cell.textView.delegate = self.viewCellTextViewDelegate;
 
     if (message.shouldStartExpireTimer && [cell conformsToProtocol:@protocol(OWSExpirableMessageView)]) {
         id<OWSExpirableMessageView> expirableView = (id<OWSExpirableMessageView>)cell;

--- a/Signal/src/view controllers/OWSMessageViewCellDelegate.h
+++ b/Signal/src/view controllers/OWSMessageViewCellDelegate.h
@@ -1,0 +1,11 @@
+//
+//  Copyright © 2017 Open Whisper Systems. All rights reserved.
+//
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface OWSMessageViewCellDelegate : NSObject <UITextViewDelegate>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Signal/src/view controllers/OWSMessageViewCellDelegate.m
+++ b/Signal/src/view controllers/OWSMessageViewCellDelegate.m
@@ -1,0 +1,46 @@
+//
+//  Copyright © 2017 Open Whisper Systems. All rights reserved.
+//
+
+#import "BrowserUtil.h"
+#import "Environment.h"
+#import "PropertyListPreferences.h"
+#import "OWSMessageViewCellDelegate.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation OWSMessageViewCellDelegate
+
+
+- (BOOL)textView:(UITextView *)textView
+        shouldInteractWithURL:(NSURL *)URL
+        inRange:(NSRange)characterRange
+        interaction:(UITextItemInteraction)interaction {
+    if (interaction != UITextItemInteractionInvokeDefaultAction) {
+        return YES;
+    }
+
+    PropertyListPreferences *prefs = Environment.preferences;
+    NSString *defaultBrowser = [prefs defaultBrowser];
+    if ([defaultBrowser isEqualToString:@"Safari"]) {
+        return YES;
+    }
+
+    NSString *oldScheme = [URL.scheme lowercaseString];
+    NSString *newScheme = [BrowserUtil schemesForBrowser:defaultBrowser][oldScheme];
+    if (newScheme == nil) {
+        return YES;
+    }
+
+    NSString *oldURLString = [URL absoluteString];
+    NSURL *newURL = [NSURL URLWithString:
+                     [newScheme stringByAppendingString:
+                      [oldURLString substringFromIndex:
+                       [oldURLString rangeOfString:@":"].location]]];
+    [[UIApplication sharedApplication] openURL:newURL];
+    return NO;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -163,6 +163,9 @@
 /* {{number of days}} embedded in strings, e.g. 'Alice updated disappearing messages expiration to {{5 days}}'. See other *_TIME_AMOUNT strings */
 "DAYS_TIME_AMOUNT" = "%u days";
 
+/* Settings section heading for choosing the default web browser for handling links in messages */
+"DEFAULT_BROWSER" = "Default Browser";
+
 /* No comment provided by engineer. */
 "DELIVERED_MESSAGE_TEXT" = "Delivered";
 


### PR DESCRIPTION
This adds Chrome as a browser, and makes it trivial to add further
browsers.

FREEBIE

### First time contributor checklist
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone SE Simulator running iOS 10.2, both with and without a browser installed which handles the googlechrome[s] link scheme.
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

- - - - - - - - - -

### Description
Fixes #1514 

This adds a setting to the Advanced settings screen to select the web browser which should be used for link handlers. It sniffs what browsers are installed (currently looking only for Chrome), and gives them as options. (Perhaps we should only show the setting at all if you don't only have Safari installed, but surfacing the capability through options may be informative to users too). When links in messages are clicked, your selected default browser is looked up and opened in place of Safari.

To add future browsers, BrowserUtil would need changing to detect and return schemes for the other browser. The scheme for sniffing would also need adding to Signal-Info.plist in the LSApplicationQueriesSchemes list.

Right now, I use Chrome as my main browser, and so having to copy links and paste them into the browser of my choice is a little annoying. Google apps that I use offer the option to auto-open in Chrome, or remain with Safari. Some other apps that I use give me the option when I long-press on a link of which browser I want to use.