### PR TITLE
block vs share

### DIFF
--- a/SignalMessaging/contacts/SelectThreadViewController.m
+++ b/SignalMessaging/contacts/SelectThreadViewController.m
@@ -234,7 +234,31 @@ NS_ASSUME_NONNULL_BEGIN
         }
                                         customRowHeight:[ContactTableViewCell rowHeight]
                                         actionBlock:^{
-                                            [weakSelf.selectThreadViewDelegate threadWasSelected:thread];
+                                            typeof(self) strongSelf = weakSelf;
+                                            if (!strongSelf) {
+                                                return;
+                                            }
+
+                                            if ([thread isKindOfClass:[TSContactThread class]]) {
+                                                BOOL isBlocked = [helper isRecipientIdBlocked:thread.contactIdentifier];
+                                                if (isBlocked
+                                                    && ![strongSelf.selectThreadViewDelegate canSelectBlockedContact]) {
+                                                    [BlockListUIUtils
+                                                        showUnblockPhoneNumberActionSheet:thread.contactIdentifier
+                                                                       fromViewController:strongSelf
+                                                                          blockingManager:helper.blockingManager
+                                                                          contactsManager:helper.contactsManager
+                                                                          completionBlock:^(BOOL isStillBlocked) {
+                                                                              if (!isStillBlocked) {
+                                                                                  [strongSelf.selectThreadViewDelegate
+                                                                                      threadWasSelected:thread];
+                                                                              }
+                                                                          }];
+                                                    return;
+                                                }
+                                            }
+
+                                            [strongSelf.selectThreadViewDelegate threadWasSelected:thread];
                                         }]];
     }
 


### PR DESCRIPTION
We were showing a "blocked" label, but not actually preventing the user from trying to send to a blocked conversation. What would happen is that after captioning the attachment when you actually tried to send, you'd get a dialog like "Can't send to Michael because he is blocked."

Now when you tap a blocked conversation, you are met with the familiar "Unblock?" actionsheet before you can proceed.

![unblock](https://user-images.githubusercontent.com/217057/35072017-f0f23308-fbb0-11e7-9ca5-3cb5f46bda51.JPG)
