### PR TITLE
Fix "bubble disappears" when receiving read receipt

### DIFF
--- a/Signal/src/ViewControllers/MessageDetailViewController.swift
+++ b/Signal/src/ViewControllers/MessageDetailViewController.swift
@@ -89,8 +89,6 @@ class MessageDetailViewController: OWSViewController, UIScrollViewDelegate, Medi
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        updateTextLayout()
-
         if mode == .focusOnMetadata {
             if let bubbleView = self.bubbleView {
                 // Force layout.
@@ -293,6 +291,8 @@ class MessageDetailViewController: OWSViewController, UIScrollViewDelegate, Medi
         if let mediaMessageView = mediaMessageView {
             mediaMessageView.autoMatch(.height, to: .width, of: mediaMessageView, withOffset:0, relation: .lessThanOrEqual)
         }
+
+        updateTextLayout()
     }
 
     private func displayableTextIfText() -> String? {


### PR DESCRIPTION
We re-create some constraints when `updateContent` is called, so
we need to ensure those constraints are configured by calling
`updateTextLayout`

PTAL @charlesmchen 