### PR TITLE
Fix attachment approval layout on iPhoneX

### DIFF
--- a/SignalMessaging/contacts/SelectThreadViewController.m
+++ b/SignalMessaging/contacts/SelectThreadViewController.m
@@ -116,8 +116,7 @@ NS_ASSUME_NONNULL_BEGIN
     [self.view addSubview:self.tableViewController.view];
     [_tableViewController.view autoPinWidthToSuperview];
     [_tableViewController.view autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:header];
-
-    [self autoPinViewToBottomGuideOrKeyboard:self.tableViewController.view];
+    [_tableViewController.view autoPinEdgeToSuperviewEdge:ALEdgeBottom];
 }
 
 - (void)yapDatabaseModifiedExternally:(NSNotification *)notification


### PR DESCRIPTION
convert captioning toolbar to autolayout in the process

Respecting the margins of the root view is key to iPhoneX layout, since they vary be device.

## Recipient Picker

**before:**

<img width="478" alt="master x share recipient list" src="https://user-images.githubusercontent.com/217057/35710091-6f8b3704-076a-11e8-9574-d41a8ca6757c.png">

**after:**

<img width="478" alt="proposed x share recipient list" src="https://user-images.githubusercontent.com/217057/35710093-71a264f4-076a-11e8-8d58-039cf5462065.png">

## Approval View

**before**
<img width="478" alt="master x approval view portrait" src="https://user-images.githubusercontent.com/217057/35710116-8f7952c6-076a-11e8-96d0-29ed68f3486a.png">

<img width="832" alt="before x approval landscape keyboard" src="https://user-images.githubusercontent.com/217057/35710531-df1e025c-076c-11e8-8e04-4554122a746c.png">

**after**

<img width="478" alt="screen shot 2018-02-01 at 4 28 31 pm" src="https://user-images.githubusercontent.com/217057/35710556-0ab4c734-076d-11e8-94de-0c6cb22e77f6.png">
<img width="478" alt="screen shot 2018-02-01 at 4 28 41 pm" src="https://user-images.githubusercontent.com/217057/35710557-0ad63162-076d-11e8-9f40-b24d7473da94.png">
<img width="832" alt="screen shot 2018-02-01 at 4 28 44 pm" src="https://user-images.githubusercontent.com/217057/35710558-0af45d54-076d-11e8-9cf4-3020c30142a6.png">
<img width="832" alt="screen shot 2018-02-01 at 4 29 05 pm" src="https://user-images.githubusercontent.com/217057/35710559-0b201f8e-076d-11e8-91fc-8545846b6454.png">

PTAL @charlesmchen 