### PR TITLE
Charlesmchen/sae vs file types

### DIFF
--- a/Signal.xcodeproj/project.pbxproj
+++ b/Signal.xcodeproj/project.pbxproj
@@ -42,6 +42,8 @@
 		344F248720069ECB00CFB4F4 /* ModalActivityIndicatorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344F248620069ECB00CFB4F4 /* ModalActivityIndicatorViewController.swift */; };
 		344F248A20069F0600CFB4F4 /* ViewControllerUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 344F248820069F0600CFB4F4 /* ViewControllerUtils.h */; };
 		344F248B20069F0600CFB4F4 /* ViewControllerUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 344F248920069F0600CFB4F4 /* ViewControllerUtils.m */; };
+		344F248D2007CCD600CFB4F4 /* DisplayableText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344F248C2007CCD600CFB4F4 /* DisplayableText.swift */; };
+		344F248F2007D7F200CFB4F4 /* OWSMessagesBubbleImageFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344F248E2007D7F200CFB4F4 /* OWSMessagesBubbleImageFactory.swift */; };
 		3461284B1FD0B94000532771 /* SAELoadViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3461284A1FD0B93F00532771 /* SAELoadViewController.swift */; };
 		346129341FD1A88700532771 /* OWSSwiftUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346129331FD1A88700532771 /* OWSSwiftUtils.swift */; };
 		346129391FD1B47300532771 /* OWSPreferences.h in Headers */ = {isa = PBXBuildFile; fileRef = 346129371FD1B47200532771 /* OWSPreferences.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -241,7 +243,6 @@
 		452037D11EE84975004E4CDF /* DebugUISessionState.m in Sources */ = {isa = PBXBuildFile; fileRef = 452037D01EE84975004E4CDF /* DebugUISessionState.m */; };
 		4520D8D51D417D8E00123472 /* Photos.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4520D8D41D417D8E00123472 /* Photos.framework */; };
 		4521C3C01F59F3BA00B4C582 /* TextFieldHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4521C3BF1F59F3BA00B4C582 /* TextFieldHelper.swift */; };
-		4523149C1F7D7F81003A428C /* OWSMessagesBubbleImageFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4523149B1F7D7F81003A428C /* OWSMessagesBubbleImageFactory.swift */; };
 		4523149E1F7E916B003A428C /* SlideOffAnimatedTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4523149D1F7E916B003A428C /* SlideOffAnimatedTransition.swift */; };
 		452314A01F7E9E18003A428C /* DirectionalPanGestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4523149F1F7E9E18003A428C /* DirectionalPanGestureRecognizer.swift */; };
 		452C468F1E427E200087B011 /* OutboundCallInitiator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 452C468E1E427E200087B011 /* OutboundCallInitiator.swift */; };
@@ -303,7 +304,6 @@
 		45DF5DF21DDB843F00C936C7 /* CompareSafetyNumbersActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45DF5DF11DDB843F00C936C7 /* CompareSafetyNumbersActivity.swift */; };
 		45E547201FD755E700DFC09E /* AttachmentApprovalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E5471F1FD755E700DFC09E /* AttachmentApprovalViewController.swift */; };
 		45E5A6991F61E6DE001E4A8A /* MarqueeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E5A6981F61E6DD001E4A8A /* MarqueeLabel.swift */; };
-		45E615161E8C590B0018AD52 /* DisplayableText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E615151E8C590B0018AD52 /* DisplayableText.swift */; };
 		45E7A6A81E71CA7E00D44FB5 /* DisplayableTextFilterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E7A6A61E71CA7E00D44FB5 /* DisplayableTextFilterTest.swift */; };
 		45F170AC1E2F0351003FC1F2 /* CallAudioSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45F170AB1E2F0351003FC1F2 /* CallAudioSession.swift */; };
 		45F170BB1E2FC5D3003FC1F2 /* CallAudioService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45F170BA1E2FC5D3003FC1F2 /* CallAudioService.swift */; };
@@ -525,6 +525,8 @@
 		344F248620069ECB00CFB4F4 /* ModalActivityIndicatorViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ModalActivityIndicatorViewController.swift; path = SignalMessaging/contacts/ModalActivityIndicatorViewController.swift; sourceTree = SOURCE_ROOT; };
 		344F248820069F0600CFB4F4 /* ViewControllerUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ViewControllerUtils.h; path = SignalMessaging/contacts/ViewControllerUtils.h; sourceTree = SOURCE_ROOT; };
 		344F248920069F0600CFB4F4 /* ViewControllerUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ViewControllerUtils.m; path = SignalMessaging/contacts/ViewControllerUtils.m; sourceTree = SOURCE_ROOT; };
+		344F248C2007CCD600CFB4F4 /* DisplayableText.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DisplayableText.swift; sourceTree = "<group>"; };
+		344F248E2007D7F200CFB4F4 /* OWSMessagesBubbleImageFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OWSMessagesBubbleImageFactory.swift; sourceTree = "<group>"; };
 		34533F161EA8D2070006114F /* OWSAudioAttachmentPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OWSAudioAttachmentPlayer.h; sourceTree = "<group>"; };
 		34533F171EA8D2070006114F /* OWSAudioAttachmentPlayer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OWSAudioAttachmentPlayer.m; sourceTree = "<group>"; };
 		3461284A1FD0B93F00532771 /* SAELoadViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SAELoadViewController.swift; sourceTree = "<group>"; };
@@ -770,7 +772,6 @@
 		452037D01EE84975004E4CDF /* DebugUISessionState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DebugUISessionState.m; sourceTree = "<group>"; };
 		4520D8D41D417D8E00123472 /* Photos.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Photos.framework; path = System/Library/Frameworks/Photos.framework; sourceTree = SDKROOT; };
 		4521C3BF1F59F3BA00B4C582 /* TextFieldHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextFieldHelper.swift; sourceTree = "<group>"; };
-		4523149B1F7D7F81003A428C /* OWSMessagesBubbleImageFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OWSMessagesBubbleImageFactory.swift; sourceTree = "<group>"; };
 		4523149D1F7E916B003A428C /* SlideOffAnimatedTransition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SlideOffAnimatedTransition.swift; path = UserInterface/SlideOffAnimatedTransition.swift; sourceTree = "<group>"; };
 		4523149F1F7E9E18003A428C /* DirectionalPanGestureRecognizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DirectionalPanGestureRecognizer.swift; sourceTree = "<group>"; };
 		452C468E1E427E200087B011 /* OutboundCallInitiator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OutboundCallInitiator.swift; sourceTree = "<group>"; };
@@ -848,7 +849,6 @@
 		45E2E91E1E13EE3500457AA0 /* OWSCallNotificationsAdaptee.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; name = OWSCallNotificationsAdaptee.h; path = UserInterface/OWSCallNotificationsAdaptee.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		45E5471F1FD755E700DFC09E /* AttachmentApprovalViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttachmentApprovalViewController.swift; sourceTree = "<group>"; };
 		45E5A6981F61E6DD001E4A8A /* MarqueeLabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MarqueeLabel.swift; sourceTree = "<group>"; };
-		45E615151E8C590B0018AD52 /* DisplayableText.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DisplayableText.swift; sourceTree = "<group>"; };
 		45E7A6A61E71CA7E00D44FB5 /* DisplayableTextFilterTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DisplayableTextFilterTest.swift; sourceTree = "<group>"; };
 		45F170AB1E2F0351003FC1F2 /* CallAudioSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CallAudioSession.swift; sourceTree = "<group>"; };
 		45F170B31E2F0A6A003FC1F2 /* RTCAudioSession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTCAudioSession.h; sourceTree = "<group>"; };
@@ -1106,6 +1106,7 @@
 				34480B4D1FD0A7A300BC14EF /* DebugLogger.h */,
 				34480B4E1FD0A7A300BC14EF /* DebugLogger.m */,
 				348F2EAD1F0D21BC00D4ECE0 /* DeviceSleepManager.swift */,
+				344F248C2007CCD600CFB4F4 /* DisplayableText.swift */,
 				346129AC1FD1F34E00532771 /* ImageCache.swift */,
 				45666EC41D99483D008FE134 /* OWSAvatarBuilder.h */,
 				45666EC51D99483D008FE134 /* OWSAvatarBuilder.m */,
@@ -1119,6 +1120,7 @@
 				34480B4B1FD0A7A300BC14EF /* OWSLogger.m */,
 				34480B481FD0A60200BC14EF /* OWSMath.h */,
 				3461293B1FD1D46900532771 /* OWSMath.m */,
+				344F248E2007D7F200CFB4F4 /* OWSMessagesBubbleImageFactory.swift */,
 				346129371FD1B47200532771 /* OWSPreferences.h */,
 				346129381FD1B47200532771 /* OWSPreferences.m */,
 				34480B4F1FD0A7A300BC14EF /* OWSScrubbingLogFormatter.h */,
@@ -1480,7 +1482,6 @@
 				34FD936F1E3BD43A00109093 /* OWSAnyTouchGestureRecognizer.m */,
 				34B3F8331E8DF1700035BE1A /* ViewControllers */,
 				76EB052B18170B33006006FC /* Views */,
-				4523149B1F7D7F81003A428C /* OWSMessagesBubbleImageFactory.swift */,
 				4523149D1F7E916B003A428C /* SlideOffAnimatedTransition.swift */,
 			);
 			name = UserInterface;
@@ -1730,7 +1731,6 @@
 				34CCAF371F0C0599004084F4 /* AppUpdateNag.m */,
 				B90418E4183E9DD40038554A /* DateUtil.h */,
 				B90418E5183E9DD40038554A /* DateUtil.m */,
-				45E615151E8C590B0018AD52 /* DisplayableText.swift */,
 				76EB04EA18170B33006006FC /* FunctionalUtil.h */,
 				76EB04EB18170B33006006FC /* FunctionalUtil.m */,
 				34B0796C1FCF46B000E248C2 /* MainAppContext.h */,
@@ -2786,6 +2786,7 @@
 				346129CD1FD2072E00532771 /* UIImage+OWS.m in Sources */,
 				344D6CEC20069E070042AF96 /* NewNonContactConversationViewController.m in Sources */,
 				346129FB1FD5F31400532771 /* OWS101ExistingUsersBlockOnIdentityChange.m in Sources */,
+				344F248D2007CCD600CFB4F4 /* DisplayableText.swift in Sources */,
 				450998651FD8A34D00D89EB3 /* DeviceSleepManager.swift in Sources */,
 				3478506B1FD9B78A007B8332 /* NoopCallMessageHandler.swift in Sources */,
 				451F8A3D1FD713CA005CB9DA /* ThreadViewHelper.m in Sources */,
@@ -2807,6 +2808,7 @@
 				4565ED06200EA29900C46DBB /* VideoPlayerView.swift in Sources */,
 				3461295B1FD1D74C00532771 /* Environment.m in Sources */,
 				346129D51FD20ADC00532771 /* UIViewController+OWS.m in Sources */,
+				344F248F2007D7F200CFB4F4 /* OWSMessagesBubbleImageFactory.swift in Sources */,
 				451F8A431FD714FE005CB9DA /* AvatarImageView.swift in Sources */,
 				346129C91FD2072E00532771 /* NSString+OWS.m in Sources */,
 				346129CB1FD2072E00532771 /* Promise+retainUntilComplete.swift in Sources */,
@@ -2892,7 +2894,6 @@
 				34B3F87B1E8DF1700035BE1A /* ExperienceUpgradesPageViewController.swift in Sources */,
 				452EA09E1EA7ABE00078744B /* AttachmentPointerView.swift in Sources */,
 				34B3F87C1E8DF1700035BE1A /* FingerprintViewController.m in Sources */,
-				4523149C1F7D7F81003A428C /* OWSMessagesBubbleImageFactory.swift in Sources */,
 				45638BDC1F3DD0D400128435 /* DebugUICalling.swift in Sources */,
 				45464DBC1DFA041F001D3FD6 /* DataChannelMessage.swift in Sources */,
 				34E3E5681EC4B19400495BAC /* AudioProgressView.swift in Sources */,
@@ -2908,7 +2909,6 @@
 				4556FA681F54AA9500AF40DD /* DebugUIProfile.swift in Sources */,
 				34DFCB851E8E04B500053165 /* AddToBlockListViewController.m in Sources */,
 				45A6DAD61EBBF85500893231 /* ReminderView.swift in Sources */,
-				45E615161E8C590B0018AD52 /* DisplayableText.swift in Sources */,
 				34B3F88A1E8DF1700035BE1A /* OWSLinkDeviceViewController.m in Sources */,
 				34D1F0881F8678AA0066283D /* ConversationViewLayout.m in Sources */,
 				3497DBEF1ECE2E4700DB2605 /* DomainFrontingCountryViewController.m in Sources */,

--- a/Signal.xcodeproj/project.pbxproj
+++ b/Signal.xcodeproj/project.pbxproj
@@ -44,6 +44,10 @@
 		344F248B20069F0600CFB4F4 /* ViewControllerUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 344F248920069F0600CFB4F4 /* ViewControllerUtils.m */; };
 		344F248D2007CCD600CFB4F4 /* DisplayableText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344F248C2007CCD600CFB4F4 /* DisplayableText.swift */; };
 		344F248F2007D7F200CFB4F4 /* OWSMessagesBubbleImageFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344F248E2007D7F200CFB4F4 /* OWSMessagesBubbleImageFactory.swift */; };
+		344F2499200FD03300CFB4F4 /* SharingThreadPickerViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 344F2495200FD03200CFB4F4 /* SharingThreadPickerViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		344F249A200FD03300CFB4F4 /* MessageApprovalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344F2496200FD03200CFB4F4 /* MessageApprovalViewController.swift */; };
+		344F249B200FD03300CFB4F4 /* SharingThreadPickerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 344F2497200FD03200CFB4F4 /* SharingThreadPickerViewController.m */; };
+		344F249C200FD03300CFB4F4 /* AttachmentApprovalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344F2498200FD03200CFB4F4 /* AttachmentApprovalViewController.swift */; };
 		3461284B1FD0B94000532771 /* SAELoadViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3461284A1FD0B93F00532771 /* SAELoadViewController.swift */; };
 		346129341FD1A88700532771 /* OWSSwiftUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346129331FD1A88700532771 /* OWSSwiftUtils.swift */; };
 		346129391FD1B47300532771 /* OWSPreferences.h in Headers */ = {isa = PBXBuildFile; fileRef = 346129371FD1B47200532771 /* OWSPreferences.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -214,8 +218,6 @@
 		45194F951FD7216600333B2C /* TSUnreadIndicatorInteraction.m in Sources */ = {isa = PBXBuildFile; fileRef = 34C42D651F4734ED0072EC04 /* TSUnreadIndicatorInteraction.m */; };
 		45194F961FD7226300333B2C /* SelectThreadViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 3400C7941EAF99F4008A8584 /* SelectThreadViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		451A13B11E13DED2000A50FD /* CallNotificationsAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451A13B01E13DED2000A50FD /* CallNotificationsAdapter.swift */; };
-		451F8A311FD70DE9005CB9DA /* SharingThreadPickerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 3400C7911EAF89CD008A8584 /* SharingThreadPickerViewController.m */; };
-		451F8A321FD70DFA005CB9DA /* SharingThreadPickerViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 3400C7901EAF89CD008A8584 /* SharingThreadPickerViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		451F8A331FD71083005CB9DA /* SelectThreadViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 3400C7951EAF99F4008A8584 /* SelectThreadViewController.m */; };
 		451F8A341FD710C3005CB9DA /* ConversationSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451777C71FD61554001225FF /* ConversationSearcher.swift */; };
 		451F8A351FD710DE005CB9DA /* Searcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45360B8C1F9521F800FA666C /* Searcher.swift */; };
@@ -302,7 +304,6 @@
 		45CD81EF1DC030E7004C9430 /* SyncPushTokensJob.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45CD81EE1DC030E7004C9430 /* SyncPushTokensJob.swift */; };
 		45D231771DC7E8F10034FA89 /* SessionResetJob.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D231761DC7E8F10034FA89 /* SessionResetJob.swift */; };
 		45DF5DF21DDB843F00C936C7 /* CompareSafetyNumbersActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45DF5DF11DDB843F00C936C7 /* CompareSafetyNumbersActivity.swift */; };
-		45E547201FD755E700DFC09E /* AttachmentApprovalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E5471F1FD755E700DFC09E /* AttachmentApprovalViewController.swift */; };
 		45E5A6991F61E6DE001E4A8A /* MarqueeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E5A6981F61E6DD001E4A8A /* MarqueeLabel.swift */; };
 		45E7A6A81E71CA7E00D44FB5 /* DisplayableTextFilterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E7A6A61E71CA7E00D44FB5 /* DisplayableTextFilterTest.swift */; };
 		45F170AC1E2F0351003FC1F2 /* CallAudioSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45F170AB1E2F0351003FC1F2 /* CallAudioSession.swift */; };
@@ -470,8 +471,6 @@
 		1C93CF3971B64E8B6C1F9AC1 /* Pods-SignalShareExtension.test.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SignalShareExtension.test.xcconfig"; path = "Pods/Target Support Files/Pods-SignalShareExtension/Pods-SignalShareExtension.test.xcconfig"; sourceTree = "<group>"; };
 		1CE3CD5C23334683BDD3D78C /* Pods-Signal.test.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Signal.test.xcconfig"; path = "Pods/Target Support Files/Pods-Signal/Pods-Signal.test.xcconfig"; sourceTree = "<group>"; };
 		264242150E87D10A357DB07B /* Pods_SignalMessaging.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SignalMessaging.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		3400C7901EAF89CD008A8584 /* SharingThreadPickerViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SharingThreadPickerViewController.h; sourceTree = "<group>"; };
-		3400C7911EAF89CD008A8584 /* SharingThreadPickerViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SharingThreadPickerViewController.m; sourceTree = "<group>"; };
 		3400C7941EAF99F4008A8584 /* SelectThreadViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SelectThreadViewController.h; sourceTree = "<group>"; };
 		3400C7951EAF99F4008A8584 /* SelectThreadViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SelectThreadViewController.m; sourceTree = "<group>"; };
 		3400C7971EAFB772008A8584 /* ThreadViewHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThreadViewHelper.h; sourceTree = "<group>"; };
@@ -527,6 +526,10 @@
 		344F248920069F0600CFB4F4 /* ViewControllerUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ViewControllerUtils.m; path = SignalMessaging/contacts/ViewControllerUtils.m; sourceTree = SOURCE_ROOT; };
 		344F248C2007CCD600CFB4F4 /* DisplayableText.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DisplayableText.swift; sourceTree = "<group>"; };
 		344F248E2007D7F200CFB4F4 /* OWSMessagesBubbleImageFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OWSMessagesBubbleImageFactory.swift; sourceTree = "<group>"; };
+		344F2495200FD03200CFB4F4 /* SharingThreadPickerViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SharingThreadPickerViewController.h; path = SignalMessaging/attachments/SharingThreadPickerViewController.h; sourceTree = SOURCE_ROOT; };
+		344F2496200FD03200CFB4F4 /* MessageApprovalViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MessageApprovalViewController.swift; path = SignalMessaging/attachments/MessageApprovalViewController.swift; sourceTree = SOURCE_ROOT; };
+		344F2497200FD03200CFB4F4 /* SharingThreadPickerViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SharingThreadPickerViewController.m; path = SignalMessaging/attachments/SharingThreadPickerViewController.m; sourceTree = SOURCE_ROOT; };
+		344F2498200FD03200CFB4F4 /* AttachmentApprovalViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AttachmentApprovalViewController.swift; path = SignalMessaging/attachments/AttachmentApprovalViewController.swift; sourceTree = SOURCE_ROOT; };
 		34533F161EA8D2070006114F /* OWSAudioAttachmentPlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OWSAudioAttachmentPlayer.h; sourceTree = "<group>"; };
 		34533F171EA8D2070006114F /* OWSAudioAttachmentPlayer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OWSAudioAttachmentPlayer.m; sourceTree = "<group>"; };
 		3461284A1FD0B93F00532771 /* SAELoadViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SAELoadViewController.swift; sourceTree = "<group>"; };
@@ -847,7 +850,6 @@
 		45E282DE1D08E67800ADD4C8 /* gl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = gl; path = translations/gl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		45E282DF1D08E6CC00ADD4C8 /* id */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = id; path = translations/id.lproj/Localizable.strings; sourceTree = "<group>"; };
 		45E2E91E1E13EE3500457AA0 /* OWSCallNotificationsAdaptee.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; name = OWSCallNotificationsAdaptee.h; path = UserInterface/OWSCallNotificationsAdaptee.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
-		45E5471F1FD755E700DFC09E /* AttachmentApprovalViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttachmentApprovalViewController.swift; sourceTree = "<group>"; };
 		45E5A6981F61E6DD001E4A8A /* MarqueeLabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MarqueeLabel.swift; sourceTree = "<group>"; };
 		45E7A6A61E71CA7E00D44FB5 /* DisplayableTextFilterTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DisplayableTextFilterTest.swift; sourceTree = "<group>"; };
 		45F170AB1E2F0351003FC1F2 /* CallAudioSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CallAudioSession.swift; sourceTree = "<group>"; };
@@ -1274,15 +1276,19 @@
 		346129DB1FD5C02900532771 /* viewControllers */ = {
 			isa = PBXGroup;
 			children = (
+				344F2498200FD03200CFB4F4 /* AttachmentApprovalViewController.swift */,
 				344F248220069E9B00CFB4F4 /* CountryCodeViewController.h */,
 				344F248320069E9B00CFB4F4 /* CountryCodeViewController.m */,
 				346129DC1FD5C02900532771 /* LockInteractionController.h */,
 				346129DD1FD5C02900532771 /* LockInteractionController.m */,
+				344F2496200FD03200CFB4F4 /* MessageApprovalViewController.swift */,
 				344F248620069ECB00CFB4F4 /* ModalActivityIndicatorViewController.swift */,
 				344D6CE920069E070042AF96 /* NewNonContactConversationViewController.h */,
 				344D6CE820069E070042AF96 /* NewNonContactConversationViewController.m */,
 				344D6CE620069E060042AF96 /* SelectRecipientViewController.h */,
 				344D6CE720069E060042AF96 /* SelectRecipientViewController.m */,
+				344F2495200FD03200CFB4F4 /* SharingThreadPickerViewController.h */,
+				344F2497200FD03200CFB4F4 /* SharingThreadPickerViewController.m */,
 				344F248820069F0600CFB4F4 /* ViewControllerUtils.h */,
 				344F248920069F0600CFB4F4 /* ViewControllerUtils.m */,
 			);
@@ -1570,9 +1576,6 @@
 			children = (
 				34B3F8391E8DF1700035BE1A /* AttachmentSharing.h */,
 				34B3F83A1E8DF1700035BE1A /* AttachmentSharing.m */,
-				45E5471F1FD755E700DFC09E /* AttachmentApprovalViewController.swift */,
-				3400C7901EAF89CD008A8584 /* SharingThreadPickerViewController.h */,
-				3400C7911EAF89CD008A8584 /* SharingThreadPickerViewController.m */,
 				34533F161EA8D2070006114F /* OWSAudioAttachmentPlayer.h */,
 				34533F171EA8D2070006114F /* OWSAudioAttachmentPlayer.m */,
 				34D913491F62D4A500722898 /* SignalAttachment.swift */,
@@ -2057,7 +2060,6 @@
 				451F8A3C1FD71392005CB9DA /* UIUtil.h in Headers */,
 				346129D61FD20ADC00532771 /* UIViewController+OWS.h in Headers */,
 				451F8A401FD7145D005CB9DA /* OWSTableViewController.h in Headers */,
-				451F8A321FD70DFA005CB9DA /* SharingThreadPickerViewController.h in Headers */,
 				3461296F1FD1D74C00532771 /* Release.h in Headers */,
 				34612A061FD7238600532771 /* OWSContactsSyncing.h in Headers */,
 				34480B571FD0A7A400BC14EF /* OWSScrubbingLogFormatter.h in Headers */,
@@ -2092,6 +2094,7 @@
 				45194F901FD7200000333B2C /* ThreadUtil.h in Headers */,
 				346129CC1FD2072E00532771 /* NSAttributedString+OWS.h in Headers */,
 				346129FD1FD5F31400532771 /* OWS102MoveLoggingPreferenceToUserDefaults.h in Headers */,
+				344F2499200FD03300CFB4F4 /* SharingThreadPickerViewController.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2759,15 +2762,16 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				344F249B200FD03300CFB4F4 /* SharingThreadPickerViewController.m in Sources */,
 				45194F951FD7216600333B2C /* TSUnreadIndicatorInteraction.m in Sources */,
 				45BE4EA22012AD2000935E59 /* DisappearingTimerConfigurationView.swift in Sources */,
 				346129F71FD5F31400532771 /* OWS105AttachmentFilePaths.m in Sources */,
 				45194F931FD7215C00333B2C /* OWSContactOffersInteraction.m in Sources */,
+				344F249A200FD03300CFB4F4 /* MessageApprovalViewController.swift in Sources */,
 				450998681FD8C0FF00D89EB3 /* AttachmentSharing.m in Sources */,
 				347850711FDAEB17007B8332 /* OWSUserProfile.m in Sources */,
 				346129761FD1E0B500532771 /* WeakTimer.swift in Sources */,
 				346129F81FD5F31400532771 /* OWS100RemoveTSRecipientsMigration.m in Sources */,
-				45E547201FD755E700DFC09E /* AttachmentApprovalViewController.swift in Sources */,
 				346129B51FD1F7E800532771 /* OWSProfileManager.m in Sources */,
 				346129701FD1D74C00532771 /* Release.m in Sources */,
 				3478506C1FD9B78A007B8332 /* NoopNotificationsManager.swift in Sources */,
@@ -2779,6 +2783,7 @@
 				34480B671FD0AA9400BC14EF /* UIFont+OWS.m in Sources */,
 				346129E61FD5C0C600532771 /* OWSDatabaseMigrationRunner.m in Sources */,
 				346129AB1FD1F0EE00532771 /* OWSFormat.m in Sources */,
+				344F249C200FD03300CFB4F4 /* AttachmentApprovalViewController.swift in Sources */,
 				451F8A461FD715BA005CB9DA /* OWSGroupAvatarBuilder.m in Sources */,
 				347850591FD9972E007B8332 /* SwiftSingletons.swift in Sources */,
 				344F248720069ECB00CFB4F4 /* ModalActivityIndicatorViewController.swift in Sources */,
@@ -2833,7 +2838,6 @@
 				3461293C1FD1D46A00532771 /* OWSMath.m in Sources */,
 				451F8A391FD711D6005CB9DA /* ContactsViewHelper.m in Sources */,
 				346129AF1FD1F5D900532771 /* SystemContactsFetcher.swift in Sources */,
-				451F8A311FD70DE9005CB9DA /* SharingThreadPickerViewController.m in Sources */,
 				344F248B20069F0600CFB4F4 /* ViewControllerUtils.m in Sources */,
 				451F8A411FD714B8005CB9DA /* ContactTableViewCell.m in Sources */,
 				346129C81FD2072E00532771 /* NSAttributedString+OWS.m in Sources */,

--- a/Signal.xcodeproj/project.pbxproj
+++ b/Signal.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		2AE2882E4C2B96BFFF9EE27C /* Pods_SignalShareExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0F94C85CB0B235DA37F68ED0 /* Pods_SignalShareExtension.framework */; };
 		340B02BA1FA0D6C700F9CFEC /* ConversationViewItemTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 340B02B91FA0D6C700F9CFEC /* ConversationViewItemTest.m */; };
 		340CB2271EAC25820001CAA1 /* UpdateGroupViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 340CB2261EAC25820001CAA1 /* UpdateGroupViewController.m */; };
+		341F1BEE20111A5300111571 /* NSItemProvider+OWS.m in Sources */ = {isa = PBXBuildFile; fileRef = 341F1BEC20111A5200111571 /* NSItemProvider+OWS.m */; };
 		341F2C0F1F2B8AE700D07D6B /* DebugUIMisc.m in Sources */ = {isa = PBXBuildFile; fileRef = 341F2C0E1F2B8AE700D07D6B /* DebugUIMisc.m */; };
 		3430FE181F7751D4000EC51B /* GiphyAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3430FE171F7751D4000EC51B /* GiphyAPI.swift */; };
 		34330A5A1E7875FB00DF2FB9 /* fontawesome-webfont.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 34330A591E7875FB00DF2FB9 /* fontawesome-webfont.ttf */; };
@@ -482,6 +483,8 @@
 		340CB2251EAC25820001CAA1 /* UpdateGroupViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UpdateGroupViewController.h; sourceTree = "<group>"; };
 		340CB2261EAC25820001CAA1 /* UpdateGroupViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UpdateGroupViewController.m; sourceTree = "<group>"; };
 		341458471FBE11C4005ABCF9 /* fa */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fa; path = translations/fa.lproj/Localizable.strings; sourceTree = "<group>"; };
+		341F1BEC20111A5200111571 /* NSItemProvider+OWS.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSItemProvider+OWS.m"; sourceTree = "<group>"; };
+		341F1BED20111A5300111571 /* NSItemProvider+OWS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSItemProvider+OWS.h"; sourceTree = "<group>"; };
 		341F2C0D1F2B8AE700D07D6B /* DebugUIMisc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DebugUIMisc.h; sourceTree = "<group>"; };
 		341F2C0E1F2B8AE700D07D6B /* DebugUIMisc.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DebugUIMisc.m; sourceTree = "<group>"; };
 		3430FE171F7751D4000EC51B /* GiphyAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GiphyAPI.swift; sourceTree = "<group>"; };
@@ -1093,6 +1096,8 @@
 		34480B2F1FD0921000BC14EF /* utils */ = {
 			isa = PBXGroup;
 			children = (
+				341F1BED20111A5300111571 /* NSItemProvider+OWS.h */,
+				341F1BEC20111A5200111571 /* NSItemProvider+OWS.m */,
 				34480B341FD0929200BC14EF /* ShareAppExtensionContext.h */,
 				34480B351FD0929200BC14EF /* ShareAppExtensionContext.m */,
 			);
@@ -2751,6 +2756,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				341F1BEE20111A5300111571 /* NSItemProvider+OWS.m in Sources */,
 				4535186B1FC635DD00210559 /* ShareViewController.swift in Sources */,
 				34480B361FD0929200BC14EF /* ShareAppExtensionContext.m in Sources */,
 				3461284B1FD0B94000532771 /* SAELoadViewController.swift in Sources */,

--- a/Signal/src/ViewControllers/ConversationView/ConversationInputToolbar.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationInputToolbar.m
@@ -77,7 +77,7 @@ static const CGFloat ConversationInputToolbarBorderViewHeight = 0.5;
 {
     self.layoutMargins = UIEdgeInsetsZero;
 
-    self.backgroundColor = [UIColor ows_inputToolbarBackgroundColor];
+    self.backgroundColor = [UIColor ows_toolbarBackgroundColor];
     self.autoresizingMask = UIViewAutoresizingFlexibleHeight;
 
     UIView *borderView = [UIView new];

--- a/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
@@ -3893,7 +3893,6 @@ typedef NS_ENUM(NSInteger, MessagesRangeSizeMode) {
     //
     // We convert large text messages to attachments
     // which are presented as normal text messages.
-    const NSUInteger kOversizeTextMessageSizeThreshold = 16 * 1024;
     BOOL didAddToProfileWhitelist = [ThreadUtil addThreadToProfileWhitelistIfEmptyContactThread:self.thread];
     TSOutgoingMessage *message;
     if ([text lengthOfBytesUsingEncoding:NSUTF8StringEncoding] >= kOversizeTextMessageSizeThreshold) {

--- a/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
@@ -499,7 +499,7 @@ typedef NS_ENUM(NSInteger, MessagesRangeSizeMode) {
 {
     [super loadView];
 
-    self.view.backgroundColor = [UIColor ows_inputToolbarBackgroundColor];
+    self.view.backgroundColor = [UIColor ows_toolbarBackgroundColor];
 }
 
 - (void)createContents

--- a/Signal/src/ViewControllers/ConversationView/ConversationViewItem.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewItem.m
@@ -309,30 +309,7 @@ NSString *NSStringForOWSMessageCellType(OWSMessageCellType cellType)
     DisplayableText *_Nullable displayableText = [[self displayableTextCache] objectForKey:interactionId];
     if (!displayableText) {
         NSString *text = textBlock();
-
-        // Only show up to N characters of text.
-        const NSUInteger kMaxTextDisplayLength = 1024;
-        NSString *_Nullable fullText = [DisplayableText displayableText:text];
-        BOOL isTextTruncated = NO;
-        if (!fullText) {
-            fullText = @"";
-        }
-        NSString *_Nullable displayText = fullText;
-        if (displayText.length > kMaxTextDisplayLength) {
-            // Trim whitespace before _AND_ after slicing the snipper from the string.
-            NSString *snippet = [[displayText substringWithRange:NSMakeRange(0, kMaxTextDisplayLength)] ows_stripped];
-            displayText = [NSString stringWithFormat:NSLocalizedString(@"OVERSIZE_TEXT_DISPLAY_FORMAT",
-                                                         @"A display format for oversize text messages."),
-                                    snippet];
-            isTextTruncated = YES;
-        }
-        if (!displayText) {
-            displayText = @"";
-        }
-
-        displayableText =
-            [[DisplayableText alloc] initWithFullText:fullText displayText:displayText isTextTruncated:isTextTruncated];
-
+        displayableText = [DisplayableText displayableText:text];
         [[self displayableTextCache] setObject:displayableText forKey:interactionId];
     }
     return displayableText;

--- a/Signal/src/ViewControllers/InboxTableViewCell.m
+++ b/Signal/src/ViewControllers/InboxTableViewCell.m
@@ -1,5 +1,5 @@
 //
-//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//  Copyright (c) 2018 Open Whisper Systems. All rights reserved.
 //
 
 #import "InboxTableViewCell.h"
@@ -189,7 +189,7 @@ const NSUInteger kAvatarViewDiameter = 52;
                                                                                                 : [UIColor lightGrayColor]),
                                                               }]];
         }
-        NSString *displayableText = [DisplayableText displayableText:thread.lastMessageLabel];
+        NSString *displayableText = [DisplayableText filterText:thread.lastMessageLabel];
         if (displayableText) {
             [snippetText appendAttributedString:[[NSAttributedString alloc]
                                                     initWithString:displayableText

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -916,6 +916,12 @@
 /* media picker option to choose from library */
 "MEDIA_FROM_LIBRARY_BUTTON" = "Photo Library";
 
+/* Title for the 'message approval' dialog. */
+"MESSAGE_APPROVAL_DIALOG_TITLE" = "Message";
+
+/* Label for the recipient name in the 'message approval' dialog. */
+"MESSAGE_APPROVAL_RECIPIENT_LABEL" = "To:";
+
 /* No comment provided by engineer. */
 "MESSAGE_COMPOSEVIEW_TITLE" = "New Message";
 

--- a/SignalMessaging/Views/OWSFlatButton.swift
+++ b/SignalMessaging/Views/OWSFlatButton.swift
@@ -1,5 +1,5 @@
 //
-//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//  Copyright (c) 2018 Open Whisper Systems. All rights reserved.
 //
 
 import Foundation
@@ -51,7 +51,7 @@ public class OWSFlatButton: UIView {
                              backgroundColor: UIColor,
                              width: CGFloat,
                              height: CGFloat,
-                             target:Any,
+                             target: Any,
                              selector: Selector) -> OWSFlatButton {
         let button = OWSFlatButton()
         button.setTitle(title:title,
@@ -70,7 +70,7 @@ public class OWSFlatButton: UIView {
                              backgroundColor: UIColor,
                              width: CGFloat,
                              height: CGFloat,
-                             target:Any,
+                             target: Any,
                              selector: Selector) -> OWSFlatButton {
         return OWSFlatButton.button(title:title,
                                     font:fontForHeight(height),
@@ -87,7 +87,7 @@ public class OWSFlatButton: UIView {
                              font: UIFont,
                              titleColor: UIColor,
                              backgroundColor: UIColor,
-                             target:Any,
+                             target: Any,
                              selector: Selector) -> OWSFlatButton {
         let button = OWSFlatButton()
         button.setTitle(title:title,
@@ -104,7 +104,7 @@ public class OWSFlatButton: UIView {
         // Cap the "button height" at 40pt or button text can look
         // excessively large.
         let fontPointSize = round(min(40, height) * 0.45)
-        return UIFont.ows_mediumFont(withSize:fontPointSize)!
+        return UIFont.ows_mediumFont(withSize:fontPointSize)
     }
 
     // MARK: Methods
@@ -150,7 +150,7 @@ public class OWSFlatButton: UIView {
     }
 
     @objc
-    public func addTarget(target:Any,
+    public func addTarget(target: Any,
                           selector: Selector) {
         button.addTarget(target, action:selector, for:.touchUpInside)
     }

--- a/SignalMessaging/attachments/AttachmentApprovalViewController.swift
+++ b/SignalMessaging/attachments/AttachmentApprovalViewController.swift
@@ -130,8 +130,8 @@ public class AttachmentApprovalViewController: OWSViewController, CaptioningTool
         scrollView.autoPinEdgesToSuperviewEdges()
 
         let defaultCaption = self.defaultCaption()
-        let isUrlShare = defaultCaption != nil
-        let backgroundColor = isUrlShare ? UIColor.ows_signalBrandBlue : UIColor.black
+        let isTextualShare = defaultCaption != nil
+        let backgroundColor = isTextualShare ? UIColor.ows_signalBrandBlue : UIColor.black
         self.view.backgroundColor = backgroundColor
 
         // Create full screen container view so the scrollView
@@ -237,12 +237,12 @@ public class AttachmentApprovalViewController: OWSViewController, CaptioningTool
     }
 
     private func defaultCaption() -> String? {
-        guard self.attachment.isUrl else {
+        guard self.attachment.isUrl || self.attachment.isText else {
             return nil
         }
         let data = self.attachment.data
         guard let messageText = String(data: data, encoding: String.Encoding.utf8) else {
-            Logger.error("\(self.logTag) Couldn't load url strubg")
+            Logger.error("\(self.logTag) Couldn't load url or text string")
             return nil
         }
         return messageText

--- a/SignalMessaging/attachments/AttachmentApprovalViewController.swift
+++ b/SignalMessaging/attachments/AttachmentApprovalViewController.swift
@@ -168,7 +168,9 @@ public class AttachmentApprovalViewController: OWSViewController, CaptioningTool
         topToolbar.items = [cancelButton]
 
         // Bottom Toolbar
-        let captioningToolbar = CaptioningToolbar()
+        //
+        // Don't add a caption to text messages.
+        let captioningToolbar = CaptioningToolbar(allowCaptions:!self.attachment.isOversizeText)
         captioningToolbar.captioningToolbarDelegate = self
         self.bottomToolbar = captioningToolbar
 
@@ -557,6 +559,7 @@ class CaptioningToolbar: UIView, UITextViewDelegate {
     private let sendButton: UIButton
     private let textView: UITextView
     private let bottomGradient: GradientView
+    private let allowCaptions: Bool
 
     // Layout Constants
     var maxTextViewHeight: CGFloat {
@@ -587,11 +590,12 @@ class CaptioningToolbar: UIView, UITextViewDelegate {
     }
 
     let kSendButtonShadowOffset: CGFloat = 1
-    init() {
+    init(allowCaptions: Bool) {
         self.sendButton = UIButton(type: .system)
         self.bottomGradient = GradientView(from: UIColor.clear, to: UIColor.black)
         self.textView =  MessageTextView()
         self.textViewHeight = kMinTextViewHeight
+        self.allowCaptions = allowCaptions
 
         super.init(frame: CGRect.zero)
 
@@ -603,6 +607,9 @@ class CaptioningToolbar: UIView, UITextViewDelegate {
         textView.addBorder(with: UIColor.lightGray)
         textView.font = UIFont.ows_dynamicTypeBody()
         textView.returnKeyType = .done
+        if !allowCaptions {
+            textView.isHidden = true
+        }
 
         let sendTitle = NSLocalizedString("ATTACHMENT_APPROVAL_SEND_BUTTON", comment: "Label for 'send' button in the 'attachment approval' dialog.")
         sendButton.setTitle(sendTitle, for: .normal)

--- a/SignalMessaging/attachments/AttachmentApprovalViewController.swift
+++ b/SignalMessaging/attachments/AttachmentApprovalViewController.swift
@@ -129,9 +129,7 @@ public class AttachmentApprovalViewController: OWSViewController, CaptioningTool
 
         scrollView.autoPinEdgesToSuperviewEdges()
 
-        let defaultCaption = self.defaultCaption()
-        let isTextualShare = defaultCaption != nil
-        let backgroundColor = isTextualShare ? UIColor.ows_signalBrandBlue : UIColor.black
+        let backgroundColor = UIColor.black
         self.view.backgroundColor = backgroundColor
 
         // Create full screen container view so the scrollView
@@ -170,7 +168,7 @@ public class AttachmentApprovalViewController: OWSViewController, CaptioningTool
         topToolbar.items = [cancelButton]
 
         // Bottom Toolbar
-        let captioningToolbar = CaptioningToolbar(defaultCaption:defaultCaption)
+        let captioningToolbar = CaptioningToolbar()
         captioningToolbar.captioningToolbarDelegate = self
         self.bottomToolbar = captioningToolbar
 
@@ -234,18 +232,6 @@ public class AttachmentApprovalViewController: OWSViewController, CaptioningTool
     public func didTapPlayerView(_ gestureRecognizer: UIGestureRecognizer) {
         assert(self.videoPlayer != nil)
         self.pauseVideo()
-    }
-
-    private func defaultCaption() -> String? {
-        guard self.attachment.isUrl || self.attachment.isText else {
-            return nil
-        }
-        let data = self.attachment.data
-        guard let messageText = String(data: data, encoding: String.Encoding.utf8) else {
-            Logger.error("\(self.logTag) Couldn't load url or text string")
-            return nil
-        }
-        return messageText
     }
 
     override public var inputAccessoryView: UIView? {
@@ -601,7 +587,7 @@ class CaptioningToolbar: UIView, UITextViewDelegate {
     }
 
     let kSendButtonShadowOffset: CGFloat = 1
-    init(defaultCaption: String?) {
+    init() {
         self.sendButton = UIButton(type: .system)
         self.bottomGradient = GradientView(from: UIColor.clear, to: UIColor.black)
         self.textView =  MessageTextView()
@@ -617,9 +603,6 @@ class CaptioningToolbar: UIView, UITextViewDelegate {
         textView.addBorder(with: UIColor.lightGray)
         textView.font = UIFont.ows_dynamicTypeBody()
         textView.returnKeyType = .done
-        if let defaultCaption = defaultCaption {
-            textView.text = defaultCaption
-        }
 
         let sendTitle = NSLocalizedString("ATTACHMENT_APPROVAL_SEND_BUTTON", comment: "Label for 'send' button in the 'attachment approval' dialog.")
         sendButton.setTitle(sendTitle, for: .normal)

--- a/SignalMessaging/attachments/MediaMessageView.swift
+++ b/SignalMessaging/attachments/MediaMessageView.swift
@@ -343,13 +343,6 @@ public class MediaMessageView: UIView, OWSAudioAttachmentPlayerDelegate {
     }
 
     private func createUrlPreview() {
-
-        let data = attachment.data
-        guard let messageText = String(data: data, encoding: String.Encoding.utf8) else {
-            createGenericPreview()
-            return
-        }
-
         // Show nothing; URLs should only appear in the attachment approval view
         // of the SAE and in this context the URL will be placed in the caption field.
     }

--- a/SignalMessaging/attachments/MediaMessageView.swift
+++ b/SignalMessaging/attachments/MediaMessageView.swift
@@ -110,6 +110,8 @@ public class MediaMessageView: UIView, OWSAudioAttachmentPlayerDelegate {
             createVideoPreview()
         } else if attachment.isAudio {
             createAudioPreview()
+        } else if attachment.isOversizeText {
+            createTextPreview()
         } else {
             createGenericPreview()
         }
@@ -284,6 +286,43 @@ public class MediaMessageView: UIView, OWSAudioAttachmentPlayerDelegate {
             imageView.isUserInteractionEnabled = true
             imageView.addGestureRecognizer(UITapGestureRecognizer(target:self, action:#selector(videoTapped)))
         }
+    }
+
+    private func createTextPreview() {
+
+        let data = attachment.data
+        guard let messageText = String(data: data, encoding: String.Encoding.utf8) else {
+            createGenericPreview()
+            return
+        }
+
+        let messageTextView = UITextView()
+        messageTextView.font = UIFont.ows_dynamicTypeBody()
+//        messageTextView.backgroundColor = UIColor.clear
+        messageTextView.backgroundColor = UIColor.white
+        messageTextView.isOpaque = false
+        messageTextView.isEditable = false
+        messageTextView.isSelectable = true
+        messageTextView.textContainerInset = UIEdgeInsets.zero
+        messageTextView.contentInset = UIEdgeInsets.zero
+        messageTextView.isScrollEnabled = true
+        messageTextView.showsHorizontalScrollIndicator = false
+        messageTextView.showsVerticalScrollIndicator = false
+        messageTextView.isUserInteractionEnabled = false
+//        messageTextView.textColor = isIncoming ? UIColor.black : UIColor.white
+        messageTextView.textColor = UIColor.black
+        messageTextView.text = messageText
+
+        self.addSubview(messageTextView)
+        messageTextView.autoPinWidthToSuperview()
+        messageTextView.autoVCenterInSuperview()
+
+        // TODO: How should text messages be displayed in this view?
+        NSLayoutConstraint.autoSetPriority(UILayoutPriorityDefaultLow) {
+            messageTextView.autoPinHeightToSuperview()
+        }
+        messageTextView.autoPinEdge(toSuperviewEdge: .top, withInset: 0, relation: .greaterThanOrEqual)
+        messageTextView.autoPinEdge(toSuperviewEdge: .bottom, withInset: 0, relation: .greaterThanOrEqual)
     }
 
     private func createGenericPreview() {

--- a/SignalMessaging/attachments/MediaMessageView.swift
+++ b/SignalMessaging/attachments/MediaMessageView.swift
@@ -112,6 +112,8 @@ public class MediaMessageView: UIView, OWSAudioAttachmentPlayerDelegate {
             createAudioPreview()
         } else if attachment.isOversizeText {
             createTextPreview()
+        } else if attachment.isUrl {
+            createUrlPreview()
         } else {
             createGenericPreview()
         }
@@ -306,7 +308,7 @@ public class MediaMessageView: UIView, OWSAudioAttachmentPlayerDelegate {
 
         let messageTextView = UITextView()
         messageTextView.font = UIFont.ows_dynamicTypeBody()
-                messageTextView.backgroundColor = UIColor.clear
+        messageTextView.backgroundColor = UIColor.clear
         messageTextView.isOpaque = false
         messageTextView.isEditable = false
         messageTextView.isSelectable = false
@@ -320,7 +322,7 @@ public class MediaMessageView: UIView, OWSAudioAttachmentPlayerDelegate {
         messageTextView.linkTextAttributes = [NSForegroundColorAttributeName : textColor,
                                               NSUnderlineStyleAttributeName : [NSUnderlineStyle.styleSingle,
                                                                                NSUnderlineStyle.patternSolid]
-                                              ]
+        ]
         messageTextView.dataDetectorTypes = [.link, .address, .calendarEvent]
         messageTextView.text = messageText
 
@@ -338,6 +340,18 @@ public class MediaMessageView: UIView, OWSAudioAttachmentPlayerDelegate {
         messageTextView.autoPinBottomToSuperview(withMargin:10)
         messageTextView.autoPinLeadingToSuperview(withMargin:10)
         messageTextView.autoPinTrailingToSuperview(withMargin:15)
+    }
+
+    private func createUrlPreview() {
+
+        let data = attachment.data
+        guard let messageText = String(data: data, encoding: String.Encoding.utf8) else {
+            createGenericPreview()
+            return
+        }
+
+        // Show nothing; URLs should only appear in the attachment approval view
+        // of the SAE and in this context the URL will be placed in the caption field.
     }
 
     private func createGenericPreview() {

--- a/SignalMessaging/attachments/MediaMessageView.swift
+++ b/SignalMessaging/attachments/MediaMessageView.swift
@@ -110,10 +110,11 @@ public class MediaMessageView: UIView, OWSAudioAttachmentPlayerDelegate {
             createVideoPreview()
         } else if attachment.isAudio {
             createAudioPreview()
+            // We handle the isOversizeText case before isText.
         } else if attachment.isOversizeText {
+            createOversizeTextPreview()
+        } else if attachment.isUrl || attachment.isText {
             createTextPreview()
-        } else if attachment.isUrl {
-            createUrlPreview()
         } else {
             createGenericPreview()
         }
@@ -290,7 +291,7 @@ public class MediaMessageView: UIView, OWSAudioAttachmentPlayerDelegate {
         }
     }
 
-    private func createTextPreview() {
+    private func createOversizeTextPreview() {
 
         let data = attachment.data
         guard let messageText = String(data: data, encoding: String.Encoding.utf8) else {
@@ -342,7 +343,7 @@ public class MediaMessageView: UIView, OWSAudioAttachmentPlayerDelegate {
         messageTextView.autoPinTrailingToSuperview(withMargin:15)
     }
 
-    private func createUrlPreview() {
+    private func createTextPreview() {
         // Show nothing; URLs should only appear in the attachment approval view
         // of the SAE and in this context the URL will be placed in the caption field.
     }

--- a/SignalMessaging/attachments/MediaMessageView.swift
+++ b/SignalMessaging/attachments/MediaMessageView.swift
@@ -296,33 +296,48 @@ public class MediaMessageView: UIView, OWSAudioAttachmentPlayerDelegate {
             return
         }
 
+        let messageBubbleView = UIImageView()
+        messageBubbleView.layoutMargins = .zero
+        let bubbleImageData =
+            OWSMessagesBubbleImageFactory.shared.outgoing
+        messageBubbleView.image = bubbleImageData.messageBubbleImage
+
+        let textColor = UIColor.white
+
         let messageTextView = UITextView()
         messageTextView.font = UIFont.ows_dynamicTypeBody()
-//        messageTextView.backgroundColor = UIColor.clear
-        messageTextView.backgroundColor = UIColor.white
+                messageTextView.backgroundColor = UIColor.clear
         messageTextView.isOpaque = false
         messageTextView.isEditable = false
-        messageTextView.isSelectable = true
+        messageTextView.isSelectable = false
         messageTextView.textContainerInset = UIEdgeInsets.zero
         messageTextView.contentInset = UIEdgeInsets.zero
-        messageTextView.isScrollEnabled = true
+        messageTextView.isScrollEnabled = false
         messageTextView.showsHorizontalScrollIndicator = false
         messageTextView.showsVerticalScrollIndicator = false
         messageTextView.isUserInteractionEnabled = false
-//        messageTextView.textColor = isIncoming ? UIColor.black : UIColor.white
-        messageTextView.textColor = UIColor.black
+        messageTextView.textColor = textColor
+        messageTextView.linkTextAttributes = [NSForegroundColorAttributeName : textColor,
+                                              NSUnderlineStyleAttributeName : [NSUnderlineStyle.styleSingle,
+                                                                               NSUnderlineStyle.patternSolid]
+                                              ]
+        messageTextView.dataDetectorTypes = [.link, .address, .calendarEvent]
         messageTextView.text = messageText
 
-        self.addSubview(messageTextView)
-        messageTextView.autoPinWidthToSuperview()
-        messageTextView.autoVCenterInSuperview()
+        messageBubbleView.layoutMargins = .zero
+        self.layoutMargins = .zero
 
-        // TODO: How should text messages be displayed in this view?
-        NSLayoutConstraint.autoSetPriority(UILayoutPriorityDefaultLow) {
-            messageTextView.autoPinHeightToSuperview()
-        }
-        messageTextView.autoPinEdge(toSuperviewEdge: .top, withInset: 0, relation: .greaterThanOrEqual)
-        messageTextView.autoPinEdge(toSuperviewEdge: .bottom, withInset: 0, relation: .greaterThanOrEqual)
+        self.addSubview(messageBubbleView)
+        messageBubbleView.autoVCenterInSuperview()
+        messageBubbleView.autoHCenterInSuperview()
+        messageBubbleView.autoPinEdge(toSuperviewEdge: .leading, withInset: 25, relation: .greaterThanOrEqual)
+        messageBubbleView.autoPinEdge(toSuperviewEdge: .trailing, withInset: 25, relation: .greaterThanOrEqual)
+
+        messageBubbleView.addSubview(messageTextView)
+        messageTextView.autoPinTopToSuperview(withMargin:10)
+        messageTextView.autoPinBottomToSuperview(withMargin:10)
+        messageTextView.autoPinLeadingToSuperview(withMargin:10)
+        messageTextView.autoPinTrailingToSuperview(withMargin:15)
     }
 
     private func createGenericPreview() {

--- a/SignalMessaging/attachments/MediaMessageView.swift
+++ b/SignalMessaging/attachments/MediaMessageView.swift
@@ -110,11 +110,6 @@ public class MediaMessageView: UIView, OWSAudioAttachmentPlayerDelegate {
             createVideoPreview()
         } else if attachment.isAudio {
             createAudioPreview()
-            // We handle the isOversizeText case before isText.
-        } else if attachment.isOversizeText {
-            createOversizeTextPreview()
-        } else if attachment.isUrl || attachment.isText {
-            createTextPreview()
         } else {
             createGenericPreview()
         }
@@ -289,63 +284,6 @@ public class MediaMessageView: UIView, OWSAudioAttachmentPlayerDelegate {
             imageView.isUserInteractionEnabled = true
             imageView.addGestureRecognizer(UITapGestureRecognizer(target:self, action:#selector(videoTapped)))
         }
-    }
-
-    private func createOversizeTextPreview() {
-
-        let data = attachment.data
-        guard let messageText = String(data: data, encoding: String.Encoding.utf8) else {
-            createGenericPreview()
-            return
-        }
-
-        let messageBubbleView = UIImageView()
-        messageBubbleView.layoutMargins = .zero
-        let bubbleImageData =
-            OWSMessagesBubbleImageFactory.shared.outgoing
-        messageBubbleView.image = bubbleImageData.messageBubbleImage
-
-        let textColor = UIColor.white
-
-        let messageTextView = UITextView()
-        messageTextView.font = UIFont.ows_dynamicTypeBody()
-        messageTextView.backgroundColor = UIColor.clear
-        messageTextView.isOpaque = false
-        messageTextView.isEditable = false
-        messageTextView.isSelectable = false
-        messageTextView.textContainerInset = UIEdgeInsets.zero
-        messageTextView.contentInset = UIEdgeInsets.zero
-        messageTextView.isScrollEnabled = false
-        messageTextView.showsHorizontalScrollIndicator = false
-        messageTextView.showsVerticalScrollIndicator = false
-        messageTextView.isUserInteractionEnabled = false
-        messageTextView.textColor = textColor
-        messageTextView.linkTextAttributes = [NSForegroundColorAttributeName : textColor,
-                                              NSUnderlineStyleAttributeName : [NSUnderlineStyle.styleSingle,
-                                                                               NSUnderlineStyle.patternSolid]
-        ]
-        messageTextView.dataDetectorTypes = [.link, .address, .calendarEvent]
-        messageTextView.text = messageText
-
-        messageBubbleView.layoutMargins = .zero
-        self.layoutMargins = .zero
-
-        self.addSubview(messageBubbleView)
-        messageBubbleView.autoVCenterInSuperview()
-        messageBubbleView.autoHCenterInSuperview()
-        messageBubbleView.autoPinEdge(toSuperviewEdge: .leading, withInset: 25, relation: .greaterThanOrEqual)
-        messageBubbleView.autoPinEdge(toSuperviewEdge: .trailing, withInset: 25, relation: .greaterThanOrEqual)
-
-        messageBubbleView.addSubview(messageTextView)
-        messageTextView.autoPinTopToSuperview(withMargin:10)
-        messageTextView.autoPinBottomToSuperview(withMargin:10)
-        messageTextView.autoPinLeadingToSuperview(withMargin:10)
-        messageTextView.autoPinTrailingToSuperview(withMargin:15)
-    }
-
-    private func createTextPreview() {
-        // Show nothing; URLs should only appear in the attachment approval view
-        // of the SAE and in this context the URL will be placed in the caption field.
     }
 
     private func createGenericPreview() {

--- a/SignalMessaging/attachments/MessageApprovalViewController.swift
+++ b/SignalMessaging/attachments/MessageApprovalViewController.swift
@@ -164,10 +164,6 @@ public class MessageApprovalViewController: OWSViewController, UITextViewDelegat
         nameLabel.setCompressionResistanceHorizontalLow()
         nameLabel.autoPinTopToSuperview(withMargin: vMargin)
 
-        recipientRow.logFrameLater(withLabel: "recipientRow")
-        toLabel.logFrameLater(withLabel: "toLabel")
-        nameLabel.logFrameLater(withLabel: "nameLabel")
-
         if let groupThread = self.thread as? TSGroupThread {
             let groupName = (groupThread.name().count > 0
             ? groupThread.name()

--- a/SignalMessaging/attachments/MessageApprovalViewController.swift
+++ b/SignalMessaging/attachments/MessageApprovalViewController.swift
@@ -3,7 +3,6 @@
 //
 
 import Foundation
-//import MediaPlayer
 
 @objc
 public protocol MessageApprovalViewControllerDelegate: class {
@@ -12,26 +11,17 @@ public protocol MessageApprovalViewControllerDelegate: class {
 }
 
 @objc
-public class MessageApprovalViewController: OWSViewController {
+public class MessageApprovalViewController: OWSViewController, UITextViewDelegate {
 
     let TAG = "[MessageApprovalViewController]"
     weak var delegate: MessageApprovalViewControllerDelegate?
 
-//    // We sometimes shrink the attachment view so that it remains somewhat visible
-//    // when the keyboard is presented.
-//    enum AttachmentViewScale {
-//        case fullsize, compact
-//    }
-
     // MARK: Properties
 
-//    let attachment: SignalAttachment
     let initialMessageText: String
 
-//    private(set) var bottomToolbar: UIView!
-//    private(set) var mediaMessageView: MediaMessageView!
-//    private(set) var scrollView: UIScrollView!
     private(set) var textView: UITextView!
+    private(set) var topToolbar: UIToolbar!
 
     // MARK: Initializers
 
@@ -56,517 +46,70 @@ public class MessageApprovalViewController: OWSViewController {
                                                       comment: "Title for the 'message approval' dialog.")
     }
 
-//    override public func viewWillLayoutSubviews() {
-//        Logger.debug("\(logTag) in \(#function)")
-//        super.viewWillLayoutSubviews()
-//
-//        // e.g. if flipping to/from landscape
-//        updateMinZoomScaleForSize(view.bounds.size)
-//    }
+    private func updateToolbar() {
+        var items = [UIBarButtonItem]()
 
-//    private func dialogTitle() -> String {
-//        guard let filename = mediaMessageView.formattedFileName() else {
-//            return NSLocalizedString("ATTACHMENT_APPROVAL_DIALOG_TITLE",
-//                                     comment: "Title for the 'attachment approval' dialog.")
-//        }
-//        return filename
-//    }
+        let cancelButton = UIBarButtonItem(barButtonSystemItem: .stop, target: self, action: #selector(cancelPressed))
+        items.append(cancelButton)
 
-//    override public func viewWillAppear(_ animated: Bool) {
-//        Logger.debug("\(logTag) in \(#function)")
-//        super.viewWillAppear(animated)
-//
-//        mediaMessageView.viewWillAppear(animated)
-//    }
-//
-//    override public func viewDidAppear(_ animated: Bool) {
-//        Logger.debug("\(logTag) in \(#function)")
-//        super.viewDidAppear(animated)
-//    }
-//
-//    override public func viewWillDisappear(_ animated: Bool) {
-//        Logger.debug("\(logTag) in \(#function)")
-//        super.viewWillDisappear(animated)
-//
-//        mediaMessageView.viewWillDisappear(animated)
-//    }
+        if textView.text.count > 0 {
+            let spacer = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+            items.append(spacer)
+            let sendButton = UIBarButtonItem(title: NSLocalizedString("SEND_BUTTON_TITLE",
+                                                                      comment:"Label for the send button in the conversation view."),
+                                             style:.plain,
+                                             target: self,
+                                             action: #selector(sendPressed))
+            items.append(sendButton)
+        }
+
+        topToolbar.items = items
+    }
 
     // MARK: - Create Views
 
     public override func loadView() {
 
         self.view = UIView()
+        self.view.backgroundColor = UIColor.white
 
-//        self.mediaMessageView = MediaMessageView(attachment: attachment, mode: .messageApproval)
+        // Top Toolbar
+        topToolbar = UIToolbar()
+        topToolbar.backgroundColor = UIColor.ows_inputToolbarBackground
+        self.view.addSubview(topToolbar)
+        topToolbar.autoPinWidthToSuperview()
+        topToolbar.autoPin(toTopLayoutGuideOf: self, withInset: 0)
+        topToolbar.setContentHuggingVerticalHigh()
+        topToolbar.setCompressionResistanceVerticalHigh()
 
+        // Text View
         textView = UITextView()
+        textView.delegate = self
+        textView.backgroundColor = UIColor.white
+        textView.textColor = UIColor.black
+        textView.font = UIFont.ows_dynamicTypeBody()
+        textView.text = self.initialMessageText
         view.addSubview(textView)
-        textView.autoPinEdgesToSuperviewEdges()
+        textView.autoPinWidthToSuperview()
+        textView.autoPinEdge(.top, to: .bottom, of: topToolbar)
+        textView.autoPin(toBottomLayoutGuideOf: self, withInset: 0)
 
-//        // Scroll View - used to zoom/pan on images and video
-//        scrollView = UIScrollView()
-//        view.addSubview(scrollView)
-//
-//        scrollView.delegate = self
-//        scrollView.showsHorizontalScrollIndicator = false
-//        scrollView.showsVerticalScrollIndicator = false
-//
-//        // Panning should stop pretty soon after the user stops scrolling
-//        scrollView.decelerationRate = UIScrollViewDecelerationRateFast
-//
-//        // We want scroll view content up and behind the system status bar content
-//        // but we want other content (e.g. bar buttons) to respect the top layout guide.
-//        self.automaticallyAdjustsScrollViewInsets = false
-//
-//        scrollView.autoPinEdgesToSuperviewEdges()
-//
-//        let defaultCaption = self.defaultCaption()
-//        let isTextualShare = defaultCaption != nil
-//        let backgroundColor = isTextualShare ? UIColor.ows_signalBrandBlue : UIColor.black
-//        self.view.backgroundColor = backgroundColor
-//
-//        // Create full screen container view so the scrollView
-//        // can compute an appropriate content size in which to center
-//        // our media view.
-//        let containerView = UIView.container()
-//        scrollView.addSubview(containerView)
-//        containerView.autoPinEdgesToSuperviewEdges()
-//        containerView.autoMatch(.height, to: .height, of: self.view)
-//        containerView.autoMatch(.width, to: .width, of: self.view)
-//
-//        containerView.addSubview(mediaMessageView)
-//        mediaMessageView.autoPinEdgesToSuperviewEdges()
-//
-//        if isZoomable {
-//            // Add top and bottom gradients to ensure toolbar controls are legible
-//            // when placed over image/video preview which may be a clashing color.
-//            let topGradient = GradientView(from: backgroundColor, to: UIColor.clear)
-//            self.view.addSubview(topGradient)
-//            topGradient.autoPinWidthToSuperview()
-//            topGradient.autoPinEdge(toSuperviewEdge: .top)
-//            topGradient.autoSetDimension(.height, toSize: ScaleFromIPhone5(60))
-//        }
-//
-//        // Hide the play button embedded in the MediaView and replace it with our own.
-//        // This allows us to zoom in on the media view without zooming in on the button
-//        if attachment.isVideo {
-//            self.mediaMessageView.videoPlayButton?.isHidden = true
-//            let playButton = UIButton()
-//            playButton.accessibilityLabel = NSLocalizedString("PLAY_BUTTON_ACCESSABILITY_LABEL", comment: "accessability label for button to start media playback")
-//            playButton.setBackgroundImage(#imageLiteral(resourceName: "play_button"), for: .normal)
-//            playButton.contentMode = .scaleAspectFit
-//
-//            let playButtonWidth = ScaleFromIPhone5(70)
-//            playButton.autoSetDimensions(to: CGSize(width: playButtonWidth, height: playButtonWidth))
-//            self.view.addSubview(playButton)
-//
-//            playButton.addTarget(self, action: #selector(playButtonTapped), for: .touchUpInside)
-//            playButton.autoCenterInSuperview()
-//        }
-//
-//        // Top Toolbar
-//        let topToolbar = makeClearToolbar()
-//
-//        self.view.addSubview(topToolbar)
-//        topToolbar.autoPinWidthToSuperview()
-//        topToolbar.autoPin(toTopLayoutGuideOf: self, withInset: 0)
-//        topToolbar.setContentHuggingVerticalHigh()
-//        topToolbar.setCompressionResistanceVerticalHigh()
-//
-//        let cancelButton = UIBarButtonItem(barButtonSystemItem: .stop, target: self, action: #selector(cancelPressed))
-//        cancelButton.tintColor = UIColor.white
-//        topToolbar.items = [cancelButton]
-//
-//        // Bottom Toolbar
-//        let captioningToolbar = CaptioningToolbar(defaultCaption:defaultCaption)
-//        captioningToolbar.captioningToolbarDelegate = self
-//        self.bottomToolbar = captioningToolbar
+        updateToolbar()
     }
-
-//    private func defaultCaption() -> String? {
-//        guard self.attachment.isUrl || self.attachment.isText else {
-//            return nil
-//        }
-//        let data = self.attachment.data
-//        guard let messageText = String(data: data, encoding: String.Encoding.utf8) else {
-//            Logger.error("\(self.logTag) Couldn't load url or text string")
-//            return nil
-//        }
-//        return messageText
-//    }
-
-//    override public var inputAccessoryView: UIView? {
-//        self.bottomToolbar.layoutIfNeeded()
-//        return self.bottomToolbar
-//    }
-
-//    override public var canBecomeFirstResponder: Bool {
-//        return true
-//    }
-
-//    private func makeClearToolbar() -> UIToolbar {
-//        let toolbar = UIToolbar()
-//
-//        toolbar.backgroundColor = UIColor.clear
-//
-//        // Making a toolbar transparent requires setting an empty uiimage
-//        toolbar.setBackgroundImage(UIImage(), forToolbarPosition: .any, barMetrics: .default)
-//
-//        // hide 1px top-border
-//        toolbar.clipsToBounds = true
-//
-//        return toolbar
-//    }
 
     // MARK: - Event Handlers
 
-//    @objc
-//    public func playButtonTapped() {
-//        mediaMessageView.playVideo()
-//    }
-
     func cancelPressed(sender: UIButton) {
-        self.delegate?.messageApprovalDidCancel(self)
+        delegate?.messageApprovalDidCancel(self)
     }
 
-//    // MARK: CaptioningToolbarDelegate
-//
-//    func captioningToolbarDidBeginEditing(_ captioningToolbar: CaptioningToolbar) {
-//        self.scaleAttachmentView(.compact)
-//    }
-//
-//    func captioningToolbarDidEndEditing(_ captioningToolbar: CaptioningToolbar) {
-//        self.scaleAttachmentView(.fullsize)
-//    }
-//
-//    func captioningToolbarDidTapSend(_ captioningToolbar: CaptioningToolbar, captionText: String?) {
-//        self.approveAttachment(captionText: captionText)
-//    }
-//
-//    func captioningToolbar(_ captioningToolbar: CaptioningToolbar, didChangeTextViewHeight newHeight: CGFloat) {
-//        Logger.info("Changed height: \(newHeight)")
-//    }
+    func sendPressed(sender: UIButton) {
+        delegate?.messageApproval(self, didApproveMessage: self.textView.text)
+    }
 
-    // MARK: Helpers
+    // MARK: - UITextViewDelegate
 
-//    var isZoomable: Bool {
-//        return attachment.isImage || attachment.isVideo
-//    }
-//
-//    private func approveAttachment(captionText: String?) {
-//        // Toolbar flickers in and out if there are errors
-//        // and remains visible momentarily after share extension is dismissed.
-//        // It's easiest to just hide it at this point since we're done with it.
-//        shouldAllowAttachmentViewResizing = false
-//        bottomToolbar.isUserInteractionEnabled = false
-//        bottomToolbar.isHidden = true
-//
-//        attachment.captionText = captionText
-//        delegate?.messageApproval(self, didApproveAttachment: attachment)
-//    }
-//
-//    // When the keyboard is popped, it can obscure the attachment view.
-//    // so we sometimes allow resizing the attachment.
-//    private var shouldAllowAttachmentViewResizing: Bool = true
-//
-//    private func scaleAttachmentView(_ fit: AttachmentViewScale) {
-//        guard shouldAllowAttachmentViewResizing else {
-//            if self.scrollView.transform != CGAffineTransform.identity {
-//                UIView.animate(withDuration: 0.2) {
-//                    self.scrollView.transform = CGAffineTransform.identity
-//                }
-//            }
-//            return
-//        }
-//
-//        switch fit {
-//        case .fullsize:
-//            UIView.animate(withDuration: 0.2) {
-//                self.scrollView.transform = CGAffineTransform.identity
-//            }
-//        case .compact:
-//            UIView.animate(withDuration: 0.2) {
-//                let kScaleFactor: CGFloat = 0.7
-//                let scale = CGAffineTransform(scaleX: kScaleFactor, y: kScaleFactor)
-//
-//                let originalHeight = self.scrollView.bounds.size.height
-//
-//                // Position the new scaled item to be centered with respect
-//                // to it's new size.
-//                let heightDelta = originalHeight * (1 - kScaleFactor)
-//                let translate = CGAffineTransform(translationX: 0, y: -heightDelta / 2)
-//
-//                self.scrollView.transform = scale.concatenating(translate)
-//            }
-//        }
-//    }
+    public func textViewDidChange(_ textView: UITextView) {
+        updateToolbar()
+    }
 }
-
-//extension MessageApprovalViewController: UIScrollViewDelegate {
-//
-//    public func viewForZooming(in scrollView: UIScrollView) -> UIView? {
-//        if isZoomable {
-//            return mediaMessageView
-//        } else {
-//            // don't zoom for audio or generic attachments.
-//            return nil
-//        }
-//    }
-//
-//    fileprivate func updateMinZoomScaleForSize(_ size: CGSize) {
-//        Logger.debug("\(logTag) in \(#function)")
-//
-//        // Ensure bounds have been computed
-//        mediaMessageView.layoutIfNeeded()
-//        guard mediaMessageView.bounds.width > 0, mediaMessageView.bounds.height > 0 else {
-//            Logger.warn("\(logTag) bad bounds in \(#function)")
-//            return
-//        }
-//
-//        let widthScale = size.width / mediaMessageView.bounds.width
-//        let heightScale = size.height / mediaMessageView.bounds.height
-//        let minScale = min(widthScale, heightScale)
-//        scrollView.maximumZoomScale = minScale * 5.0
-//        scrollView.minimumZoomScale = minScale
-//        scrollView.zoomScale = minScale
-//    }
-//
-//    // Keep the media view centered within the scroll view as you zoom
-//    public func scrollViewDidZoom(_ scrollView: UIScrollView) {
-//        // The scroll view has zoomed, so you need to re-center the contents
-//        let scrollViewSize = self.scrollViewVisibleSize
-//
-//        // First assume that mediaMessageView center coincides with the contents center
-//        // This is correct when the mediaMessageView is bigger than scrollView due to zoom
-//        var contentCenter = CGPoint(x: (scrollView.contentSize.width / 2), y: (scrollView.contentSize.height / 2))
-//
-//        let scrollViewCenter = self.scrollViewCenter
-//
-//        // if mediaMessageView is smaller than the scrollView visible size - fix the content center accordingly
-//        if self.scrollView.contentSize.width < scrollViewSize.width {
-//            contentCenter.x = scrollViewCenter.x
-//        }
-//
-//        if self.scrollView.contentSize.height < scrollViewSize.height {
-//            contentCenter.y = scrollViewCenter.y
-//        }
-//
-//        self.mediaMessageView.center = contentCenter
-//    }
-//
-//    // return the scroll view center
-//    private var scrollViewCenter: CGPoint {
-//        let size = scrollViewVisibleSize
-//        return CGPoint(x: (size.width / 2), y: (size.height / 2))
-//    }
-//
-//    // Return scrollview size without the area overlapping with tab and nav bar.
-//    private var scrollViewVisibleSize: CGSize {
-//        let contentInset = scrollView.contentInset
-//        let scrollViewSize = scrollView.bounds.standardized.size
-//        let width = scrollViewSize.width - (contentInset.left + contentInset.right)
-//        let height = scrollViewSize.height - (contentInset.top + contentInset.bottom)
-//        return CGSize(width: width, height: height)
-//    }
-//}
-//
-//private class GradientView: UIView {
-//
-//    let gradientLayer = CAGradientLayer()
-//
-//    required init(from fromColor: UIColor, to toColor: UIColor) {
-//        gradientLayer.colors = [fromColor.cgColor, toColor.cgColor]
-//        super.init(frame: CGRect.zero)
-//
-//        self.layer.addSublayer(gradientLayer)
-//    }
-//
-//    required init?(coder aDecoder: NSCoder) {
-//        fatalError("init(coder:) has not been implemented")
-//    }
-//
-//    override func layoutSubviews() {
-//        super.layoutSubviews()
-//        gradientLayer.frame = self.bounds
-//    }
-//}
-
-//protocol CaptioningToolbarDelegate: class {
-//    func captioningToolbarDidTapSend(_ captioningToolbar: CaptioningToolbar, captionText: String?)
-//    func captioningToolbar(_ captioningToolbar: CaptioningToolbar, didChangeTextViewHeight newHeight: CGFloat)
-//    func captioningToolbarDidBeginEditing(_ captioningToolbar: CaptioningToolbar)
-//    func captioningToolbarDidEndEditing(_ captioningToolbar: CaptioningToolbar)
-//}
-
-//class CaptioningToolbar: UIView, UITextViewDelegate {
-//
-//    weak var captioningToolbarDelegate: CaptioningToolbarDelegate?
-//    private let sendButton: UIButton
-//    private let textView: UITextView
-//    private let bottomGradient: GradientView
-//
-//    // Layout Constants
-//    var maxTextViewHeight: CGFloat {
-//        // About ~4 lines in portrait and ~3 lines in landscape.
-//        // Otherwise we risk obscuring too much of the content.
-//        return UIDevice.current.orientation.isPortrait ? 160 : 100
-//    }
-//
-//    let kMinTextViewHeight: CGFloat = 38
-//    var textViewHeight: CGFloat {
-//        didSet {
-//            self.captioningToolbarDelegate?.captioningToolbar(self, didChangeTextViewHeight: textViewHeight)
-//        }
-//    }
-//
-//    required init?(coder aDecoder: NSCoder) {
-//        fatalError("init(coder:) has not been implemented")
-//    }
-//
-//    class MessageTextView: UITextView {
-//        // When creating new lines, contentOffset is animated, but because because
-//        // we are simultaneously resizing the text view, this can cause the
-//        // text in the textview to be "too high" in the text view.
-//        // Solution is to disable animation for setting content offset.
-//        override func setContentOffset(_ contentOffset: CGPoint, animated: Bool) {
-//            super.setContentOffset(contentOffset, animated: false)
-//        }
-//    }
-//
-//    let kSendButtonShadowOffset: CGFloat = 1
-//    init(defaultCaption: String?) {
-//        self.sendButton = UIButton(type: .system)
-//        self.bottomGradient = GradientView(from: UIColor.clear, to: UIColor.black)
-//        self.textView =  MessageTextView()
-//        self.textViewHeight = kMinTextViewHeight
-//
-//        super.init(frame: CGRect.zero)
-//
-//        self.backgroundColor = UIColor.clear
-//
-//        textView.delegate = self
-//        textView.backgroundColor = UIColor.white
-//        textView.layer.cornerRadius = 4.0
-//        textView.addBorder(with: UIColor.lightGray)
-//        textView.font = UIFont.ows_dynamicTypeBody()
-//        textView.returnKeyType = .done
-//        if let defaultCaption = defaultCaption {
-//            textView.text = defaultCaption
-//        }
-//
-//        let sendTitle = NSLocalizedString("ATTACHMENT_APPROVAL_SEND_BUTTON", comment: "Label for 'send' button in the 'attachment approval' dialog.")
-//        sendButton.setTitle(sendTitle, for: .normal)
-//        sendButton.addTarget(self, action: #selector(didTapSend), for: .touchUpInside)
-//
-//        sendButton.titleLabel?.font = UIFont.ows_mediumFont(withSize: 16)
-//        sendButton.titleLabel?.textAlignment = .center
-//        sendButton.tintColor = UIColor.white
-//        sendButton.backgroundColor = UIColor.ows_systemPrimaryButton
-//        sendButton.layer.cornerRadius = 4
-//
-//        // Send Button Shadow - without this the send button bottom doesn't align with the toolbar.
-//        sendButton.layer.shadowColor = UIColor.darkGray.cgColor
-//        sendButton.layer.shadowOffset = CGSize(width: 0, height: kSendButtonShadowOffset)
-//        sendButton.layer.shadowOpacity = 0.8
-//        sendButton.layer.shadowRadius = 0.0
-//        sendButton.layer.masksToBounds = false
-//
-//        // Increase hit area of send button
-//        sendButton.contentEdgeInsets = UIEdgeInsets(top: 6, left: 8, bottom: 6, right: 8)
-//
-//        addSubview(bottomGradient)
-//        addSubview(sendButton)
-//        addSubview(textView)
-//
-//        sendButton.sizeToFit()
-//    }
-//
-//    func didTapSend() {
-//        self.captioningToolbarDelegate?.captioningToolbarDidTapSend(self, captionText: self.textView.text)
-//    }
-//
-//    // MARK: - UIView Overrides
-//
-//    // We do progammatic layout, explicitly computing and setting frames since autoLayout does
-//    // not seem to work with inputAccessory views, even when forcing a layout.
-//    override func layoutSubviews() {
-//        super.layoutSubviews()
-//
-//        let kToolbarHMargin: CGFloat = 8
-//        let kToolbarVMargin: CGFloat = 8
-//
-//        let sendButtonWidth = sendButton.frame.size.width
-//
-//        let kOriginalToolbarHeight = kMinTextViewHeight + 2 * kToolbarVMargin
-//        // Assume send button has proper size.
-//        let textViewWidth = frame.size.width - 3 * kToolbarHMargin - sendButtonWidth
-//
-//        // determine height given a fixed width
-//        let textViewHeight = clampedTextViewHeight(fixedWidth: textViewWidth)
-//        let newToolbarHeight = textViewHeight + 2 * kToolbarVMargin
-//        self.frame.size.height = newToolbarHeight
-//        let toolbarHeightOffset = newToolbarHeight - kOriginalToolbarHeight
-//
-//        let textViewY = kToolbarVMargin - toolbarHeightOffset
-//        textView.frame = CGRect(x: kToolbarHMargin, y: textViewY, width: textViewWidth, height: textViewHeight)
-//        if (self.textViewHeight != textViewHeight) {
-//            // textViewHeight changed without textView's content changing, this can happen
-//            // when the user flips their device orientation after writing a caption.
-//            self.textViewHeight = textViewHeight
-//        }
-//
-//        // Send Button
-//
-//        // position in bottom right corner
-//        let sendButtonX = frame.size.width - kToolbarHMargin - sendButton.frame.size.width
-//        let sendButtonY = kOriginalToolbarHeight - kToolbarVMargin - sendButton.frame.size.height - kSendButtonShadowOffset
-//        sendButton.frame = CGRect(origin: CGPoint(x: sendButtonX, y: sendButtonY), size: sendButton.frame.size)
-//        sendButton.frame.size.height = kMinTextViewHeight - kSendButtonShadowOffset - textView.layer.borderWidth
-//
-//        let bottomGradientHeight = ScaleFromIPhone5(100)
-//        let bottomGradientY = kOriginalToolbarHeight - bottomGradientHeight
-//        bottomGradient.frame = CGRect(x: 0, y: bottomGradientY, width: frame.size.width, height: bottomGradientHeight)
-//    }
-//
-//    // MARK: - UITextViewDelegate
-//
-//    public func textViewDidChange(_ textView: UITextView) {
-//        // compute new height assuming width is unchanged
-//        let currentSize = textView.frame.size
-//        let newHeight = clampedTextViewHeight(fixedWidth: currentSize.width)
-//
-//        if newHeight != self.textViewHeight {
-//            Logger.debug("\(self.logTag) TextView height changed: \(self.textViewHeight) -> \(newHeight)")
-//            self.textViewHeight = newHeight
-//            self.setNeedsLayout()
-//            self.layoutIfNeeded()
-//        }
-//    }
-//
-//    public func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
-//        // Though we can wrap the text, we don't want to encourage multline captions, plus a "done" button
-//        // allows the user to get the keyboard out of the way while in the attachment approval view.
-//        if text == "\n" {
-//            textView.resignFirstResponder()
-//            return false
-//        } else {
-//            return true
-//        }
-//    }
-//
-//    public func textViewDidBeginEditing(_ textView: UITextView) {
-//        self.captioningToolbarDelegate?.captioningToolbarDidBeginEditing(self)
-//    }
-//
-//    public func textViewDidEndEditing(_ textView: UITextView) {
-//        self.captioningToolbarDelegate?.captioningToolbarDidEndEditing(self)
-//    }
-//
-//    // MARK: - Helpers
-//
-//    private func clampedTextViewHeight(fixedWidth: CGFloat) -> CGFloat {
-//        let contentSize = textView.sizeThatFits(CGSize(width: fixedWidth, height: CGFloat.greatestFiniteMagnitude))
-//        return Clamp(contentSize.height, kMinTextViewHeight, maxTextViewHeight)
-//    }
-//
-//}

--- a/SignalMessaging/attachments/MessageApprovalViewController.swift
+++ b/SignalMessaging/attachments/MessageApprovalViewController.swift
@@ -1,0 +1,572 @@
+//
+//  Copyright (c) 2018 Open Whisper Systems. All rights reserved.
+//
+
+import Foundation
+//import MediaPlayer
+
+@objc
+public protocol MessageApprovalViewControllerDelegate: class {
+    func messageApproval(_ messageApproval: MessageApprovalViewController, didApproveMessage messageText: String)
+    func messageApprovalDidCancel(_ messageApproval: MessageApprovalViewController)
+}
+
+@objc
+public class MessageApprovalViewController: OWSViewController {
+
+    let TAG = "[MessageApprovalViewController]"
+    weak var delegate: MessageApprovalViewControllerDelegate?
+
+//    // We sometimes shrink the attachment view so that it remains somewhat visible
+//    // when the keyboard is presented.
+//    enum AttachmentViewScale {
+//        case fullsize, compact
+//    }
+
+    // MARK: Properties
+
+//    let attachment: SignalAttachment
+    let initialMessageText: String
+
+//    private(set) var bottomToolbar: UIView!
+//    private(set) var mediaMessageView: MediaMessageView!
+//    private(set) var scrollView: UIScrollView!
+    private(set) var textView: UITextView!
+
+    // MARK: Initializers
+
+    @available(*, unavailable, message:"use attachment: constructor instead.")
+    required public init?(coder aDecoder: NSCoder) {
+        fatalError("unimplemented")
+    }
+
+    @objc
+    required public init(messageText: String, delegate: MessageApprovalViewControllerDelegate) {
+        self.initialMessageText = messageText
+        self.delegate = delegate
+
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    // MARK: View Lifecycle
+
+    override public func viewDidLoad() {
+        super.viewDidLoad()
+        self.navigationItem.title = NSLocalizedString("MESSAGE_APPROVAL_DIALOG_TITLE",
+                                                      comment: "Title for the 'message approval' dialog.")
+    }
+
+//    override public func viewWillLayoutSubviews() {
+//        Logger.debug("\(logTag) in \(#function)")
+//        super.viewWillLayoutSubviews()
+//
+//        // e.g. if flipping to/from landscape
+//        updateMinZoomScaleForSize(view.bounds.size)
+//    }
+
+//    private func dialogTitle() -> String {
+//        guard let filename = mediaMessageView.formattedFileName() else {
+//            return NSLocalizedString("ATTACHMENT_APPROVAL_DIALOG_TITLE",
+//                                     comment: "Title for the 'attachment approval' dialog.")
+//        }
+//        return filename
+//    }
+
+//    override public func viewWillAppear(_ animated: Bool) {
+//        Logger.debug("\(logTag) in \(#function)")
+//        super.viewWillAppear(animated)
+//
+//        mediaMessageView.viewWillAppear(animated)
+//    }
+//
+//    override public func viewDidAppear(_ animated: Bool) {
+//        Logger.debug("\(logTag) in \(#function)")
+//        super.viewDidAppear(animated)
+//    }
+//
+//    override public func viewWillDisappear(_ animated: Bool) {
+//        Logger.debug("\(logTag) in \(#function)")
+//        super.viewWillDisappear(animated)
+//
+//        mediaMessageView.viewWillDisappear(animated)
+//    }
+
+    // MARK: - Create Views
+
+    public override func loadView() {
+
+        self.view = UIView()
+
+//        self.mediaMessageView = MediaMessageView(attachment: attachment, mode: .messageApproval)
+
+        textView = UITextView()
+        view.addSubview(textView)
+        textView.autoPinEdgesToSuperviewEdges()
+
+//        // Scroll View - used to zoom/pan on images and video
+//        scrollView = UIScrollView()
+//        view.addSubview(scrollView)
+//
+//        scrollView.delegate = self
+//        scrollView.showsHorizontalScrollIndicator = false
+//        scrollView.showsVerticalScrollIndicator = false
+//
+//        // Panning should stop pretty soon after the user stops scrolling
+//        scrollView.decelerationRate = UIScrollViewDecelerationRateFast
+//
+//        // We want scroll view content up and behind the system status bar content
+//        // but we want other content (e.g. bar buttons) to respect the top layout guide.
+//        self.automaticallyAdjustsScrollViewInsets = false
+//
+//        scrollView.autoPinEdgesToSuperviewEdges()
+//
+//        let defaultCaption = self.defaultCaption()
+//        let isTextualShare = defaultCaption != nil
+//        let backgroundColor = isTextualShare ? UIColor.ows_signalBrandBlue : UIColor.black
+//        self.view.backgroundColor = backgroundColor
+//
+//        // Create full screen container view so the scrollView
+//        // can compute an appropriate content size in which to center
+//        // our media view.
+//        let containerView = UIView.container()
+//        scrollView.addSubview(containerView)
+//        containerView.autoPinEdgesToSuperviewEdges()
+//        containerView.autoMatch(.height, to: .height, of: self.view)
+//        containerView.autoMatch(.width, to: .width, of: self.view)
+//
+//        containerView.addSubview(mediaMessageView)
+//        mediaMessageView.autoPinEdgesToSuperviewEdges()
+//
+//        if isZoomable {
+//            // Add top and bottom gradients to ensure toolbar controls are legible
+//            // when placed over image/video preview which may be a clashing color.
+//            let topGradient = GradientView(from: backgroundColor, to: UIColor.clear)
+//            self.view.addSubview(topGradient)
+//            topGradient.autoPinWidthToSuperview()
+//            topGradient.autoPinEdge(toSuperviewEdge: .top)
+//            topGradient.autoSetDimension(.height, toSize: ScaleFromIPhone5(60))
+//        }
+//
+//        // Hide the play button embedded in the MediaView and replace it with our own.
+//        // This allows us to zoom in on the media view without zooming in on the button
+//        if attachment.isVideo {
+//            self.mediaMessageView.videoPlayButton?.isHidden = true
+//            let playButton = UIButton()
+//            playButton.accessibilityLabel = NSLocalizedString("PLAY_BUTTON_ACCESSABILITY_LABEL", comment: "accessability label for button to start media playback")
+//            playButton.setBackgroundImage(#imageLiteral(resourceName: "play_button"), for: .normal)
+//            playButton.contentMode = .scaleAspectFit
+//
+//            let playButtonWidth = ScaleFromIPhone5(70)
+//            playButton.autoSetDimensions(to: CGSize(width: playButtonWidth, height: playButtonWidth))
+//            self.view.addSubview(playButton)
+//
+//            playButton.addTarget(self, action: #selector(playButtonTapped), for: .touchUpInside)
+//            playButton.autoCenterInSuperview()
+//        }
+//
+//        // Top Toolbar
+//        let topToolbar = makeClearToolbar()
+//
+//        self.view.addSubview(topToolbar)
+//        topToolbar.autoPinWidthToSuperview()
+//        topToolbar.autoPin(toTopLayoutGuideOf: self, withInset: 0)
+//        topToolbar.setContentHuggingVerticalHigh()
+//        topToolbar.setCompressionResistanceVerticalHigh()
+//
+//        let cancelButton = UIBarButtonItem(barButtonSystemItem: .stop, target: self, action: #selector(cancelPressed))
+//        cancelButton.tintColor = UIColor.white
+//        topToolbar.items = [cancelButton]
+//
+//        // Bottom Toolbar
+//        let captioningToolbar = CaptioningToolbar(defaultCaption:defaultCaption)
+//        captioningToolbar.captioningToolbarDelegate = self
+//        self.bottomToolbar = captioningToolbar
+    }
+
+//    private func defaultCaption() -> String? {
+//        guard self.attachment.isUrl || self.attachment.isText else {
+//            return nil
+//        }
+//        let data = self.attachment.data
+//        guard let messageText = String(data: data, encoding: String.Encoding.utf8) else {
+//            Logger.error("\(self.logTag) Couldn't load url or text string")
+//            return nil
+//        }
+//        return messageText
+//    }
+
+//    override public var inputAccessoryView: UIView? {
+//        self.bottomToolbar.layoutIfNeeded()
+//        return self.bottomToolbar
+//    }
+
+//    override public var canBecomeFirstResponder: Bool {
+//        return true
+//    }
+
+//    private func makeClearToolbar() -> UIToolbar {
+//        let toolbar = UIToolbar()
+//
+//        toolbar.backgroundColor = UIColor.clear
+//
+//        // Making a toolbar transparent requires setting an empty uiimage
+//        toolbar.setBackgroundImage(UIImage(), forToolbarPosition: .any, barMetrics: .default)
+//
+//        // hide 1px top-border
+//        toolbar.clipsToBounds = true
+//
+//        return toolbar
+//    }
+
+    // MARK: - Event Handlers
+
+//    @objc
+//    public func playButtonTapped() {
+//        mediaMessageView.playVideo()
+//    }
+
+    func cancelPressed(sender: UIButton) {
+        self.delegate?.messageApprovalDidCancel(self)
+    }
+
+//    // MARK: CaptioningToolbarDelegate
+//
+//    func captioningToolbarDidBeginEditing(_ captioningToolbar: CaptioningToolbar) {
+//        self.scaleAttachmentView(.compact)
+//    }
+//
+//    func captioningToolbarDidEndEditing(_ captioningToolbar: CaptioningToolbar) {
+//        self.scaleAttachmentView(.fullsize)
+//    }
+//
+//    func captioningToolbarDidTapSend(_ captioningToolbar: CaptioningToolbar, captionText: String?) {
+//        self.approveAttachment(captionText: captionText)
+//    }
+//
+//    func captioningToolbar(_ captioningToolbar: CaptioningToolbar, didChangeTextViewHeight newHeight: CGFloat) {
+//        Logger.info("Changed height: \(newHeight)")
+//    }
+
+    // MARK: Helpers
+
+//    var isZoomable: Bool {
+//        return attachment.isImage || attachment.isVideo
+//    }
+//
+//    private func approveAttachment(captionText: String?) {
+//        // Toolbar flickers in and out if there are errors
+//        // and remains visible momentarily after share extension is dismissed.
+//        // It's easiest to just hide it at this point since we're done with it.
+//        shouldAllowAttachmentViewResizing = false
+//        bottomToolbar.isUserInteractionEnabled = false
+//        bottomToolbar.isHidden = true
+//
+//        attachment.captionText = captionText
+//        delegate?.messageApproval(self, didApproveAttachment: attachment)
+//    }
+//
+//    // When the keyboard is popped, it can obscure the attachment view.
+//    // so we sometimes allow resizing the attachment.
+//    private var shouldAllowAttachmentViewResizing: Bool = true
+//
+//    private func scaleAttachmentView(_ fit: AttachmentViewScale) {
+//        guard shouldAllowAttachmentViewResizing else {
+//            if self.scrollView.transform != CGAffineTransform.identity {
+//                UIView.animate(withDuration: 0.2) {
+//                    self.scrollView.transform = CGAffineTransform.identity
+//                }
+//            }
+//            return
+//        }
+//
+//        switch fit {
+//        case .fullsize:
+//            UIView.animate(withDuration: 0.2) {
+//                self.scrollView.transform = CGAffineTransform.identity
+//            }
+//        case .compact:
+//            UIView.animate(withDuration: 0.2) {
+//                let kScaleFactor: CGFloat = 0.7
+//                let scale = CGAffineTransform(scaleX: kScaleFactor, y: kScaleFactor)
+//
+//                let originalHeight = self.scrollView.bounds.size.height
+//
+//                // Position the new scaled item to be centered with respect
+//                // to it's new size.
+//                let heightDelta = originalHeight * (1 - kScaleFactor)
+//                let translate = CGAffineTransform(translationX: 0, y: -heightDelta / 2)
+//
+//                self.scrollView.transform = scale.concatenating(translate)
+//            }
+//        }
+//    }
+}
+
+//extension MessageApprovalViewController: UIScrollViewDelegate {
+//
+//    public func viewForZooming(in scrollView: UIScrollView) -> UIView? {
+//        if isZoomable {
+//            return mediaMessageView
+//        } else {
+//            // don't zoom for audio or generic attachments.
+//            return nil
+//        }
+//    }
+//
+//    fileprivate func updateMinZoomScaleForSize(_ size: CGSize) {
+//        Logger.debug("\(logTag) in \(#function)")
+//
+//        // Ensure bounds have been computed
+//        mediaMessageView.layoutIfNeeded()
+//        guard mediaMessageView.bounds.width > 0, mediaMessageView.bounds.height > 0 else {
+//            Logger.warn("\(logTag) bad bounds in \(#function)")
+//            return
+//        }
+//
+//        let widthScale = size.width / mediaMessageView.bounds.width
+//        let heightScale = size.height / mediaMessageView.bounds.height
+//        let minScale = min(widthScale, heightScale)
+//        scrollView.maximumZoomScale = minScale * 5.0
+//        scrollView.minimumZoomScale = minScale
+//        scrollView.zoomScale = minScale
+//    }
+//
+//    // Keep the media view centered within the scroll view as you zoom
+//    public func scrollViewDidZoom(_ scrollView: UIScrollView) {
+//        // The scroll view has zoomed, so you need to re-center the contents
+//        let scrollViewSize = self.scrollViewVisibleSize
+//
+//        // First assume that mediaMessageView center coincides with the contents center
+//        // This is correct when the mediaMessageView is bigger than scrollView due to zoom
+//        var contentCenter = CGPoint(x: (scrollView.contentSize.width / 2), y: (scrollView.contentSize.height / 2))
+//
+//        let scrollViewCenter = self.scrollViewCenter
+//
+//        // if mediaMessageView is smaller than the scrollView visible size - fix the content center accordingly
+//        if self.scrollView.contentSize.width < scrollViewSize.width {
+//            contentCenter.x = scrollViewCenter.x
+//        }
+//
+//        if self.scrollView.contentSize.height < scrollViewSize.height {
+//            contentCenter.y = scrollViewCenter.y
+//        }
+//
+//        self.mediaMessageView.center = contentCenter
+//    }
+//
+//    // return the scroll view center
+//    private var scrollViewCenter: CGPoint {
+//        let size = scrollViewVisibleSize
+//        return CGPoint(x: (size.width / 2), y: (size.height / 2))
+//    }
+//
+//    // Return scrollview size without the area overlapping with tab and nav bar.
+//    private var scrollViewVisibleSize: CGSize {
+//        let contentInset = scrollView.contentInset
+//        let scrollViewSize = scrollView.bounds.standardized.size
+//        let width = scrollViewSize.width - (contentInset.left + contentInset.right)
+//        let height = scrollViewSize.height - (contentInset.top + contentInset.bottom)
+//        return CGSize(width: width, height: height)
+//    }
+//}
+//
+//private class GradientView: UIView {
+//
+//    let gradientLayer = CAGradientLayer()
+//
+//    required init(from fromColor: UIColor, to toColor: UIColor) {
+//        gradientLayer.colors = [fromColor.cgColor, toColor.cgColor]
+//        super.init(frame: CGRect.zero)
+//
+//        self.layer.addSublayer(gradientLayer)
+//    }
+//
+//    required init?(coder aDecoder: NSCoder) {
+//        fatalError("init(coder:) has not been implemented")
+//    }
+//
+//    override func layoutSubviews() {
+//        super.layoutSubviews()
+//        gradientLayer.frame = self.bounds
+//    }
+//}
+
+//protocol CaptioningToolbarDelegate: class {
+//    func captioningToolbarDidTapSend(_ captioningToolbar: CaptioningToolbar, captionText: String?)
+//    func captioningToolbar(_ captioningToolbar: CaptioningToolbar, didChangeTextViewHeight newHeight: CGFloat)
+//    func captioningToolbarDidBeginEditing(_ captioningToolbar: CaptioningToolbar)
+//    func captioningToolbarDidEndEditing(_ captioningToolbar: CaptioningToolbar)
+//}
+
+//class CaptioningToolbar: UIView, UITextViewDelegate {
+//
+//    weak var captioningToolbarDelegate: CaptioningToolbarDelegate?
+//    private let sendButton: UIButton
+//    private let textView: UITextView
+//    private let bottomGradient: GradientView
+//
+//    // Layout Constants
+//    var maxTextViewHeight: CGFloat {
+//        // About ~4 lines in portrait and ~3 lines in landscape.
+//        // Otherwise we risk obscuring too much of the content.
+//        return UIDevice.current.orientation.isPortrait ? 160 : 100
+//    }
+//
+//    let kMinTextViewHeight: CGFloat = 38
+//    var textViewHeight: CGFloat {
+//        didSet {
+//            self.captioningToolbarDelegate?.captioningToolbar(self, didChangeTextViewHeight: textViewHeight)
+//        }
+//    }
+//
+//    required init?(coder aDecoder: NSCoder) {
+//        fatalError("init(coder:) has not been implemented")
+//    }
+//
+//    class MessageTextView: UITextView {
+//        // When creating new lines, contentOffset is animated, but because because
+//        // we are simultaneously resizing the text view, this can cause the
+//        // text in the textview to be "too high" in the text view.
+//        // Solution is to disable animation for setting content offset.
+//        override func setContentOffset(_ contentOffset: CGPoint, animated: Bool) {
+//            super.setContentOffset(contentOffset, animated: false)
+//        }
+//    }
+//
+//    let kSendButtonShadowOffset: CGFloat = 1
+//    init(defaultCaption: String?) {
+//        self.sendButton = UIButton(type: .system)
+//        self.bottomGradient = GradientView(from: UIColor.clear, to: UIColor.black)
+//        self.textView =  MessageTextView()
+//        self.textViewHeight = kMinTextViewHeight
+//
+//        super.init(frame: CGRect.zero)
+//
+//        self.backgroundColor = UIColor.clear
+//
+//        textView.delegate = self
+//        textView.backgroundColor = UIColor.white
+//        textView.layer.cornerRadius = 4.0
+//        textView.addBorder(with: UIColor.lightGray)
+//        textView.font = UIFont.ows_dynamicTypeBody()
+//        textView.returnKeyType = .done
+//        if let defaultCaption = defaultCaption {
+//            textView.text = defaultCaption
+//        }
+//
+//        let sendTitle = NSLocalizedString("ATTACHMENT_APPROVAL_SEND_BUTTON", comment: "Label for 'send' button in the 'attachment approval' dialog.")
+//        sendButton.setTitle(sendTitle, for: .normal)
+//        sendButton.addTarget(self, action: #selector(didTapSend), for: .touchUpInside)
+//
+//        sendButton.titleLabel?.font = UIFont.ows_mediumFont(withSize: 16)
+//        sendButton.titleLabel?.textAlignment = .center
+//        sendButton.tintColor = UIColor.white
+//        sendButton.backgroundColor = UIColor.ows_systemPrimaryButton
+//        sendButton.layer.cornerRadius = 4
+//
+//        // Send Button Shadow - without this the send button bottom doesn't align with the toolbar.
+//        sendButton.layer.shadowColor = UIColor.darkGray.cgColor
+//        sendButton.layer.shadowOffset = CGSize(width: 0, height: kSendButtonShadowOffset)
+//        sendButton.layer.shadowOpacity = 0.8
+//        sendButton.layer.shadowRadius = 0.0
+//        sendButton.layer.masksToBounds = false
+//
+//        // Increase hit area of send button
+//        sendButton.contentEdgeInsets = UIEdgeInsets(top: 6, left: 8, bottom: 6, right: 8)
+//
+//        addSubview(bottomGradient)
+//        addSubview(sendButton)
+//        addSubview(textView)
+//
+//        sendButton.sizeToFit()
+//    }
+//
+//    func didTapSend() {
+//        self.captioningToolbarDelegate?.captioningToolbarDidTapSend(self, captionText: self.textView.text)
+//    }
+//
+//    // MARK: - UIView Overrides
+//
+//    // We do progammatic layout, explicitly computing and setting frames since autoLayout does
+//    // not seem to work with inputAccessory views, even when forcing a layout.
+//    override func layoutSubviews() {
+//        super.layoutSubviews()
+//
+//        let kToolbarHMargin: CGFloat = 8
+//        let kToolbarVMargin: CGFloat = 8
+//
+//        let sendButtonWidth = sendButton.frame.size.width
+//
+//        let kOriginalToolbarHeight = kMinTextViewHeight + 2 * kToolbarVMargin
+//        // Assume send button has proper size.
+//        let textViewWidth = frame.size.width - 3 * kToolbarHMargin - sendButtonWidth
+//
+//        // determine height given a fixed width
+//        let textViewHeight = clampedTextViewHeight(fixedWidth: textViewWidth)
+//        let newToolbarHeight = textViewHeight + 2 * kToolbarVMargin
+//        self.frame.size.height = newToolbarHeight
+//        let toolbarHeightOffset = newToolbarHeight - kOriginalToolbarHeight
+//
+//        let textViewY = kToolbarVMargin - toolbarHeightOffset
+//        textView.frame = CGRect(x: kToolbarHMargin, y: textViewY, width: textViewWidth, height: textViewHeight)
+//        if (self.textViewHeight != textViewHeight) {
+//            // textViewHeight changed without textView's content changing, this can happen
+//            // when the user flips their device orientation after writing a caption.
+//            self.textViewHeight = textViewHeight
+//        }
+//
+//        // Send Button
+//
+//        // position in bottom right corner
+//        let sendButtonX = frame.size.width - kToolbarHMargin - sendButton.frame.size.width
+//        let sendButtonY = kOriginalToolbarHeight - kToolbarVMargin - sendButton.frame.size.height - kSendButtonShadowOffset
+//        sendButton.frame = CGRect(origin: CGPoint(x: sendButtonX, y: sendButtonY), size: sendButton.frame.size)
+//        sendButton.frame.size.height = kMinTextViewHeight - kSendButtonShadowOffset - textView.layer.borderWidth
+//
+//        let bottomGradientHeight = ScaleFromIPhone5(100)
+//        let bottomGradientY = kOriginalToolbarHeight - bottomGradientHeight
+//        bottomGradient.frame = CGRect(x: 0, y: bottomGradientY, width: frame.size.width, height: bottomGradientHeight)
+//    }
+//
+//    // MARK: - UITextViewDelegate
+//
+//    public func textViewDidChange(_ textView: UITextView) {
+//        // compute new height assuming width is unchanged
+//        let currentSize = textView.frame.size
+//        let newHeight = clampedTextViewHeight(fixedWidth: currentSize.width)
+//
+//        if newHeight != self.textViewHeight {
+//            Logger.debug("\(self.logTag) TextView height changed: \(self.textViewHeight) -> \(newHeight)")
+//            self.textViewHeight = newHeight
+//            self.setNeedsLayout()
+//            self.layoutIfNeeded()
+//        }
+//    }
+//
+//    public func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+//        // Though we can wrap the text, we don't want to encourage multline captions, plus a "done" button
+//        // allows the user to get the keyboard out of the way while in the attachment approval view.
+//        if text == "\n" {
+//            textView.resignFirstResponder()
+//            return false
+//        } else {
+//            return true
+//        }
+//    }
+//
+//    public func textViewDidBeginEditing(_ textView: UITextView) {
+//        self.captioningToolbarDelegate?.captioningToolbarDidBeginEditing(self)
+//    }
+//
+//    public func textViewDidEndEditing(_ textView: UITextView) {
+//        self.captioningToolbarDelegate?.captioningToolbarDidEndEditing(self)
+//    }
+//
+//    // MARK: - Helpers
+//
+//    private func clampedTextViewHeight(fixedWidth: CGFloat) -> CGFloat {
+//        let contentSize = textView.sizeThatFits(CGSize(width: fixedWidth, height: CGFloat.greatestFiniteMagnitude))
+//        return Clamp(contentSize.height, kMinTextViewHeight, maxTextViewHeight)
+//    }
+//
+//}

--- a/SignalMessaging/attachments/MessageApprovalViewController.swift
+++ b/SignalMessaging/attachments/MessageApprovalViewController.swift
@@ -131,10 +131,7 @@ public class MessageApprovalViewController: OWSViewController, UITextViewDelegat
         bottomBorder.autoPinBottomToSuperview()
         bottomBorder.autoSetDimension(.height, toSize: borderThickness)
 
-        guard let font = UIFont.ows_regularFont(withSize:ScaleFromIPhone5To7Plus(14.0, 18.0)) else {
-            owsFail("Can't load font")
-            return recipientRow
-        }
+        let font = UIFont.ows_regularFont(withSize:ScaleFromIPhone5To7Plus(14.0, 18.0))
         let hSpacing = CGFloat(10)
         let hMargin = CGFloat(15)
         let vSpacing = CGFloat(5)

--- a/SignalMessaging/attachments/MessageApprovalViewController.swift
+++ b/SignalMessaging/attachments/MessageApprovalViewController.swift
@@ -112,7 +112,6 @@ public class MessageApprovalViewController: OWSViewController, UITextViewDelegat
     private func createRecipientRow() -> UIView {
         let recipientRow = UIView.container()
         recipientRow.backgroundColor = UIColor.ows_toolbarBackground
-        recipientRow.autoSetDimension(.height, toSize: 40.0)
 
         // Hairline borders should be 1 pixel, not 1 point.
         let borderThickness = 1.0 / UIScreen.main.scale
@@ -138,6 +137,8 @@ public class MessageApprovalViewController: OWSViewController, UITextViewDelegat
         }
         let hSpacing = CGFloat(10)
         let hMargin = CGFloat(15)
+        let vSpacing = CGFloat(5)
+        let vMargin = CGFloat(10)
 
         let toLabel = UILabel()
         toLabel.text = NSLocalizedString("MESSAGE_APPROVAL_RECIPIENT_LABEL",
@@ -145,27 +146,35 @@ public class MessageApprovalViewController: OWSViewController, UITextViewDelegat
         toLabel.textColor = UIColor.ows_darkGray
         toLabel.font = font
         recipientRow.addSubview(toLabel)
-        toLabel.autoVCenterInSuperview()
+
+        let nameLabel = UILabel()
+        nameLabel.textColor = UIColor.black
+        nameLabel.font = font
+        nameLabel.lineBreakMode = .byTruncatingTail
+        recipientRow.addSubview(nameLabel)
+
         toLabel.autoPinLeadingToSuperview(withMargin: hMargin)
         toLabel.setContentHuggingHorizontalHigh()
         toLabel.setCompressionResistanceHorizontalHigh()
+        toLabel.autoAlignAxis(.horizontal, toSameAxisOf: nameLabel)
+
+        nameLabel.autoPinLeading(toTrailingOf: toLabel, margin:hSpacing)
+        nameLabel.autoPinTrailingToSuperview(withMargin: hMargin)
+        nameLabel.setContentHuggingHorizontalLow()
+        nameLabel.setCompressionResistanceHorizontalLow()
+        nameLabel.autoPinTopToSuperview(withMargin: vMargin)
+
+        recipientRow.logFrameLater(withLabel: "recipientRow")
+        toLabel.logFrameLater(withLabel: "toLabel")
+        nameLabel.logFrameLater(withLabel: "nameLabel")
 
         if let groupThread = self.thread as? TSGroupThread {
             let groupName = (groupThread.name().count > 0
             ? groupThread.name()
                 : MessageStrings.newGroupDefaultTitle)
 
-            let nameLabel = UILabel()
             nameLabel.text = groupName
-            nameLabel.textColor = UIColor.black
-            nameLabel.font = font
-            nameLabel.lineBreakMode = .byTruncatingTail
-            recipientRow.addSubview(nameLabel)
-            nameLabel.autoVCenterInSuperview()
-            nameLabel.autoPinLeading(toTrailingOf: toLabel, margin:hSpacing)
-            nameLabel.autoPinTrailingToSuperview(withMargin: hMargin)
-            nameLabel.setContentHuggingHorizontalLow()
-            nameLabel.setCompressionResistanceHorizontalLow()
+            nameLabel.autoPinBottomToSuperview(withMargin: vMargin)
 
             return recipientRow
         }
@@ -174,81 +183,38 @@ public class MessageApprovalViewController: OWSViewController, UITextViewDelegat
             return recipientRow
         }
 
-//        let recipientLabel = UILabel()
-//        recipientLabel.text = NSLocalizedString("MESSAGE_APPROVAL_RECIPIENT_LABEL",
-//                                                comment: "Label for the recipient name in the 'message approval' dialog.")
-//        recipientLabel.textColor = UIColor.black
-//        recipientLabel.font = UIFont.ows_regularFont(withSize:ScaleFromIPhone5To7Plus(14.0, 18.0))
-//        recipientLabel.lineBreakMode = .byTruncatingTail
-//        recipientRow.addSubview(recipientLabel)
-//        recipientLabel.autoVCenterInSuperview()
-//        recipientLabel.autoPinLeading(toTrailingOf: toLabel)
-//        recipientLabel.autoPinTrailingToSuperview(withMargin: 20.0)
-//
-//
-//        topToolbar.autoSetDimension(.height, toSize: 30.0)
-//
-//        let toLabel = UILabel()
-//        toLabel.text = NSLocalizedString("MESSAGE_APPROVAL_RECIPIENT_LABEL",
-//                                         comment: "Label for the recipient name in the 'message approval' dialog.")
-//        toLabel.textColor = UIColor.ows_darkGray
-//        toLabel.font = UIFont.ows_regularFont(withSize:ScaleFromIPhone5To7Plus(14.0, 18.0))
-//        recipientRow.addSubview(toLabel)
-//        toLabel.autoVCenterInSuperview()
-//        toLabel.autoPinLeadingToSuperview(withMargin: 20.0)
-//
-        let recipientLabel = UILabel()
-        recipientLabel.textColor = UIColor.black
-        recipientLabel.font = font
-        recipientLabel.attributedText = contactsManager.formattedFullName(forRecipientId:contactThread.contactIdentifier(), font:font)
-        //            self.nameLabel.attributedText =
-        //                [contactsManager formattedFullNameForRecipientId:recipientId font:self.nameLabel.font];
-        recipientLabel.lineBreakMode = .byTruncatingTail
-        recipientRow.addSubview(recipientLabel)
-        recipientLabel.autoVCenterInSuperview()
-        recipientLabel.autoPinLeading(toTrailingOf: toLabel, margin:hSpacing)
-        recipientLabel.autoPinTrailingToSuperview(withMargin: hMargin)
-        recipientLabel.setContentHuggingHorizontalLow()
-        recipientLabel.setCompressionResistanceHorizontalLow()
+        nameLabel.attributedText = contactsManager.formattedFullName(forRecipientId:contactThread.contactIdentifier(), font:font)
+        nameLabel.textColor = UIColor.black
 
-//        recipientLabel
-
-    //            - (void)configureWithRecipientId:(NSString *)recipientId contactsManager:(OWSContactsManager *)contactsManager
-    //        {
-    //            self.recipientId = recipientId;
-    //            self.contactsManager = contactsManager;
-    //
-    //            self.nameLabel.attributedText =
-    //                [contactsManager formattedFullNameForRecipientId:recipientId font:self.nameLabel.font];
-    //
-    //            - (void)updateProfileName
-    //                {
-    //                    OWSContactsManager *contactsManager = self.contactsManager;
-    //                    if (contactsManager == nil) {
-    //                        OWSFail(@"%@ contactsManager should not be nil", self.logTag);
-    //                        self.profileNameLabel.text = nil;
-    //                        return;
-    //                    }
-    //
-    //                    NSString *recipientId = self.recipientId;
-    //                    if (recipientId.length == 0) {
-    //                        OWSFail(@"%@ recipientId should not be nil", self.logTag);
-    //                        self.profileNameLabel.text = nil;
-    //                        return;
-    //                    }
-    //
-    //                    if ([contactsManager hasNameInSystemContactsForRecipientId:recipientId]) {
-    //                        // Don't display profile name when we have a veritas name in system Contacts
-    //                        self.profileNameLabel.text = nil;
-    //                    } else {
-    //                        // Use profile name, if any is available
-    //                        self.profileNameLabel.text = [contactsManager formattedProfileNameForRecipientId:recipientId];
-    //                    }
-    //
-    //                    [self.profileNameLabel setNeedsLayout];
-    //            }
+        if let profileName = self.profileName(contactThread:contactThread) {
+            // If there's a profile name worth showing, add it as a second line below the name.
+            let profileNameLabel = UILabel()
+            profileNameLabel.textColor = UIColor.ows_darkGray
+            profileNameLabel.font = font
+            profileNameLabel.text = profileName
+            profileNameLabel.lineBreakMode = .byTruncatingTail
+            recipientRow.addSubview(profileNameLabel)
+            profileNameLabel.autoPinEdge(.top, to: .bottom, of: nameLabel, withOffset: vSpacing)
+            profileNameLabel.autoPinLeading(toTrailingOf: toLabel, margin:hSpacing)
+            profileNameLabel.autoPinTrailingToSuperview(withMargin: hMargin)
+            profileNameLabel.setContentHuggingHorizontalLow()
+            profileNameLabel.setCompressionResistanceHorizontalLow()
+            profileNameLabel.autoPinBottomToSuperview(withMargin: vMargin)
+        } else {
+            nameLabel.autoPinBottomToSuperview(withMargin: vMargin)
+        }
 
         return recipientRow
+    }
+
+    private func profileName(contactThread: TSContactThread) -> String? {
+        let recipientId = contactThread.contactIdentifier()
+
+        if contactsManager.hasNameInSystemContacts(forRecipientId:recipientId) {
+            // Don't display profile name when we have a veritas name in system Contacts
+            return nil
+        }
+        return contactsManager.formattedProfileName(forRecipientId:recipientId)
     }
 
     // MARK: - Event Handlers

--- a/SignalMessaging/attachments/MessageApprovalViewController.swift
+++ b/SignalMessaging/attachments/MessageApprovalViewController.swift
@@ -99,8 +99,8 @@ public class MessageApprovalViewController: OWSViewController, UITextViewDelegat
         textView.textColor = UIColor.black
         textView.font = UIFont.ows_dynamicTypeBody()
         textView.text = self.initialMessageText
-        textView.textContainerInset = UIEdgeInsets(top:0.0, left:0.0, bottom:0.0, right:0.0)
-        textView.contentInset = UIEdgeInsets(top:10.0, left:10.0, bottom:10.0, right:10.0)
+        textView.contentInset = UIEdgeInsets(top:0.0, left:0.0, bottom:0.0, right:0.0)
+        textView.textContainerInset = UIEdgeInsets(top:10.0, left:10.0, bottom:10.0, right:10.0)
         view.addSubview(textView)
         textView.autoPinWidthToSuperview()
         textView.autoPinEdge(.top, to: .bottom, of: recipientRow)

--- a/SignalMessaging/attachments/SharingThreadPickerViewController.m
+++ b/SignalMessaging/attachments/SharingThreadPickerViewController.m
@@ -183,6 +183,8 @@ typedef void (^SendMessageBlock)(SendCompletionBlock completion);
 {
     [ThreadUtil addThreadToProfileWhitelistIfEmptyContactThread:self.thread];
     [self tryToSendMessageWithBlock:^(SendCompletionBlock sendCompletion) {
+        OWSAssertIsOnMainThread();
+
         __block TSOutgoingMessage *outgoingMessage = nil;
         outgoingMessage = [ThreadUtil sendMessageWithAttachment:attachment
                                                        inThread:self.thread
@@ -190,6 +192,9 @@ typedef void (^SendMessageBlock)(SendCompletionBlock completion);
                                                      completion:^(NSError *_Nullable error) {
                                                          sendCompletion(error, outgoingMessage);
                                                      }];
+
+        // This is necessary to show progress.
+        self.outgoingMessage = outgoingMessage;
     }
                  fromViewController:approvalViewController];
 }
@@ -209,6 +214,8 @@ typedef void (^SendMessageBlock)(SendCompletionBlock completion);
 
     [ThreadUtil addThreadToProfileWhitelistIfEmptyContactThread:self.thread];
     [self tryToSendMessageWithBlock:^(SendCompletionBlock sendCompletion) {
+        OWSAssertIsOnMainThread();
+
         __block TSOutgoingMessage *outgoingMessage = nil;
         outgoingMessage = [ThreadUtil sendMessageWithText:messageText
             inThread:self.thread
@@ -219,6 +226,9 @@ typedef void (^SendMessageBlock)(SendCompletionBlock completion);
             failure:^(NSError *_Nonnull error) {
                 sendCompletion(error, outgoingMessage);
             }];
+
+        // This is necessary to show progress.
+        self.outgoingMessage = outgoingMessage;
     }
                  fromViewController:approvalViewController];
 }
@@ -229,7 +239,6 @@ typedef void (^SendMessageBlock)(SendCompletionBlock completion);
 }
 
 #pragma mark - Helpers
-typedef void (^SendMessageBlock)(SendCompletionBlock completion);
 
 - (void)tryToSendMessageWithBlock:(SendMessageBlock)sendMessageBlock
                fromViewController:(UIViewController *)fromViewController

--- a/SignalMessaging/attachments/SharingThreadPickerViewController.m
+++ b/SignalMessaging/attachments/SharingThreadPickerViewController.m
@@ -147,7 +147,10 @@ typedef void (^SendMessageBlock)(SendCompletionBlock completion);
 
     if (messageText) {
         MessageApprovalViewController *approvalVC =
-            [[MessageApprovalViewController alloc] initWithMessageText:messageText delegate:self];
+            [[MessageApprovalViewController alloc] initWithMessageText:messageText
+                                                                thread:thread
+                                                       contactsManager:self.contactsManager
+                                                              delegate:self];
 
         [self.navigationController pushViewController:approvalVC animated:YES];
     } else {

--- a/SignalMessaging/attachments/SharingThreadPickerViewController.m
+++ b/SignalMessaging/attachments/SharingThreadPickerViewController.m
@@ -133,6 +133,7 @@ typedef void (^SendMessageBlock)(SendCompletionBlock completion);
     }
     NSData *data = self.attachment.data;
     NSString *_Nullable messageText = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+    DDLogVerbose(@"%@ messageTextForAttachment: %@", self.logTag, messageText);
     return messageText;
 }
 

--- a/SignalMessaging/attachments/SharingThreadPickerViewController.m
+++ b/SignalMessaging/attachments/SharingThreadPickerViewController.m
@@ -131,6 +131,9 @@ typedef void (^SendMessageBlock)(SendCompletionBlock completion);
     if (!(self.attachment.isUrl || self.attachment.isText)) {
         return nil;
     }
+    if (!self.attachment.isConvertibleToTextMessage) {
+        return nil;
+    }
     NSData *data = self.attachment.data;
     NSString *_Nullable messageText = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
     DDLogVerbose(@"%@ messageTextForAttachment: %@", self.logTag, messageText);

--- a/SignalMessaging/attachments/SignalAttachment.swift
+++ b/SignalMessaging/attachments/SignalAttachment.swift
@@ -1,5 +1,5 @@
 //
-//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//  Copyright (c) 2018 Open Whisper Systems. All rights reserved.
 //
 
 import Foundation
@@ -290,7 +290,7 @@ public class SignalAttachment: NSObject {
                 }
             }
         }
-        if dataUTI == kOversizeTextAttachmentUTI {
+        if isOversizeText {
             return OWSMimeTypeOversizeTextMessage
         }
         if dataUTI == kUnknownTestAttachmentUTI {
@@ -334,7 +334,7 @@ public class SignalAttachment: NSObject {
                 return fileExtension
             }
         }
-        if dataUTI == kOversizeTextAttachmentUTI {
+        if isOversizeText {
             return kOversizeTextAttachmentFileExtension
         }
         if dataUTI == kUnknownTestAttachmentUTI {
@@ -412,6 +412,11 @@ public class SignalAttachment: NSObject {
     @objc
     public var isAudio: Bool {
         return SignalAttachment.audioUTISet.contains(dataUTI)
+    }
+
+    @objc
+    public var isOversizeText: Bool {
+        return dataUTI == kOversizeTextAttachmentUTI
     }
 
     @objc

--- a/SignalMessaging/attachments/SignalAttachment.swift
+++ b/SignalMessaging/attachments/SignalAttachment.swift
@@ -420,6 +420,11 @@ public class SignalAttachment: NSObject {
     }
 
     @objc
+    public var isUrl: Bool {
+        return dataUTI == (kUTTypeURL as String)
+    }
+
+    @objc
     public class func pasteboardHasPossibleAttachment() -> Bool {
         return UIPasteboard.general.numberOfItems > 0
     }

--- a/SignalMessaging/attachments/SignalAttachment.swift
+++ b/SignalMessaging/attachments/SignalAttachment.swift
@@ -138,6 +138,10 @@ public class SignalAttachment: NSObject {
         return dataSource.isValidImage()
     }
 
+    // This flag should be set for text attachments that can be sent as text messages.
+    @objc
+    public var isConvertibleToTextMessage = false
+
     // Attachment types are identified using UTIs.
     //
     // See: https://developer.apple.com/library/content/documentation/Miscellaneous/Reference/UTIRef/Articles/System-DeclaredUniformTypeIdentifiers.html

--- a/SignalMessaging/attachments/SignalAttachment.swift
+++ b/SignalMessaging/attachments/SignalAttachment.swift
@@ -420,8 +420,13 @@ public class SignalAttachment: NSObject {
     }
 
     @objc
+    public var isText: Bool {
+        return UTTypeConformsTo(dataUTI as CFString, kUTTypeText) || isOversizeText
+    }
+
+    @objc
     public var isUrl: Bool {
-        return dataUTI == (kUTTypeURL as String)
+        return UTTypeConformsTo(dataUTI as CFString, kUTTypeURL)
     }
 
     @objc

--- a/SignalMessaging/categories/UIColor+OWS.h
+++ b/SignalMessaging/categories/UIColor+OWS.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (class, readonly, nonatomic) UIColor *ows_darkIconColor;
 @property (class, readonly, nonatomic) UIColor *ows_errorMessageBorderColor;
 @property (class, readonly, nonatomic) UIColor *ows_infoMessageBorderColor;
-@property (class, readonly, nonatomic) UIColor *ows_inputToolbarBackgroundColor;
+@property (class, readonly, nonatomic) UIColor *ows_toolbarBackgroundColor;
 
 + (UIColor *)backgroundColorForContact:(NSString *)contactIdentifier;
 + (UIColor *)colorWithRGBHex:(unsigned long)value;

--- a/SignalMessaging/categories/UIColor+OWS.m
+++ b/SignalMessaging/categories/UIColor+OWS.m
@@ -91,7 +91,7 @@ NS_ASSUME_NONNULL_BEGIN
     return [UIColor colorWithRed:239.f / 255.f green:189.f / 255.f blue:88.f / 255.f alpha:1.0f];
 }
 
-+ (UIColor *)ows_inputToolbarBackgroundColor
++ (UIColor *)ows_toolbarBackgroundColor
 {
     return [self colorWithWhite:245 / 255.f alpha:1.f];
 }

--- a/SignalMessaging/categories/UIFont+OWS.h
+++ b/SignalMessaging/categories/UIFont+OWS.h
@@ -1,8 +1,10 @@
 //
-//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//  Copyright (c) 2018 Open Whisper Systems. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
 
 @interface UIFont (OWS)
 
@@ -31,3 +33,5 @@
 + (UIFont *)ows_footnoteFont;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/SignalMessaging/categories/UIFont+OWS.m
+++ b/SignalMessaging/categories/UIFont+OWS.m
@@ -1,8 +1,10 @@
 //
-//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//  Copyright (c) 2018 Open Whisper Systems. All rights reserved.
 //
 
 #import "UIFont+OWS.h"
+
+NS_ASSUME_NONNULL_BEGIN
 
 @implementation UIFont (OWS)
 
@@ -105,3 +107,5 @@
 }
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/SignalMessaging/categories/UIView+OWS.h
+++ b/SignalMessaging/categories/UIView+OWS.h
@@ -117,9 +117,11 @@ CGFloat ScaleFromIPhone5(CGFloat iPhone5Value);
 // Add red border to self, and all subviews recursively.
 - (void)addRedBorderRecursively;
 
+#ifdef DEBUG
 - (void)logFrameLater;
 - (void)logFrameLaterWithLabel:(NSString *)label;
 - (void)logHierarchyUpwardLaterWithLabel:(NSString *)label;
+#endif
 
 @end
 

--- a/SignalMessaging/categories/UIView+OWS.h
+++ b/SignalMessaging/categories/UIView+OWS.h
@@ -117,6 +117,10 @@ CGFloat ScaleFromIPhone5(CGFloat iPhone5Value);
 // Add red border to self, and all subviews recursively.
 - (void)addRedBorderRecursively;
 
+- (void)logFrameLater;
+- (void)logFrameLaterWithLabel:(NSString *)label;
+- (void)logHierarchyUpwardLaterWithLabel:(NSString *)label;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SignalMessaging/categories/UIView+OWS.h
+++ b/SignalMessaging/categories/UIView+OWS.h
@@ -83,7 +83,10 @@ CGFloat ScaleFromIPhone5(CGFloat iPhone5Value);
 - (NSLayoutConstraint *)autoPinLeadingToSuperviewWithMargin:(CGFloat)margin;
 - (NSLayoutConstraint *)autoPinTrailingToSuperview;
 - (NSLayoutConstraint *)autoPinTrailingToSuperviewWithMargin:(CGFloat)margin;
+
+- (NSLayoutConstraint *)autoPinTopToSuperview;
 - (NSLayoutConstraint *)autoPinTopToSuperviewWithMargin:(CGFloat)margin;
+- (NSLayoutConstraint *)autoPinBottomToSuperview;
 - (NSLayoutConstraint *)autoPinBottomToSuperviewWithMargin:(CGFloat)margin;
 
 - (NSLayoutConstraint *)autoPinLeadingToTrailingOfView:(UIView *)view;

--- a/SignalMessaging/categories/UIView+OWS.m
+++ b/SignalMessaging/categories/UIView+OWS.m
@@ -496,6 +496,39 @@ CGFloat ScaleFromIPhone5(CGFloat iPhone5Value)
     }
 }
 
+- (void)logFrameLater
+{
+    [self logFrameLaterWithLabel:@""];
+}
+
+- (void)logFrameLaterWithLabel:(NSString *)label
+{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        DDLogVerbose(@"%@ %@ frame: %@, hidden: %d, opacity: %f",
+            self.logTag,
+            label,
+            NSStringFromCGRect(self.frame),
+            self.hidden,
+            self.layer.opacity);
+    });
+}
+
+- (void)logHierarchyUpwardLaterWithLabel:(NSString *)label
+{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        DDLogVerbose(@"%@ %@ ----", self.logTag, label);
+    });
+
+    UIResponder *responder = self;
+    while (responder) {
+        if ([responder isKindOfClass:[UIView class]]) {
+            UIView *view = (UIView *)responder;
+            [view logFrameLaterWithLabel:@"\t"];
+        }
+        responder = responder.nextResponder;
+    }
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SignalMessaging/categories/UIView+OWS.m
+++ b/SignalMessaging/categories/UIView+OWS.m
@@ -268,6 +268,8 @@ CGFloat ScaleFromIPhone5(CGFloat iPhone5Value)
 
 - (NSLayoutConstraint *)autoPinLeadingToSuperviewWithMargin:(CGFloat)margin
 {
+    self.translatesAutoresizingMaskIntoConstraints = NO;
+
     if (@available(iOS 9.0, *)) {
         NSLayoutConstraint *constraint =
             [self.leadingAnchor constraintEqualToAnchor:self.superview.layoutMarginsGuide.leadingAnchor
@@ -287,6 +289,8 @@ CGFloat ScaleFromIPhone5(CGFloat iPhone5Value)
 
 - (NSLayoutConstraint *)autoPinTrailingToSuperviewWithMargin:(CGFloat)margin
 {
+    self.translatesAutoresizingMaskIntoConstraints = NO;
+
     if (@available(iOS 9.0, *)) {
         NSLayoutConstraint *constraint =
             [self.trailingAnchor constraintEqualToAnchor:self.superview.layoutMarginsGuide.trailingAnchor
@@ -299,8 +303,15 @@ CGFloat ScaleFromIPhone5(CGFloat iPhone5Value)
     }
 }
 
+- (NSLayoutConstraint *)autoPinBottomToSuperview
+{
+    return [self autoPinBottomToSuperviewWithMargin:0.f];
+}
+
 - (NSLayoutConstraint *)autoPinBottomToSuperviewWithMargin:(CGFloat)margin
 {
+    self.translatesAutoresizingMaskIntoConstraints = NO;
+
     if (@available(iOS 9.0, *)) {
         NSLayoutConstraint *constraint =
             [self.bottomAnchor constraintEqualToAnchor:self.superview.layoutMarginsGuide.bottomAnchor constant:-margin];
@@ -311,8 +322,15 @@ CGFloat ScaleFromIPhone5(CGFloat iPhone5Value)
     }
 }
 
+- (NSLayoutConstraint *)autoPinTopToSuperview
+{
+    return [self autoPinTopToSuperviewWithMargin:0.f];
+}
+
 - (NSLayoutConstraint *)autoPinTopToSuperviewWithMargin:(CGFloat)margin
 {
+    self.translatesAutoresizingMaskIntoConstraints = NO;
+
     if (@available(iOS 9.0, *)) {
         NSLayoutConstraint *constraint =
             [self.topAnchor constraintEqualToAnchor:self.superview.layoutMarginsGuide.topAnchor constant:margin];
@@ -333,6 +351,8 @@ CGFloat ScaleFromIPhone5(CGFloat iPhone5Value)
 - (NSLayoutConstraint *)autoPinLeadingToTrailingOfView:(UIView *)view margin:(CGFloat)margin
 {
     OWSAssert(view);
+
+    self.translatesAutoresizingMaskIntoConstraints = NO;
 
     if (@available(iOS 9.0, *)) {
         NSLayoutConstraint *constraint =
@@ -355,6 +375,8 @@ CGFloat ScaleFromIPhone5(CGFloat iPhone5Value)
 {
     OWSAssert(view);
 
+    self.translatesAutoresizingMaskIntoConstraints = NO;
+
     if (@available(iOS 9.0, *)) {
         NSLayoutConstraint *constraint =
             [self.trailingAnchor constraintEqualToAnchor:view.leadingAnchor constant:-margin];
@@ -376,6 +398,8 @@ CGFloat ScaleFromIPhone5(CGFloat iPhone5Value)
 {
     OWSAssert(view);
 
+    self.translatesAutoresizingMaskIntoConstraints = NO;
+
     if (@available(iOS 9.0, *)) {
         NSLayoutConstraint *constraint =
             [self.leadingAnchor constraintEqualToAnchor:view.leadingAnchor constant:margin];
@@ -396,6 +420,8 @@ CGFloat ScaleFromIPhone5(CGFloat iPhone5Value)
 - (NSLayoutConstraint *)autoPinTrailingToView:(UIView *)view margin:(CGFloat)margin
 {
     OWSAssert(view);
+
+    self.translatesAutoresizingMaskIntoConstraints = NO;
 
     if (@available(iOS 9.0, *)) {
         NSLayoutConstraint *constraint =

--- a/SignalMessaging/utils/OWSMessagesBubbleImageFactory.swift
+++ b/SignalMessaging/utils/OWSMessagesBubbleImageFactory.swift
@@ -1,5 +1,5 @@
 //
-//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//  Copyright (c) 2018 Open Whisper Systems. All rights reserved.
 //
 
 import Foundation
@@ -8,7 +8,7 @@ import SignalServiceKit
 import SignalMessaging
 
 @objc
-class OWSMessagesBubbleImageFactory: NSObject {
+public class OWSMessagesBubbleImageFactory: NSObject {
 
     static let shared = OWSMessagesBubbleImageFactory()
 

--- a/SignalServiceKit/src/Messages/OWSMessageSender.h
+++ b/SignalServiceKit/src/Messages/OWSMessageSender.h
@@ -1,10 +1,12 @@
 //
-//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//  Copyright (c) 2018 Open Whisper Systems. All rights reserved.
 //
 
 #import "DataSource.h"
 
 NS_ASSUME_NONNULL_BEGIN
+
+extern const NSUInteger kOversizeTextMessageSizeThreshold;
 
 @class ContactsUpdater;
 @class OWSBlockingManager;

--- a/SignalServiceKit/src/Messages/OWSMessageSender.m
+++ b/SignalServiceKit/src/Messages/OWSMessageSender.m
@@ -45,6 +45,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+const NSUInteger kOversizeTextMessageSizeThreshold = 16 * 1024;
+
 void AssertIsOnSendingQueue()
 {
 #ifdef DEBUG
@@ -383,6 +385,9 @@ NSString *const OWSMessageSenderRateLimitedException = @"RateLimitedException";
                failure:(void (^)(NSError *error))failureHandler
 {
     OWSAssert(message);
+    if (message.body.length > 0) {
+        OWSAssert([message.body lengthOfBytesUsingEncoding:NSUTF8StringEncoding] <= kOversizeTextMessageSizeThreshold);
+    }
 
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         // This method will use a read/write transaction. This transaction

--- a/SignalServiceKit/src/Util/OWSFileSystem.h
+++ b/SignalServiceKit/src/Util/OWSFileSystem.h
@@ -29,6 +29,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (NSArray<NSString *> *_Nullable)allFilesInDirectoryRecursive:(NSString *)dirPath error:(NSError **)error;
 
+// Returns nil on failure.
++ (nullable NSString *)writeDataToTemporaryFile:(NSData *)data fileExtension:(NSString *_Nullable)fileExtension;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SignalServiceKit/src/Util/OWSFileSystem.m
+++ b/SignalServiceKit/src/Util/OWSFileSystem.m
@@ -166,6 +166,28 @@ NS_ASSUME_NONNULL_BEGIN
     return filePaths;
 }
 
++ (nullable NSString *)writeDataToTemporaryFile:(NSData *)data fileExtension:(NSString *_Nullable)fileExtension
+{
+    OWSAssert(data);
+
+    NSString *temporaryDirectory = NSTemporaryDirectory();
+    NSString *tempFileName = NSUUID.UUID.UUIDString;
+    if (fileExtension.length > 0) {
+        tempFileName = [[tempFileName stringByAppendingString:@"."] stringByAppendingString:fileExtension];
+    }
+    NSString *tempFilePath = [temporaryDirectory stringByAppendingPathComponent:tempFileName];
+    NSError *error;
+    BOOL success = [data writeToFile:tempFilePath options:NSDataWritingAtomic error:&error];
+    if (!success || error) {
+        OWSFail(@"%@ could not write to temporary file: %@", self.logTag, error);
+        return nil;
+    }
+
+    [self protectFileOrFolderAtPath:tempFilePath];
+
+    return tempFilePath;
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SignalShareExtension/Info.plist
+++ b/SignalShareExtension/Info.plist
@@ -64,6 +64,7 @@
                 ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.data"
                 || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.url"
                 )
+                AND NOT (ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.vcard")
                 ).@count == 1
                 ).@count == 1
             </string>

--- a/SignalShareExtension/Info.plist
+++ b/SignalShareExtension/Info.plist
@@ -53,21 +53,20 @@
 	<dict>
 		<key>NSExtensionAttributes</key>
 		<dict>
-			<key>NSExtensionActivationRule</key>
-			<dict>
-				<key>NSExtensionActivationSupportsFileWithMaxCount</key>
-				<integer>1</integer>
-				<key>NSExtensionActivationSupportsImageWithMaxCount</key>
-				<integer>1</integer>
-				<key>NSExtensionActivationSupportsMovieWithMaxCount</key>
-				<integer>1</integer>
-				<key>NSExtensionActivationSupportsText</key>
-				<true/>
-				<key>NSExtensionActivationSupportsWebPageWithMaxCount</key>
-				<integer>1</integer>
-				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
-				<integer>1</integer>
-			</dict>
+            <key>NSExtensionActivationRule</key>
+            <string>SUBQUERY (
+                extensionItems,
+                $extensionItem,
+                SUBQUERY (
+                $extensionItem.attachments,
+                $attachment,
+                (
+                ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.data"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.url"
+                )
+                ).@count == 1
+                ).@count == 1
+            </string>
 		</dict>
 		<key>NSExtensionMainStoryboard</key>
 		<string>MainInterface</string>

--- a/SignalShareExtension/ShareViewController.swift
+++ b/SignalShareExtension/ShareViewController.swift
@@ -79,7 +79,7 @@ public class ShareViewController: UINavigationController, ShareViewDelegate, SAE
         self.loadViewController = loadViewController
 
         // Don't display load screen immediately, in hopes that we can avoid it altogether.
-        after(seconds: 0.5).then { () -> Void in
+        after(seconds: 0.25).then { () -> Void in
             guard self.presentedViewController == nil else {
                 Logger.debug("\(self.logTag) setup completed quickly, no need to present load view controller.")
                 return

--- a/SignalShareExtension/ShareViewController.swift
+++ b/SignalShareExtension/ShareViewController.swift
@@ -457,7 +457,6 @@ public class ShareViewController: UINavigationController, ShareViewDelegate, SAE
         // class to convert types for us.
         let utiTypes: [String] = [kUTTypeImage as String,
                                   kUTTypeData as String]
-        Logger.verbose("\(self.logTag) in \(#function): registeredTypeIdentifiers: \(itemProvider.registeredTypeIdentifiers)")
 
         let matchingUtiType = utiTypes.first { (utiType: String) -> Bool in
             itemProvider.hasItemConformingToTypeIdentifier(utiType)

--- a/SignalShareExtension/ShareViewController.swift
+++ b/SignalShareExtension/ShareViewController.swift
@@ -520,6 +520,7 @@ public class ShareViewController: UINavigationController, ShareViewDelegate, SAE
 
             var rawDataSource: DataSource?
             if utiType == (kUTTypeURL as String) {
+                // Share URLs as oversize text messages whose text content is the URL.
                 let urlString = url.absoluteString
                 rawDataSource = DataSourceValue.dataSource(withOversizeText:urlString)
             } else {
@@ -529,12 +530,14 @@ public class ShareViewController: UINavigationController, ShareViewDelegate, SAE
                 throw ShareViewControllerError.assertionError(description: "Unable to read attachment data")
             }
             if utiType != (kUTTypeURL as String) {
+                // Ignore the filename for URLs.
                 dataSource.sourceFilename = url.lastPathComponent
             }
 
             // start with base utiType, but it might be something generic like "image"
             var specificUTIType = utiType
             if utiType == (kUTTypeURL as String) {
+                // Share URLs as oversize text messages whose text content is the URL.
                 Logger.debug("\(self.logTag) using text UTI type for URL.")
                 specificUTIType = kOversizeTextAttachmentUTI as String
             } else if url.pathExtension.count > 0 {

--- a/SignalShareExtension/ShareViewController.swift
+++ b/SignalShareExtension/ShareViewController.swift
@@ -442,7 +442,7 @@ public class ShareViewController: UINavigationController, ShareViewDelegate, SAE
     }
 
     private func utiTypeForItem(itemProvider: NSItemProvider) -> String? {
-        // Special case URLs.  Most shares will confirm to kUTTypeURL, but
+        // Special case URLs.  Many shares (e.g. pdfs) will register kUTTypeURL, but
         // URLs will have kUTTypeURL as their only registered UTI type.
         if itemProvider.registeredTypeIdentifiers.count == 1 {
             if let firstUtiType = itemProvider.registeredTypeIdentifiers.first {

--- a/SignalShareExtension/ShareViewController.swift
+++ b/SignalShareExtension/ShareViewController.swift
@@ -259,7 +259,10 @@ public class ShareViewController: UINavigationController, ShareViewDelegate, SAE
             // is has already saved their local profile key in the main app.
             showNotReadyView()
         } else {
-            presentConversationPicker()
+            DispatchQueue.main.async { [weak self] in
+                guard let strongSelf = self else { return }
+                strongSelf.presentConversationPicker()
+            }
         }
 
         // We don't use the AppUpdateNag in the SAE.

--- a/SignalShareExtension/ShareViewController.swift
+++ b/SignalShareExtension/ShareViewController.swift
@@ -540,7 +540,7 @@ public class ShareViewController: UINavigationController, ShareViewDelegate, SAE
         }
         Logger.debug("\(logTag) matched utiType: \(srcUtiType)")
 
-        let (promise, fulfill, reject) = Promise<(URL, String)>.pending()
+        let (promise, fulfill, reject) = Promise<(itemUrl: URL, utiType: String)>.pending()
 
         var customFileName: String?
         var isConvertibleToTextMessage = false
@@ -576,7 +576,7 @@ public class ShareViewController: UINavigationController, ShareViewDelegate, SAE
                     return
                 }
                 let fileUrl = URL(fileURLWithPath:tempFilePath)
-                fulfill((fileUrl, srcUtiType))
+                fulfill((itemUrl: fileUrl, utiType: srcUtiType))
             } else if let string = value as? String {
                 Logger.debug("\(self.logTag) string provider: \(string)")
                 guard let data = string.data(using: String.Encoding.utf8) else {
@@ -595,18 +595,18 @@ public class ShareViewController: UINavigationController, ShareViewDelegate, SAE
                 isConvertibleToTextMessage = !itemProvider.registeredTypeIdentifiers.contains(kUTTypeFileURL as String)
 
                 if UTTypeConformsTo(srcUtiType as CFString, kUTTypeText) {
-                    fulfill((fileUrl, srcUtiType))
+                    fulfill((itemUrl: fileUrl, utiType: srcUtiType))
                 } else {
-                    fulfill((fileUrl, kUTTypeText as String))
+                    fulfill((itemUrl: fileUrl, utiType:  kUTTypeText as String))
                 }
             } else if let url = value as? URL {
                 // If the share itself is a URL (e.g. a link from Safari), try to send this as a text message.
                 isConvertibleToTextMessage = (itemProvider.registeredTypeIdentifiers.contains(kUTTypeURL as String) &&
                     !itemProvider.registeredTypeIdentifiers.contains(kUTTypeFileURL as String))
                 if isConvertibleToTextMessage {
-                    fulfill((url, kUTTypeURL as String))
+                    fulfill((itemUrl: url, utiType: kUTTypeURL as String))
                 } else {
-                    fulfill((url, srcUtiType))
+                    fulfill((itemUrl: url, utiType: srcUtiType))
                 }
             } else {
                 // It's unavoidable that we may sometimes receives data types that we
@@ -633,7 +633,7 @@ public class ShareViewController: UINavigationController, ShareViewDelegate, SAE
 
             Logger.debug("\(self.logTag) building DataSource with url: \(url), utiType: \(utiType)")
 
-            guard let dataSource = ShareViewController.createDataSource(utiType : utiType, url : url, customFileName : customFileName) else {
+            guard let dataSource = ShareViewController.createDataSource(utiType: utiType, url: url, customFileName: customFileName) else {
                 throw ShareViewControllerError.assertionError(description: "Unable to read attachment data")
             }
 

--- a/SignalShareExtension/ShareViewController.swift
+++ b/SignalShareExtension/ShareViewController.swift
@@ -440,16 +440,24 @@ public class ShareViewController: UINavigationController, ShareViewDelegate, SAE
             owsFail("\(self.logTag) building attachment failed with error: \(error)")
         }.retainUntilComplete()
     }
+    
+    private func isUrlItem(itemProvider: NSItemProvider) -> Bool {
+        // Special case URLs.  Many shares (e.g. pdfs) will register kUTTypeURL, but
+        // URLs will have kUTTypeURL as their only registered UTI type.
+        guard itemProvider.registeredTypeIdentifiers.count == 1 else {
+            return false
+        }
+        guard let firstUtiType = itemProvider.registeredTypeIdentifiers.first else {
+            return false
+        }
+        return firstUtiType == kUTTypeURL as String
+    }
 
     private func utiTypeForItem(itemProvider: NSItemProvider) -> String? {
         // Special case URLs.  Many shares (e.g. pdfs) will register kUTTypeURL, but
         // URLs will have kUTTypeURL as their only registered UTI type.
-        if itemProvider.registeredTypeIdentifiers.count == 1 {
-            if let firstUtiType = itemProvider.registeredTypeIdentifiers.first {
-                if firstUtiType == kUTTypeURL as String {
-                    return kUTTypeURL as String
-                }
-            }
+        if isUrlItem(itemProvider:itemProvider) {
+            return kUTTypeURL as String
         }
 
         // Order matters if we want to take advantage of share conversion in loadItem,
@@ -598,7 +606,7 @@ public class ShareViewController: UINavigationController, ShareViewDelegate, SAE
     // Perhaps the AVFoundation APIs require some extra file system permssion we don't have in the
     // passed through URL.
     private func isVideoNeedingRelocation(itemProvider: NSItemProvider, itemUrl: URL) -> Bool {
-        if itemProvider.hasItemConformingToTypeIdentifier(kUTTypeURL as String) {
+        if isUrlItem(itemProvider:itemProvider) {
             return false
         }
 

--- a/SignalShareExtension/ShareViewController.swift
+++ b/SignalShareExtension/ShareViewController.swift
@@ -630,6 +630,8 @@ public class ShareViewController: UINavigationController, ShareViewDelegate, SAE
         //
         // Unfortunately, we have no alternative.  Therefore, we face the real possibility
         // of receiving an "unexpected type" that we don't know how to handle.
+        //
+        // See: https://developer.apple.com/documentation/foundation/nsitemprovider/1403900-loaditemfortypeidentifier
         itemProvider.loadItem(forTypeIdentifier: srcUtiType, options: nil, completionHandler: loadCompletion)
 
         return promise.then { (itemUrl: URL, utiType: String) -> Promise<SignalAttachment> in

--- a/SignalShareExtension/ShareViewController.swift
+++ b/SignalShareExtension/ShareViewController.swift
@@ -584,6 +584,9 @@ public class ShareViewController: UINavigationController, ShareViewDelegate, SAE
             var rawDataSource: DataSource?
             if utiType == (kUTTypeURL as String) {
                 // Share URLs as oversize text messages whose text content is the URL.
+                //
+                // NOTE: SharingThreadPickerViewController will try to unpack them
+                //       and send them as normal text messages if possible.
                 let urlString = url.absoluteString
                 rawDataSource = DataSourceValue.dataSource(withOversizeText:urlString)
             } else {

--- a/SignalShareExtension/ShareViewController.swift
+++ b/SignalShareExtension/ShareViewController.swift
@@ -79,7 +79,7 @@ public class ShareViewController: UINavigationController, ShareViewDelegate, SAE
         self.loadViewController = loadViewController
 
         // Don't display load screen immediately, in hopes that we can avoid it altogether.
-        after(seconds: 0.25).then { () -> Void in
+        after(seconds: 0.5).then { () -> Void in
             guard self.presentedViewController == nil else {
                 Logger.debug("\(self.logTag) setup completed quickly, no need to present load view controller.")
                 return
@@ -463,16 +463,6 @@ public class ShareViewController: UINavigationController, ShareViewDelegate, SAE
                                           utiType:kUTTypeContact as String)
     }
 
-    private class func isSpecialItem(itemProvider: NSItemProvider) -> Bool {
-        if isUrlItem(itemProvider:itemProvider) {
-            return true
-        } else if isContactItem(itemProvider:itemProvider) {
-            return true
-        } else {
-            return false
-        }
-    }
-
     private class func utiTypeForItem(itemProvider: NSItemProvider) -> String? {
         Logger.info("\(self.logTag) utiTypeForItem: \(itemProvider.registeredTypeIdentifiers)")
 
@@ -718,9 +708,7 @@ public class ShareViewController: UINavigationController, ShareViewDelegate, SAE
     // Perhaps the AVFoundation APIs require some extra file system permssion we don't have in the
     // passed through URL.
     private func isVideoNeedingRelocation(itemProvider: NSItemProvider, itemUrl: URL) -> Bool {
-        if ShareViewController.isSpecialItem(itemProvider:itemProvider) {
-            return false
-        }
+        Logger.info("\(self.logTag) isVideoNeedingRelocation: \(itemProvider.registeredTypeIdentifiers), itemUrl: \(itemUrl)")
 
         let pathExtension = itemUrl.pathExtension
         guard pathExtension.count > 0 else {
@@ -731,6 +719,7 @@ public class ShareViewController: UINavigationController, ShareViewDelegate, SAE
             Logger.verbose("\(self.logTag) in \(#function): item has unknown UTI type: \(itemUrl).")
             return false
         }
+        Logger.verbose("\(self.logTag) utiTypeForURL: \(utiTypeForURL)")
         guard utiTypeForURL == kUTTypeMPEG4 as String else {
             // Either it's not a video or it was a video which was not auto-converted to mp4.
             // Not affected by the issue.

--- a/SignalShareExtension/ShareViewController.swift
+++ b/SignalShareExtension/ShareViewController.swift
@@ -507,8 +507,7 @@ public class ShareViewController: UINavigationController, ShareViewDelegate, SAE
             //
             // NOTE: SharingThreadPickerViewController will try to unpack them
             //       and send them as normal text messages if possible.
-            let urlString = url.absoluteString
-            return DataSourceValue.dataSource(withOversizeText:urlString)
+            return DataSourcePath.dataSource(with: url)
         } else {
             guard let dataSource = DataSourcePath.dataSource(with: url) else {
                 return nil
@@ -579,6 +578,7 @@ public class ShareViewController: UINavigationController, ShareViewDelegate, SAE
                 let fileUrl = URL(fileURLWithPath:tempFilePath)
                 fulfill((fileUrl, srcUtiType))
             } else if let string = provider as? String {
+                Logger.debug("\(self.logTag) string provider: \(string)")
                 guard let data = string.data(using: String.Encoding.utf8) else {
                     let writeError = ShareViewControllerError.assertionError(description: "Error writing item data: \(String(describing: error))")
                     reject(writeError)

--- a/SignalShareExtension/ShareViewController.swift
+++ b/SignalShareExtension/ShareViewController.swift
@@ -605,9 +605,7 @@ public class ShareViewController: UINavigationController, ShareViewDelegate, SAE
             // start with base utiType, but it might be something generic like "image"
             var specificUTIType = utiType
             if utiType == (kUTTypeURL as String) {
-                // Share URLs as oversize text messages whose text content is the URL.
-                Logger.debug("\(self.logTag) using text UTI type for URL.")
-                specificUTIType = kOversizeTextAttachmentUTI as String
+                // Use kUTTypeURL for URLs.
             } else if url.pathExtension.count > 0 {
                 // Determine a more specific utiType based on file extension
                 if let typeExtension = MIMETypeUtil.utiType(forFileExtension: url.pathExtension) {

--- a/SignalShareExtension/ShareViewController.swift
+++ b/SignalShareExtension/ShareViewController.swift
@@ -609,23 +609,17 @@ public class ShareViewController: UINavigationController, ShareViewDelegate, SAE
                     fulfill((url, srcUtiType))
                 }
             } else {
+                // It's unavoidable that we may sometimes receives data types that we
+                // don't know how to handle.
+                //
+                // See comments on NSItemProvider+OWS.h.
                 let unexpectedTypeError = ShareViewControllerError.assertionError(description: "unexpected value: \(String(describing: value))")
                 reject(unexpectedTypeError)
             }
         }
 
-        // NSItemProvider.loadItem(forTypeIdentifier:...) is unsafe to call from Swift,
-        // since it can yield values of arbitrary type.  It has a highly unusual design
-        // in which its behavior depends on the _type_ of the completion handler.
-        // loadItem(forTypeIdentifier:...) tries to satisfy the expected type of the
-        // completion handler.  This "hinting" only works in Objective-C.  In Swift,
-        // The type of the completion handler must agree with the param type.
-        //
-        // Unfortunately, we have no alternative.  Therefore, we face the real possibility
-        // of receiving an "unexpected type" that we don't know how to handle.
-        //
-        // See: https://developer.apple.com/documentation/foundation/nsitemprovider/1403900-loaditemfortypeidentifier
-        itemProvider.loadItem(forTypeIdentifier: srcUtiType, options: nil, completionHandler: loadCompletion)
+        // See comments on NSItemProvider+OWS.h.
+        itemProvider.loadData(forTypeIdentifier: srcUtiType, options: nil, completionHandler: loadCompletion)
 
         return promise.then { (itemUrl: URL, utiType: String) -> Promise<SignalAttachment> in
 

--- a/SignalShareExtension/ShareViewController.swift
+++ b/SignalShareExtension/ShareViewController.swift
@@ -532,6 +532,15 @@ public class ShareViewController: UINavigationController, ShareViewDelegate, SAE
         }
         Logger.info("\(self.logTag) attachment: \(itemProvider)")
 
+        // We need to be very careful about which UTI type we use.
+        //
+        // * In the case of "textual" shares (e.g. web URLs and text snippets), we want to
+        //   coerce the UTI type to kUTTypeURL or kUTTypeText.
+        // * We want to treat shared files as file attachments.  Therefore we do not
+        //   want to treat file URLs like web URLs.
+        // * UTIs aren't very descriptive (there are far more MIME types than UTI types)
+        //   so in the case of file attachments we try to refine the attachment type
+        //   using the file extension.
         guard let srcUtiType = ShareViewController.utiTypeForItem(itemProvider: itemProvider) else {
             let error = ShareViewControllerError.unsupportedMedia
             return Promise(error: error)

--- a/SignalShareExtension/SignalShareExtension-Bridging-Header.h
+++ b/SignalShareExtension/SignalShareExtension-Bridging-Header.h
@@ -6,6 +6,7 @@
 #import <UIKit/UIKit.h>
 
 // Separate iOS Frameworks from other imports.
+#import "NSItemProvider+OWS.h"
 #import "ShareAppExtensionContext.h"
 #import <SignalMessaging/DebugLogger.h>
 #import <SignalMessaging/Environment.h>

--- a/SignalShareExtension/utils/NSItemProvider+OWS.h
+++ b/SignalShareExtension/utils/NSItemProvider+OWS.h
@@ -1,0 +1,26 @@
+//
+//  Copyright (c) 2018 Open Whisper Systems. All rights reserved.
+//
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NSItemProvider (OWS)
+
+// NSItemProvider.loadItem(forTypeIdentifier:...) is unsafe to call from Swift,
+// since it can yield values of arbitrary type.  It has a highly unusual design
+// in which its behavior depends on the _type_ of the completion handler.
+// loadItem(forTypeIdentifier:...) tries to satisfy the expected type of the
+// completion handler.  This "hinting" only works in Objective-C.  In Swift,
+// The type of the completion handler must agree with the param type.
+//
+// Therefore we use an Objective-C category to hint to NSItemProvider that we
+// prefer an instance of NSData.
+//
+// See: https://developer.apple.com/documentation/foundation/nsitemprovider/1403900-loaditemfortypeidentifier
+- (void)loadDataForTypeIdentifier:(NSString *)typeIdentifier
+                          options:(nullable NSDictionary *)options
+                completionHandler:(nullable NSItemProviderCompletionHandler)completionHandler;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/SignalShareExtension/utils/NSItemProvider+OWS.m
+++ b/SignalShareExtension/utils/NSItemProvider+OWS.m
@@ -1,0 +1,24 @@
+//
+//  Copyright (c) 2018 Open Whisper Systems. All rights reserved.
+//
+
+#import "NSItemProvider+OWS.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation NSItemProvider (OWS)
+
+- (void)loadDataForTypeIdentifier:(NSString *)typeIdentifier
+                          options:(nullable NSDictionary *)options
+                completionHandler:(nullable NSItemProviderCompletionHandler)completionHandler
+{
+    [self loadItemForTypeIdentifier:typeIdentifier
+                            options:options
+                  completionHandler:^(NSData *_Nullable item, NSError *__null_unspecified error) {
+                      completionHandler(item, error);
+                  }];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
* Adds support for sharing URLs in SAE.
  * Our entire SAE experience is premised around attachments, not text messages, so we'll share URLs (and other textual shares) as "oversize text message" attachments.
* Modified attachment approval view to properly preview "oversize text message" attachments.
* Fixed support for sharing arbitrary data (e.g. PDFs, .log, etc.)

PTAL @michaelkirk 

![simulator screen shot - iphone x - 2018-01-11 at 13 32 43](https://user-images.githubusercontent.com/625803/34840867-5a098dc8-f6d4-11e7-90f0-086b7ee765fa.png)
![simulator screen shot - iphone x - 2018-01-11 at 13 32 30](https://user-images.githubusercontent.com/625803/34840868-5a1af6da-f6d4-11e7-968a-f3d73c1bc01e.png)
