### PR TITLE
Strip media metadata.

### DIFF
--- a/Signal/src/ViewControllers/PrivacySettingsTableViewController.m
+++ b/Signal/src/ViewControllers/PrivacySettingsTableViewController.m
@@ -65,6 +65,15 @@ NS_ASSUME_NONNULL_BEGIN
                                                              target:weakSelf
                                                            selector:@selector(didToggleScreenSecuritySwitch:)]];
     [contents addSection:screenSecuritySection];
+    
+    OWSTableSection *removeMetadataSection = [OWSTableSection new];
+    removeMetadataSection.headerTitle = NSLocalizedString(@"SETTINGS_REMOVE_METADATA_TITLE", @"Remove metadata section header");
+    removeMetadataSection.footerTitle = NSLocalizedString(@"SETTINGS_REMOVE_METADATA_DETAIL", @"Remove metadata section footer");
+    [removeMetadataSection addItem:[OWSTableItem switchItemWithText:NSLocalizedString(@"SETTINGS_REMOVE_METADATA", @"Remove metadata table cell label")
+                                                               isOn:[Environment.preferences isRemoveMetadataEnabled]
+                                                             target:weakSelf
+                                                           selector:@selector(didToggleRemoveMetadataSwitch:)]];
+    [contents addSection:removeMetadataSection];
 
     // Allow calls to connect directly vs. using TURN exclusively
     OWSTableSection *callingSection = [OWSTableSection new];
@@ -169,6 +178,13 @@ NS_ASSUME_NONNULL_BEGIN
     BOOL enabled = sender.isOn;
     DDLogInfo(@"%@ toggled screen security: %@", self.logTag, enabled ? @"ON" : @"OFF");
     [Environment.preferences setScreenSecurity:enabled];
+}
+
+- (void)didToggleRemoveMetadataSwitch:(UISwitch *)sender
+{
+    BOOL enabled = sender.isOn;
+    DDLogInfo(@"%@ toggled remove metadata: %@", self.logTag, enabled ? @"ON" : @"OFF");
+    [Environment.preferences setIsRemoveMetadataEnabled:enabled];
 }
 
 - (void)didToggleReadReceiptsSwitch:(UISwitch *)sender

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -115,6 +115,9 @@
 /* Attachment error message for video attachments which could not be converted to MP4 */
 "ATTACHMENT_ERROR_COULD_NOT_CONVERT_TO_MP4" = "Unable to process video.";
 
+/* Attachment error message for image attachments in which metadata could not be removed */
+"ATTACHMENT_ERROR_COULD_NOT_REMOVE_METADATA" = "Unable to remove metadata from image.";
+
 /* Attachment error message for image attachments which cannot be parsed */
 "ATTACHMENT_ERROR_COULD_NOT_PARSE_IMAGE" = "Image attachment could not be parsed.";
 
@@ -1607,6 +1610,15 @@
 
 /* No comment provided by engineer. */
 "SETTINGS_SCREEN_SECURITY_DETAIL" = "Prevent Signal previews from appearing in the app switcher.";
+
+/* Remove metadata table view header label. */
+"SETTINGS_REMOVE_METADATA_TITLE" = "Metadata";
+
+/* Label for the remove metadata setting. */
+"SETTINGS_REMOVE_METADATA" = "Remove Media Metadata";
+
+/* Footer label explanation of the remove metadata setting. */
+"SETTINGS_REMOVE_METADATA_DETAIL" = "Removes user-identifying metadata and GPS information when sending image and video messages.";
 
 /* Settings table section footer. */
 "SETTINGS_SECTION_CALL_KIT_DESCRIPTION" = "iOS Call Integration shows Signal calls on your lock screen and in the system's call history. You may optionally show your contact's name and number. If iCloud is enabled, this call history will be shared with Apple.";

--- a/SignalMessaging/utils/OWSPreferences.h
+++ b/SignalMessaging/utils/OWSPreferences.h
@@ -42,6 +42,9 @@ extern NSString *const OWSPreferencesKeyEnableDebugLog;
 - (BOOL)screenSecurityIsEnabled;
 - (void)setScreenSecurity:(BOOL)flag;
 
+- (BOOL)isRemoveMetadataEnabled;
+- (void)setIsRemoveMetadataEnabled:(BOOL)enabled;
+
 - (NotificationType)notificationPreviewType;
 - (void)setNotificationPreviewType:(NotificationType)type;
 - (NSString *)nameForNotificationPreviewType:(NotificationType)notificationType;

--- a/SignalMessaging/utils/OWSPreferences.m
+++ b/SignalMessaging/utils/OWSPreferences.m
@@ -23,6 +23,7 @@ NSString *const OWSPreferencesKeyLastRecordedVoipToken = @"LastRecordedVoipToken
 NSString *const OWSPreferencesKeyCallKitEnabled = @"CallKitEnabled";
 NSString *const OWSPreferencesKeyCallKitPrivacyEnabled = @"CallKitPrivacyEnabled";
 NSString *const OWSPreferencesKeyCallsHideIPAddress = @"CallsHideIPAddress";
+NSString *const OWSPreferencesKeyRemoveMetadata = @"Remove Metadata Key";
 NSString *const OWSPreferencesKeyHasDeclinedNoContactsView = @"hasDeclinedNoContactsView";
 NSString *const OWSPreferencesKeyIOSUpgradeNagDate = @"iOSUpgradeNagDate";
 NSString *const OWSPreferencesKey_IsReadyForAppExtensions = @"isReadyForAppExtensions_5";
@@ -94,6 +95,17 @@ NSString *const OWSPreferencesKeySystemCallLogEnabled = @"OWSPreferencesKeySyste
 - (void)setScreenSecurity:(BOOL)flag
 {
     [self setValueForKey:OWSPreferencesKeyScreenSecurity toValue:@(flag)];
+}
+
+- (BOOL)isRemoveMetadataEnabled
+{
+    NSNumber *preference = [self tryGetValueForKey:OWSPreferencesKeyRemoveMetadata];
+    return preference ? [preference boolValue] : YES;
+}
+
+- (void)setIsRemoveMetadataEnabled:(BOOL)enabled
+{
+    [self setValueForKey:OWSPreferencesKeyRemoveMetadata toValue:@(enabled)];
 }
 
 - (BOOL)getHasSentAMessage


### PR DESCRIPTION
- removes non-orientation metadata from image and video attachments
- option to disable the feature

// FREEBIE

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone X, iOS 11.2
 * iPhone 7, iOS 10.3.3
 * iPhone 6S, iOS 11.0
 * iPhone 5, iOS 9.3.5

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->
Strips non-orientation metadata from image and video attachments, with an option to leave the metadata in. This was tested by printing out the metadata dictionaries before and after the modification, as well as checking the attachment on a secondary device to make sure the information was truly removed. 

All attachments flow through the SignalAttachment class. Images flow through the imageAttachment method of that class which strips out the metadata. I noticed that the master branch has been updated so that all video attachments are piped through the compressVideoAsMp4 inside the SignalAttachment class, so removal of video metadata was implemented there.

Fixes #1984