### PR TITLE
Remove spurious warning.

### DIFF
--- a/SignalServiceKit/src/Storage/OWSStorage.m
+++ b/SignalServiceKit/src/Storage/OWSStorage.m
@@ -263,6 +263,7 @@ typedef NSData *_Nullable (^CreateDatabaseMetadataBlock)(void);
             //
             // The best we can try to do is to discard the current database
             // and behave like a clean install.
+            OWSFail(@"%@ Could not load database", self.logTag);
             OWSProdCritical([OWSAnalyticsEvents storageErrorCouldNotLoadDatabase]);
 
             // Try to reset app by deleting all databases.
@@ -271,6 +272,7 @@ typedef NSData *_Nullable (^CreateDatabaseMetadataBlock)(void);
             //            [OWSStorage deleteDatabaseFiles];
 
             if (![self tryToLoadDatabase]) {
+                OWSFail(@"%@ Could not load database (second try)", self.logTag);
                 OWSProdCritical([OWSAnalyticsEvents storageErrorCouldNotLoadDatabaseSecondAttempt]);
 
                 // Sleep to give analytics events time to be delivered.
@@ -665,6 +667,7 @@ typedef NSData *_Nullable (^CreateDatabaseMetadataBlock)(void);
 
         BOOL shouldHaveDatabaseMetadata = [NSFileManager.defaultManager fileExistsAtPath:[self databaseFilePath]];
         if (shouldHaveDatabaseMetadata) {
+            OWSFail(@"%@ Could not load database metadata", self.logTag);
             OWSProdCritical([OWSAnalyticsEvents storageErrorCouldNotLoadDatabaseSecondAttempt]);
         }
 
@@ -754,6 +757,7 @@ typedef NSData *_Nullable (^CreateDatabaseMetadataBlock)(void);
     [SAMKeychain setAccessibilityType:kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly];
     BOOL success = [SAMKeychain setPasswordData:data forService:keychainService account:keychainKey error:&error];
     if (!success || error) {
+        OWSFail(@"%@ Could not store database metadata", self.logTag);
         OWSProdCritical([OWSAnalyticsEvents storageErrorCouldNotStoreKeychainValue]);
 
         [OWSStorage deletePasswordFromKeychain];

--- a/SignalServiceKit/src/Util/OWSFileSystem.h
+++ b/SignalServiceKit/src/Util/OWSFileSystem.h
@@ -8,8 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 
-// TODO: We shouldn't ignore the return value of this method.
-+ (BOOL)protectFileOrFolderAtPath:(NSString *)path __attribute__((warn_unused_result));
++ (BOOL)protectFileOrFolderAtPath:(NSString *)path;
 
 + (NSString *)appDocumentDirectoryPath;
 

--- a/SignalServiceKit/src/Util/OWSFileSystem.m
+++ b/SignalServiceKit/src/Util/OWSFileSystem.m
@@ -25,6 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
     BOOL success = [ressourceURL setResourceValues:resourcesAttrs error:&error];
 
     if (error || !success) {
+        OWSFail(@"Could not protect file or folder: %@", error);
         OWSProdCritical([OWSAnalyticsEvents storageErrorFileProtection]);
         return NO;
     }


### PR DESCRIPTION
Having looked at the callers of this method, I don't think we need this warning.  I didn't realize we had an `OWSFail()` within the method itself.

PTAL @michaelkirk 