### PR TITLE
Zoom in/out on message image when presenting/dismissing fullscreen video

### DIFF
--- a/Signal.xcodeproj/project.pbxproj
+++ b/Signal.xcodeproj/project.pbxproj
@@ -214,6 +214,7 @@
 		76EB063E18170B33006006FC /* Operation.m in Sources */ = {isa = PBXBuildFile; fileRef = 76EB04EF18170B33006006FC /* Operation.m */; };
 		76EB064218170B33006006FC /* StringUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 76EB04F618170B33006006FC /* StringUtil.m */; };
 		76EB068618170B34006006FC /* ContactTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 76EB052F18170B33006006FC /* ContactTableViewCell.m */; };
+		8BCE4BD11EA96BFA007B333A /* FullscreenVideoViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BCE4BD01EA96BFA007B333A /* FullscreenVideoViewController.m */; };
 		954AEE6A1DF33E01002E5410 /* ContactsPickerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954AEE681DF33D32002E5410 /* ContactsPickerTest.swift */; };
 		A10FDF79184FB4BB007FF963 /* MediaPlayer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 76C87F18181EFCE600C4ACAB /* MediaPlayer.framework */; };
 		A11CD70D17FA230600A2D1B1 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A11CD70C17FA230600A2D1B1 /* QuartzCore.framework */; };
@@ -625,6 +626,8 @@
 		76EB052E18170B33006006FC /* ContactTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ContactTableViewCell.h; sourceTree = "<group>"; };
 		76EB052F18170B33006006FC /* ContactTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ContactTableViewCell.m; sourceTree = "<group>"; };
 		7DB8EE72F8522189E3E2CB45 /* libPods-Signal.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Signal.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		8BCE4BCF1EA96BFA007B333A /* FullscreenVideoViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FullscreenVideoViewController.h; sourceTree = "<group>"; };
+		8BCE4BD01EA96BFA007B333A /* FullscreenVideoViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FullscreenVideoViewController.m; sourceTree = "<group>"; };
 		954AEE681DF33D32002E5410 /* ContactsPickerTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContactsPickerTest.swift; sourceTree = "<group>"; };
 		A11CD70C17FA230600A2D1B1 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		A163E8AA16F3F6A90094D68B /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
@@ -891,6 +894,8 @@
 				34B3F8481E8DF1700035BE1A /* FullImageViewController.m */,
 				34D5CCA71EAE3D30005515DB /* GroupViewHelper.h */,
 				34D5CCA81EAE3D30005515DB /* GroupViewHelper.m */,
+				8BCE4BCF1EA96BFA007B333A /* FullscreenVideoViewController.h */,
+				8BCE4BD01EA96BFA007B333A /* FullscreenVideoViewController.m */,
 				34B3F8491E8DF1700035BE1A /* InboxTableViewCell.h */,
 				34B3F84A1E8DF1700035BE1A /* InboxTableViewCell.m */,
 				34B3F84B1E8DF1700035BE1A /* InboxTableViewCell.xib */,
@@ -2017,6 +2022,7 @@
 				B60C16651988999D00E97A6C /* VersionMigrations.m in Sources */,
 				B97940271832BD2400BD66CB /* UIUtil.m in Sources */,
 				34B3F8791E8DF1700035BE1A /* CountryCodeViewController.m in Sources */,
+				8BCE4BD11EA96BFA007B333A /* FullscreenVideoViewController.m in Sources */,
 				4CE0E3771B954546007210CF /* TSAnimatedAdapter.m in Sources */,
 				4531C9C41DD8E6D800F08304 /* JSQMessagesCollectionViewCell+OWS.m in Sources */,
 				4516E3FF1DD2193B00DC4206 /* OWS101ExistingUsersBlockOnIdentityChange.m in Sources */,

--- a/Signal/src/ViewControllers/FullImageViewController.h
+++ b/Signal/src/ViewControllers/FullImageViewController.h
@@ -12,8 +12,7 @@
 - (instancetype)initWithAttachment:(TSAttachmentStream *)attachment
                           fromRect:(CGRect)rect
                     forInteraction:(TSInteraction *)interaction
-                       messageItem:(id<OWSMessageData>)messageItem
-                        isAnimated:(BOOL)animated;
+                       messageItem:(id<OWSMessageData>)messageItem;
 
 - (void)presentFromViewController:(UIViewController *)viewController;
 

--- a/Signal/src/ViewControllers/FullImageViewController.m
+++ b/Signal/src/ViewControllers/FullImageViewController.m
@@ -56,7 +56,6 @@
 
 @property (nonatomic) CGRect originRect;
 @property (nonatomic) BOOL isPresenting;
-@property (nonatomic) BOOL isAnimated;
 @property (nonatomic) NSData *fileData;
 
 @property (nonatomic) TSAttachmentStream *attachment;
@@ -74,8 +73,7 @@
 - (instancetype)initWithAttachment:(TSAttachmentStream *)attachment
                           fromRect:(CGRect)rect
                     forInteraction:(TSInteraction *)interaction
-                       messageItem:(id<OWSMessageData>)messageItem
-                        isAnimated:(BOOL)animated {
+                       messageItem:(id<OWSMessageData>)messageItem {
     self = [super initWithNibName:nil bundle:nil];
 
     if (self) {
@@ -83,7 +81,6 @@
         self.originRect  = rect;
         self.interaction = interaction;
         self.messageItem = messageItem;
-        self.isAnimated  = animated;
         self.fileData    = [NSData dataWithContentsOfURL:[attachment mediaURL]];
     }
 
@@ -166,7 +163,7 @@
 }
 
 - (void)initializeImageView {
-    if (self.isAnimated) {
+    if (self.attachment.isAnimated) {
         // Present the animated image using Flipboard/FLAnimatedImage
         FLAnimatedImage *animatedGif   = [FLAnimatedImage animatedImageWithGIFData:self.fileData];
         FLAnimatedImageView *imageView = [[FLAnimatedImageView alloc] init];
@@ -192,7 +189,7 @@
 }
 
 - (void)populateImageView:(UIImage *)image {
-    if (image && !self.isAnimated) {
+    if (image && !self.attachment.isAnimated) {
         self.imageView.image = image;
     }
 }

--- a/Signal/src/ViewControllers/FullImageViewController.m
+++ b/Signal/src/ViewControllers/FullImageViewController.m
@@ -92,7 +92,6 @@
 
 - (void)loadView {
     self.view = [AttachmentMenuView new];
-    self.view.backgroundColor = [UIColor colorWithWhite:0 alpha:kBackgroundAlpha];
     self.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
 }
 
@@ -120,10 +119,7 @@
 #pragma mark - Initializers
 
 - (void)initializeBackground {
-    self.imageView.backgroundColor      = [UIColor colorWithWhite:0 alpha:kBackgroundAlpha];
-    
     self.backgroundView                 = [UIView new];
-    self.backgroundView.backgroundColor = [UIColor colorWithWhite:0 alpha:kBackgroundAlpha];
     [self.view addSubview:self.backgroundView];
     [self.backgroundView autoPinEdgesToSuperviewEdges];
 }
@@ -318,7 +314,7 @@
                        // coordinate system of the window.
                        self.imageView.frame = [self.view convertRect:self.originRect
                                                             fromView:window];
-                       
+
                      [UIView animateWithDuration:0.25f
                          delay:0
                          options:UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionCurveEaseOut
@@ -333,6 +329,7 @@
                              self.imageView.frame = [self resizedFrameForImageView:self.image.size];
                              self.imageView.center = [self.contentView convertPoint:self.contentView.center
                                                                            fromView:self.contentView];
+                             self.backgroundView.backgroundColor = [UIColor colorWithWhite:0 alpha:kBackgroundAlpha];
                          }
                          completion:^(BOOL completed) {
                            self.scrollView.frame = self.contentView.bounds;
@@ -352,17 +349,24 @@
         [UIMenuController sharedMenuController].menuItems = self.oldMenuItems;
     }
 
+    _isPresenting = YES;
     self.view.userInteractionEnabled = NO;
+
+    self.scrollView.zoomScale = 1.0f;
+    self.imageView.center = [self.scrollView convertPoint:self.imageView.center toView:self.view];
+    [self.view addSubview:self.imageView];
+    self.view.backgroundColor = [UIColor clearColor];
+    self.backgroundView.backgroundColor = [UIColor clearColor];
+
     [UIView animateWithDuration:0.25f
         delay:0
         options:UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionCurveLinear
         animations:^() {
-          self.backgroundView.backgroundColor = [UIColor clearColor];
-          self.scrollView.alpha               = 0;
-          self.view.alpha                     = 0;
+            UIWindow *window = [UIApplication sharedApplication].keyWindow;
+            self.imageView.frame = [self.view convertRect:self.originRect fromView:window];
         }
         completion:^(BOOL completed) {
-          [self.presentingViewController dismissViewControllerAnimated:NO completion:nil];
+            [self.presentingViewController dismissViewControllerAnimated:NO completion:nil];
         }];
 }
 

--- a/Signal/src/ViewControllers/FullImageViewController.m
+++ b/Signal/src/ViewControllers/FullImageViewController.m
@@ -15,7 +15,7 @@
 #define kMinZoomScale 1.0f
 #define kMaxZoomScale 8.0f
 
-#define kBackgroundAlpha 0.6f
+#define kBackgroundAlpha 0.7f
 
 #define kToolbarHeight 44.0f
 
@@ -144,7 +144,8 @@
                     animated:NO];
     [self.backgroundView addSubview:self.footerBar];
     [self.footerBar autoPinWidthToSuperview];
-    self.footerBottomConstraint = [self.footerBar autoPinToBottomLayoutGuideOfViewController:self withInset:-kToolbarHeight];
+    self.footerBottomConstraint = [self.footerBar autoPinToBottomLayoutGuideOfViewController:self
+                                                                                   withInset:-kToolbarHeight];
 }
 
 - (void)shareWasPressed:(id)sender {
@@ -302,7 +303,6 @@
     self.view.userInteractionEnabled = NO;
     [self.view addSubview:self.imageView];
     self.modalPresentationStyle = UIModalPresentationOverCurrentContext;
-    self.view.alpha             = 0;
 
     [viewController
         presentViewController:self
@@ -320,7 +320,6 @@
                          delay:0
                          options:UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionCurveEaseOut
                          animations:^() {
-                             self.view.alpha      = 1.0f;
                              // During the presentation animation, we want to seamlessly animate the image
                              // to its resting location in this view.  We use `resizedFrameForImageView`
                              // to determine its size "at rest" in the content view, and then convert
@@ -358,7 +357,6 @@
     self.scrollView.zoomScale = 1.0f;
     self.imageView.center = [self.scrollView convertPoint:self.imageView.center toView:self.view];
     [self.view addSubview:self.imageView];
-    self.view.backgroundColor = [UIColor clearColor];
     self.backgroundView.backgroundColor = [UIColor clearColor];
 
     [UIView animateWithDuration:0.25f

--- a/Signal/src/ViewControllers/FullImageViewController.m
+++ b/Signal/src/ViewControllers/FullImageViewController.m
@@ -17,6 +17,8 @@
 
 #define kBackgroundAlpha 0.6f
 
+#define kToolbarHeight 44.0f
+
 // In order to use UIMenuController, the view from which it is
 // presented must have certain custom behaviors.
 @interface AttachmentMenuView : UIView
@@ -49,6 +51,8 @@
 @property (nonatomic) UIImageView *imageView;
 @property (nonatomic) UIButton *shareButton;
 @property (nonatomic) UIView *contentView;
+
+@property (nonatomic) NSLayoutConstraint *footerBottomConstraint;
 
 @property (nonatomic) CGRect originRect;
 @property (nonatomic) BOOL isPresenting;
@@ -129,6 +133,7 @@
     [self.backgroundView addSubview:self.contentView];
     [self.contentView autoPinWidthToSuperview];
     [self.contentView autoPinToTopLayoutGuideOfViewController:self withInset:0];
+    [self.contentView autoPinEdgeToSuperviewEdge:ALEdgeBottom withInset:kToolbarHeight];
     
     self.footerBar = [UIToolbar new];
     _footerBar.barTintColor = [UIColor ows_signalBrandBlueColor];
@@ -142,8 +147,7 @@
                     animated:NO];
     [self.backgroundView addSubview:self.footerBar];
     [self.footerBar autoPinWidthToSuperview];
-    [self.footerBar autoPinToBottomLayoutGuideOfViewController:self withInset:0];
-    [self.footerBar autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:self.contentView];
+    self.footerBottomConstraint = [self.footerBar autoPinToBottomLayoutGuideOfViewController:self withInset:-kToolbarHeight];
 }
 
 - (void)shareWasPressed:(id)sender {
@@ -330,6 +334,8 @@
                              self.imageView.center = [self.contentView convertPoint:self.contentView.center
                                                                            fromView:self.contentView];
                              self.backgroundView.backgroundColor = [UIColor colorWithWhite:0 alpha:kBackgroundAlpha];
+                             self.footerBottomConstraint.constant = 0;
+                             [self.view layoutIfNeeded];
                          }
                          completion:^(BOOL completed) {
                            self.scrollView.frame = self.contentView.bounds;
@@ -364,6 +370,11 @@
         animations:^() {
             UIWindow *window = [UIApplication sharedApplication].keyWindow;
             self.imageView.frame = [self.view convertRect:self.originRect fromView:window];
+            // This specifies bottom (it's a NSLayoutAttributeBottom constraint) instead of inset
+            // so we pass the negative of what we passed to
+            // autoPinToBottomLayoutGuideOfViewController:withInset: above.
+            self.footerBottomConstraint.constant = kToolbarHeight;
+            [self.view layoutIfNeeded];
         }
         completion:^(BOOL completed) {
             [self.presentingViewController dismissViewControllerAnimated:NO completion:nil];

--- a/Signal/src/ViewControllers/FullscreenVideoViewController.h
+++ b/Signal/src/ViewControllers/FullscreenVideoViewController.h
@@ -1,0 +1,16 @@
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import <MediaPlayer/MediaPlayer.h>
+#import "TSAttachmentStream.h"
+
+@interface FullscreenVideoViewController : UIViewController<UIViewControllerTransitioningDelegate>
+
+- (instancetype)initWithAttachment:(TSAttachmentStream *)attachment
+                          fromRect:(CGRect)rect;
+
+- (void)presentFromViewController:(UIViewController *)viewController;
+
+@end

--- a/Signal/src/ViewControllers/FullscreenVideoViewController.m
+++ b/Signal/src/ViewControllers/FullscreenVideoViewController.m
@@ -1,0 +1,264 @@
+//
+//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//
+
+#import "FLAnimatedImage.h"
+#import "FullscreenVideoViewController.h"
+#import "UIView+OWS.h"
+#import "ViewControllerUtils.h"
+
+#pragma mark - FullscreenMediaAnimator
+
+@interface FullscreenVideoAnimator : NSObject <UIViewControllerAnimatedTransitioning>
+
+- (instancetype)initWithImage:(UIImage *)image originRect:(CGRect)origin;
+
+@property UIImageView *imageView;
+@property UIImage *image;
+@property CGRect origin;
+
+@property (nonatomic) BOOL dismiss;
+
+@end
+
+@implementation FullscreenVideoAnimator
+
+- (instancetype)initWithImage:(UIImage *)image originRect:(CGRect)origin {
+    self = [super init];
+    if (self) {
+        self.image = image;
+        self.origin = origin;
+    }
+    return self;
+}
+
+- (NSTimeInterval)transitionDuration:(id<UIViewControllerContextTransitioning>)transitionContext {
+    return 0.3;
+}
+
+- (void)animateTransition:(id<UIViewControllerContextTransitioning>)transitionContext {
+    UIView *fromView = [transitionContext viewForKey:UITransitionContextFromViewKey];
+    UIView *toView = [transitionContext viewForKey:UITransitionContextToViewKey];
+    UIWindow *window = [UIApplication sharedApplication].keyWindow;
+
+    CGRect startFrame, endFrame;
+    UIView *imgParent = transitionContext.containerView;
+
+    [transitionContext.containerView addSubview:toView];
+    [self createImageView];
+
+    if (self.dismiss) {
+        self.imageView.alpha = 1;
+        startFrame = fromView.frame;
+        endFrame = [window convertRect:self.origin toView:imgParent];
+    } else {
+        startFrame = [window convertRect:self.origin toView:imgParent];
+        endFrame = toView.frame;
+    }
+    
+    [imgParent addSubview:self.imageView];
+    self.imageView.contentMode = UIViewContentModeScaleAspectFit;
+    self.imageView.frame = startFrame;
+
+    [UIView animateKeyframesWithDuration:[self transitionDuration:transitionContext]
+                                   delay:0
+                                 options:0
+                              animations: ^{
+        if (self.dismiss) {
+            [UIView addKeyframeWithRelativeStartTime:0 relativeDuration:0.333 animations:^{
+                fromView.backgroundColor = [UIColor clearColor];
+            }];
+            [UIView addKeyframeWithRelativeStartTime:0.333 relativeDuration:0.667 animations:^{
+                self.imageView.frame = endFrame;
+            }];
+        } else {
+            [UIView addKeyframeWithRelativeStartTime:0 relativeDuration:0.667 animations:^{
+                self.imageView.frame = endFrame;
+            }];
+            [UIView addKeyframeWithRelativeStartTime:0.667 relativeDuration:0.333 animations:^{
+                toView.backgroundColor = [UIColor blackColor];
+            }];
+        }
+    } completion:^(BOOL finished) {
+        if (self.dismiss) {
+            [self.imageView removeFromSuperview];
+        }
+
+        BOOL wasCancelled = [transitionContext transitionWasCancelled];
+        [transitionContext completeTransition:!wasCancelled];
+    }];
+}
+
+- (void)createImageView {
+    if (!self.imageView) {
+        self.imageView = [[UIImageView alloc] initWithImage:self.image];
+    }
+}
+
+// Allow the view controller to show/hide the transiton image so that it
+// can coordinate with the media player.
+- (void)hideImage {
+    self.imageView.alpha = 0;
+}
+- (void)showImage {
+    self.imageView.alpha = 1;
+}
+
+@end
+
+
+#pragma mark - FullVideoViewController Private
+
+@interface FullscreenVideoViewController ()
+
+@property (nonatomic) CGRect originRect;
+@property (nonatomic) TSAttachmentStream *attachment;
+@property (nonatomic) FullscreenVideoAnimator *animator;
+@property MPMoviePlayerController *player;
+
+@end
+
+@implementation FullscreenVideoViewController
+
+#pragma mark - Initializers
+
+- (instancetype)initWithAttachment:(TSAttachmentStream *)attachment
+                          fromRect:(CGRect)rect {
+    self = [super initWithNibName:nil bundle:nil];
+
+    if (self) {
+        self.attachment  = attachment;
+        self.originRect  = rect;
+        self.transitioningDelegate = self;
+    }
+
+    return self;
+}
+
+#pragma mark - UIViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    self.player = [[MPMoviePlayerController alloc] initWithContentURL:self.attachment.mediaURL];
+    // We want the player to look like it is in fullscreen mode
+    // but not actually to be in fullscreen mode because that
+    // comes with screen flashes as it transitions in and out
+    // (even if we pass animated:NO).
+    self.player.controlStyle = MPMovieControlStyleFullscreen;
+    self.player.shouldAutoplay = YES;
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(moviePlayerDidFinish:)
+                                                 name:MPMoviePlayerPlaybackDidFinishNotification
+                                               object:self.player];
+
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(moviePlayerLoadStateChange:)
+                                                 name:MPMoviePlayerLoadStateDidChangeNotification
+                                               object:self.player];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(dismissIfDoneState:)
+                                                 name:MPMoviePlayerPlaybackStateDidChangeNotification
+                                               object:self.player];
+}
+
+- (void)viewWillDisappear:(BOOL)animated {
+    [super viewWillDisappear:animated];
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+#pragma mark - Other Setup
+
+- (void) initAnimator {
+    self.animator = [[FullscreenVideoAnimator alloc] initWithImage:self.attachment.image
+                                                        originRect:self.originRect];
+  
+}
+
+#pragma mark - Presentation
+
+- (void)presentFromViewController:(UIViewController *)viewController {
+    [self initAnimator];
+  
+    // Though the player is entirely opaque this is probably our best bet for being able to zoom
+    // back out to the original location because it leaves the views in MessagesViewController
+    // unchanged instead of necessitating saving and restoring a scroll offset in that class.
+    self.modalPresentationStyle = UIModalPresentationOverCurrentContext;
+    [ViewControllerUtils setAudioIgnoresHardwareMuteSwitch:YES];
+
+    [viewController presentViewController:self animated:YES completion:^{
+        [self.player prepareToPlay];
+        [self.view addSubview:self.player.view];
+        self.player.view.frame = self.view.bounds;
+        self.player.shouldAutoplay = YES;
+    }];
+}
+
+- (void)dismiss {
+    [ViewControllerUtils setAudioIgnoresHardwareMuteSwitch:NO];
+    [self.animator showImage];
+    [self.player.view removeFromSuperview];
+    [self dismissViewControllerAnimated:YES completion:nil];
+}
+
+#pragma mark - Notifications
+
+- (void)moviePlayerLoadStateChange:(NSNotification *)notification {
+    // Wait until the player is ready to play to hide the image
+    // minimizing black flash to the extent possible.
+    if (self.player.loadState != MPMovieLoadStateUnknown) {
+        [self.animator hideImage];
+    } else {
+        [self dismissIfDoneState:notification];
+    }
+}
+
+- (void)dismissIfDoneState:(NSNotification *)notification {
+    // This covers the case when the user taps the back or next button unloading the video
+    if (self.player.loadState == MPMovieLoadStateUnknown &&
+        self.player.playbackState == MPMoviePlaybackStateStopped) {
+        [self dismiss];
+    }
+}
+
+- (void)moviePlayerDidFinish:(NSNotification *)notification {
+    // This covers the user tapping the done button
+    if (notification.userInfo) {
+        NSNumber *reason = [notification.userInfo valueForKey:MPMoviePlayerPlaybackDidFinishReasonUserInfoKey];
+        if ([reason intValue] == MPMovieFinishReasonUserExited) {
+            [self dismiss];
+        }
+    }
+}
+
+#pragma mark - UIViewControllerTransitionDelegate
+
+- (id<UIViewControllerAnimatedTransitioning>)animationControllerForPresentedController:(UIViewController *)presented
+                                                                  presentingController:(UIViewController *)presenting
+                                                                      sourceController:(UIViewController *)source {
+    self.animator.dismiss = NO;
+    return self.animator;
+}
+
+- (id<UIViewControllerAnimatedTransitioning>)animationControllerForDismissedController:(UIViewController *)dismissed {
+    self.animator.dismiss = YES;
+    return self.animator;
+}
+
+
+#pragma mark - Logging
+
++ (NSString *)tag {
+    return [NSString stringWithFormat:@"[%@]", self.class];
+}
+
+- (NSString *)tag {
+    return self.class.tag;
+}
+
+@end

--- a/Signal/src/ViewControllers/MessagesViewController.h
+++ b/Signal/src/ViewControllers/MessagesViewController.h
@@ -3,9 +3,9 @@
 //
 
 #import <AVFoundation/AVFoundation.h>
-#import <MediaPlayer/MediaPlayer.h>
 #import <JSQMessagesViewController/JSQMessagesViewController.h>
 #import "TSGroupModel.h"
+
 @class TSThread;
 
 extern NSString *const OWSMessagesViewControllerDidAppearNotification;

--- a/Signal/src/ViewControllers/MessagesViewController.m
+++ b/Signal/src/ViewControllers/MessagesViewController.m
@@ -2023,7 +2023,8 @@ typedef enum : NSUInteger {
             BOOL isMediaMessage = [messageItem isMediaMessage];
 
             if (isMediaMessage) {
-                if ([[messageItem media] isKindOfClass:[TSPhotoAdapter class]]) {
+                if ([[messageItem media] isKindOfClass:[TSPhotoAdapter class]] ||
+                    [[messageItem media] isKindOfClass:[TSAnimatedAdapter class]]) {
                     TSPhotoAdapter *messageMedia = (TSPhotoAdapter *)[messageItem media];
 
                     tappedImage = ((UIImageView *)[messageMedia mediaView]).image;
@@ -2048,38 +2049,8 @@ typedef enum : NSUInteger {
                                                              initWithAttachment:attStream
                                                              fromRect:convertedRect
                                                              forInteraction:interaction
-                                                             messageItem:messageItem
-                                                             isAnimated:NO];
+                                                             messageItem:messageItem];
 
-                            [vc presentFromViewController:self];
-                        }
-                    }
-                } else if ([[messageItem media] isKindOfClass:[TSAnimatedAdapter class]]) {
-                    // Show animated image full-screen
-                    TSAnimatedAdapter *messageMedia = (TSAnimatedAdapter *)[messageItem media];
-                    tappedImage                     = ((UIImageView *)[messageMedia mediaView]).image;
-                    if(tappedImage == nil) {
-                        DDLogWarn(@"tapped TSAnimatedAdapter with nil image");
-                    } else {
-                        UIWindow *window = [UIApplication sharedApplication].keyWindow;
-                        JSQMessagesCollectionViewCell *cell = (JSQMessagesCollectionViewCell *) [collectionView cellForItemAtIndexPath:indexPath];
-                        OWSAssert([cell isKindOfClass:[JSQMessagesCollectionViewCell class]]);
-                        CGRect convertedRect = [cell.mediaView convertRect:cell.mediaView.bounds
-                                                                    toView:window];
-
-                        __block TSAttachment *attachment = nil;
-                        [self.uiDatabaseConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
-                            attachment =
-                            [TSAttachment fetchObjectWithUniqueID:messageMedia.attachmentId transaction:transaction];
-                        }];
-                        if ([attachment isKindOfClass:[TSAttachmentStream class]]) {
-                            TSAttachmentStream *attStream = (TSAttachmentStream *)attachment;
-                            FullImageViewController *vc =
-                            [[FullImageViewController alloc] initWithAttachment:attStream
-                                                                       fromRect:convertedRect
-                                                                 forInteraction:interaction
-                                                                    messageItem:messageItem
-                                                                     isAnimated:YES];
                             [vc presentFromViewController:self];
                         }
                     }


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist

- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 5, iOS 8.3
 * iPhone 6, iOS 9.3.5
 * iPhone 7+, iOS 10.3.1
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

- - - - - - - - - -

### Description

This fixes #1126 with a few related changes. 

#### Included:

* Update `FullImageViewController` to zoom the image back into place on dismissal. In the process I changed the `FullImageViewController` attachment bar animation to slide up/down from the bottom instead of dissolving in/out.
* Add `FullscreenVideoViewController` to wrap `MPMoviePlayerVideoController` and provide similar transition zoom animations using a custom UIViewController transition animator.
* Some related code cleanup

The commit messages provide some detail.


#### Notes

* This should also fix Issue #1293. It does so by setting `self.modalPresentationStyle = UIModalPresentationOverCurrentContext` on the new view controller so the message view controller doesn't get torn down in the background. It's not ideal because the video controller is opaque, but the complexity of the alternative seemed worse. I saw Pull #1538, but in my testing that method would not really work because [the if block that scrolls to the bottom in `viewWillAppear`](https://github.com/WhisperSystems/Signal-iOS/blob/0cd71b3b2ea93e4c3ad543108ea19214b5ab8ee6/Signal/src/ViewControllers/MessagesViewController.m#L550) does not do anything, I think because of `resetContentAndLayout` below. Further, in this case you would want to return to a precise scroll offset, not just ensure an index path is showing.
* Before presenting `FullImageViewController` and `FullscreenVideoViewController` the keyboard needs to be dismissed so that the zoom out animation lines up.
* Since multiple views in `FullImageViewController` were set to have a semi-transparent black background the resulting alpha level was not `kBackgroundAlpha` but something higher based on whatever blending iOS is using. I changed it so that only one view has a background color set and upped the constant to be closer to matching the current effective value.
* As in the current version the zoom animations can potentially show up over the message controller navigation bar. My opinion is that the *best* solution is to take after Message.app and leave the navigation bar intact on zoom in instead of overlaying over the entire screen. This likely requires a custom movie player view instead of using `MPMoviePlayerController`.
* I did take a shot at unifying the zoom animation code between `FullImageViewController` and `FullscreenVideoViewController`. Unfortunately given the wrangling required to use `MPMoviePlayerViewControler` I ended up with more complicated to share code. It probably would make sense to merge the two if `MPMoviePlayerViewControler` were ditched in favor of a custom player view controller. (And, in my opinion, going custom feels like a natural next step given a) `MPMoviePlayerViewControler` is deprecated and the new `AVPlayerViewController` is not as well suited in this context and b) it would make it possible to unify the UI with the image version and add the same share button.)

#### Testing

I tested on a few devices and iOS 8, 9 and 10. I did my best to initiate the zooms from different scroll positions and keyboard states. Since I change the `MPMoviePlayerViewController` usage to not use its fullscreen mode (though it does use the fullscreen controls) I did testing that the video view is not dismissed prematurely and correctly dismissed for all relevant user interactions. 
