### PR TITLE
ConversationView first load avoids redundant layout

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
@@ -4462,12 +4462,14 @@ typedef enum : NSUInteger {
         // bottom of content"; if the mapping's "window" size grows, it will grow
         // _upward_.
         CGFloat viewTopToContentBottom = 0;
-        if ([self.collectionView.collectionViewLayout isKindOfClass:[ConversationViewLayout class]]) {
-            ConversationViewLayout *conversationViewLayout
-                = (ConversationViewLayout *)self.collectionView.collectionViewLayout;
-            if (conversationViewLayout.hasLayout) {
-                viewTopToContentBottom = self.safeContentHeight - self.collectionView.contentOffset.y;
-            }
+        OWSAssert([self.collectionView.collectionViewLayout isKindOfClass:[ConversationViewLayout class]]);
+        ConversationViewLayout *conversationViewLayout
+            = (ConversationViewLayout *)self.collectionView.collectionViewLayout;
+        // To avoid laying out the collection view during initial view
+        // presentation, don't trigger layout here (via safeContentHeight)
+        // until layout has been done at least once.
+        if (conversationViewLayout.hasEverHadLayout) {
+            viewTopToContentBottom = self.safeContentHeight - self.collectionView.contentOffset.y;
         }
 
         NSUInteger oldCellCount = [self.messageMappings numberOfItemsInGroup:self.thread.uniqueId];

--- a/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
@@ -4461,7 +4461,14 @@ typedef enum : NSUInteger {
         // Snapshot the scroll state by measuring the "distance from top of view to
         // bottom of content"; if the mapping's "window" size grows, it will grow
         // _upward_.
-        CGFloat viewTopToContentBottom = self.safeContentHeight - self.collectionView.contentOffset.y;
+        CGFloat viewTopToContentBottom = 0;
+        if ([self.collectionView.collectionViewLayout isKindOfClass:[ConversationViewLayout class]]) {
+            ConversationViewLayout *conversationViewLayout
+                = (ConversationViewLayout *)self.collectionView.collectionViewLayout;
+            if (conversationViewLayout.hasLayout) {
+                viewTopToContentBottom = self.safeContentHeight - self.collectionView.contentOffset.y;
+            }
+        }
 
         NSUInteger oldCellCount = [self.messageMappings numberOfItemsInGroup:self.thread.uniqueId];
 

--- a/Signal/src/ViewControllers/ConversationView/ConversationViewLayout.h
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewLayout.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//  Copyright (c) 2018 Open Whisper Systems. All rights reserved.
 //
 
 NS_ASSUME_NONNULL_BEGIN
@@ -38,6 +38,7 @@ typedef NS_ENUM(NSInteger, ConversationViewLayoutAlignment) {
 
 @property (nonatomic, weak) id<ConversationViewLayoutDelegate> delegate;
 @property (nonatomic, readonly) BOOL hasLayout;
+@property (nonatomic, readonly) BOOL hasEverHadLayout;
 @property (nonatomic, readonly) int contentWidth;
 
 @end

--- a/Signal/src/ViewControllers/ConversationView/ConversationViewLayout.h
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewLayout.h
@@ -37,7 +37,7 @@ typedef NS_ENUM(NSInteger, ConversationViewLayoutAlignment) {
 @interface ConversationViewLayout : UICollectionViewLayout
 
 @property (nonatomic, weak) id<ConversationViewLayoutDelegate> delegate;
-
+@property (nonatomic, readonly) BOOL hasLayout;
 @property (nonatomic, readonly) int contentWidth;
 
 @end

--- a/Signal/src/ViewControllers/ConversationView/ConversationViewLayout.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewLayout.m
@@ -19,6 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 // layout without incurring any of the (great) expense of performing an
 // unnecessary layout pass.
 @property (nonatomic) BOOL hasLayout;
+@property (nonatomic) BOOL hasEverHadLayout;
 
 @property (nonatomic) int contentWidth;
 
@@ -35,6 +36,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     return self;
+}
+
+- (void)setHasLayout:(BOOL)hasLayout
+{
+    _hasLayout = hasLayout;
+
+    if (hasLayout) {
+        self.hasEverHadLayout = YES;
+    }
 }
 
 - (void)invalidateLayout


### PR DESCRIPTION
Problem:

We are laying out the collection view, invalidating the layout, and then
laying out the collection view again on first appearance of the
conversation view. This is quite expensive - removing it shaves off
about 30% of load time.

**before**

<img width="1792" alt="screen shot 2018-04-11 at 5 18 01 pm" src="https://user-images.githubusercontent.com/36971200/38643811-69e77d9e-3dac-11e8-808f-bc89218970ef.png">

**after**

<img width="1792" alt="screen shot 2018-04-11 at 5 17 52 pm" src="https://user-images.githubusercontent.com/36971200/38643812-6a142704-3dac-11e8-8042-d2b002dcfe3c.png">

PTAL @charlesmchen 