### PR TITLE
Refine message date/time formatting.

### DIFF
--- a/Signal/src/ViewControllers/MessageDetailViewController.swift
+++ b/Signal/src/ViewControllers/MessageDetailViewController.swift
@@ -211,7 +211,7 @@ class MessageDetailViewController: OWSViewController, UIScrollViewDelegate, Medi
                 }
 
                 for recipientId in thread.recipientIdentifiers {
-                    let (recipientStatus, statusMessage) = MessageRecipientStatusUtils.recipientStatusAndStatusMessage(outgoingMessage: outgoingMessage, recipientId: recipientId, referenceView: self.view)
+                    let (recipientStatus, shortStatusMessage, longStatusMessage) = MessageRecipientStatusUtils.recipientStatusAndStatusMessage(outgoingMessage: outgoingMessage, recipientId: recipientId, referenceView: self.view)
 
                     guard recipientStatus == recipientStatusGroup else {
                         continue
@@ -229,9 +229,11 @@ class MessageDetailViewController: OWSViewController, UIScrollViewDelegate, Medi
                     let cell = ContactTableViewCell()
                     cell.configure(withRecipientId: recipientId, contactsManager: self.contactsManager)
                     let statusLabel = UILabel()
-                    statusLabel.text = statusMessage
+                    // We use the "short" status message to avoid being redundant with the section title.
+                    statusLabel.text = shortStatusMessage
                     statusLabel.textColor = UIColor.ows_darkGray
                     statusLabel.font = UIFont.ows_footnote()
+                    statusLabel.adjustsFontSizeToFitWidth = true
                     statusLabel.sizeToFit()
                     cell.accessoryView = statusLabel
                     cell.autoSetDimension(.height, toSize: ContactTableViewCell.rowHeight())
@@ -258,12 +260,14 @@ class MessageDetailViewController: OWSViewController, UIScrollViewDelegate, Medi
 
         rows.append(valueRow(name: NSLocalizedString("MESSAGE_METADATA_VIEW_SENT_DATE_TIME",
                                                      comment: "Label for the 'sent date & time' field of the 'message metadata' view."),
-                             value: DateUtil.formatPastTimestampRelativeToNow(message.timestamp)))
+                             value: DateUtil.formatPastTimestampRelativeToNow(message.timestamp,
+                                                                              isRTL:self.view.isRTL())))
 
         if message as? TSIncomingMessage != nil {
             rows.append(valueRow(name: NSLocalizedString("MESSAGE_METADATA_VIEW_RECEIVED_DATE_TIME",
                                                          comment: "Label for the 'received date & time' field of the 'message metadata' view."),
-                                 value: DateUtil.formatPastTimestampRelativeToNow(message.timestampForSorting())))
+                                 value: DateUtil.formatPastTimestampRelativeToNow(message.timestampForSorting(),
+                                                                                  isRTL:self.view.isRTL())))
         }
 
         rows += addAttachmentMetadataRows()

--- a/Signal/src/util/DateUtil.h
+++ b/Signal/src/util/DateUtil.h
@@ -1,6 +1,8 @@
 //
-//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//  Copyright (c) 2018 Open Whisper Systems. All rights reserved.
 //
+
+NS_ASSUME_NONNULL_BEGIN
 
 @interface DateUtil : NSObject
 
@@ -11,6 +13,8 @@
 + (BOOL)dateIsToday:(NSDate *)date;
 
 + (NSString *)formatPastTimestampRelativeToNow:(uint64_t)pastTimestamp
-    NS_SWIFT_NAME(formatPastTimestampRelativeToNow(_:));
+                                         isRTL:(BOOL)isRTL NS_SWIFT_NAME(formatPastTimestampRelativeToNow(_:isRTL:));
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Signal/src/util/DateUtil.m
+++ b/Signal/src/util/DateUtil.m
@@ -87,8 +87,6 @@ static NSString *const DATE_FORMAT_WEEKDAY = @"EEEE";
         dateString = NSLocalizedString(@"DATE_TODAY", @"The current day.");
     } else if ([self dateIsYesterday:pastDate]) {
         dateString = NSLocalizedString(@"DATE_YESTERDAY", @"The day before today.");
-    } else if (![self dateIsOlderThanOneWeek:pastDate]) {
-        dateString = [[self weekdayFormatter] stringFromDate:pastDate];
     } else {
         dateString = [[self dateFormatter] stringFromDate:pastDate];
     }

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -493,6 +493,12 @@
 /* Title shown while the app is updating its database. */
 "DATABASE_VIEW_OVERLAY_TITLE" = "Updating Database";
 
+/* The current day. */
+"DATE_TODAY" = "Today";
+
+/* The day before today. */
+"DATE_YESTERDAY" = "Yesterday";
+
 /* Message indicating that the debug log is being uploaded. */
 "DEBUG_LOG_ACTIVITY_INDICATOR" = "Sending Debug Log...";
 

--- a/SignalMessaging/categories/NSString+OWS.h
+++ b/SignalMessaging/categories/NSString+OWS.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//  Copyright (c) 2018 Open Whisper Systems. All rights reserved.
 //
 
 NS_ASSUME_NONNULL_BEGIN
@@ -9,6 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString *)ows_stripped;
 
 - (NSString *)rtlSafeAppend:(NSString *)string referenceView:(UIView *)referenceView;
+- (NSString *)rtlSafeAppend:(NSString *)string isRTL:(BOOL)isRTL;
 
 - (NSString *)digitsOnly;
 

--- a/SignalMessaging/categories/NSString+OWS.m
+++ b/SignalMessaging/categories/NSString+OWS.m
@@ -1,5 +1,5 @@
 //
-//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//  Copyright (c) 2018 Open Whisper Systems. All rights reserved.
 //
 
 #import "NSString+OWS.h"
@@ -19,7 +19,14 @@ NS_ASSUME_NONNULL_BEGIN
     OWSAssert(string);
     OWSAssert(referenceView);
 
-    if ([referenceView isRTL]) {
+    return [self rtlSafeAppend:string isRTL:referenceView.isRTL];
+}
+
+- (NSString *)rtlSafeAppend:(NSString *)string isRTL:(BOOL)isRTL
+{
+    OWSAssert(string);
+
+    if (isRTL) {
         return [string stringByAppendingString:self];
     } else {
         return [self stringByAppendingString:string];
@@ -28,7 +35,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSString *)removeAllCharactersIn:(NSCharacterSet *)characterSet
 {
-    OWSAssert(characterSet != nil);
+    OWSAssert(characterSet);
+
     return [[self componentsSeparatedByCharactersInSet:characterSet] componentsJoinedByString:@""];
 }
 


### PR DESCRIPTION
PTAL @michaelkirk 

* Always show time on "read".
* Remove redundant messages (e.g. read) from status lines - they're redundant with the section title.
* Show time on "delivered" if possible - but we won't have that until we start sending new-style delivery receipts.
* We don't track "sent" times.  We could.

![simulator screen shot - iphone x - 2018-02-13 at 13 05 30](https://user-images.githubusercontent.com/625803/36165801-b5d6ed90-10be-11e8-9a26-9a43216c60a1.png)
![simulator screen shot - iphone x - 2018-02-13 at 13 05 20](https://user-images.githubusercontent.com/625803/36165802-b5e33050-10be-11e8-8de4-70b968f70838.png)
![simulator screen shot - iphone x - 2018-02-13 at 13 05 10](https://user-images.githubusercontent.com/625803/36165803-b5f56eaa-10be-11e8-87bf-763288b050f2.png)
![simulator screen shot - iphone x - 2018-02-13 at 13 04 49](https://user-images.githubusercontent.com/625803/36165804-b6031ee2-10be-11e8-8898-5714ce22eecb.png)
![simulator screen shot - iphone x - 2018-02-13 at 13 04 44](https://user-images.githubusercontent.com/625803/36165806-b611755a-10be-11e8-947e-acffc6520491.png)
![simulator screen shot - iphone x - 2018-02-13 at 13 04 40](https://user-images.githubusercontent.com/625803/36165807-b61fe6e4-10be-11e8-9ad0-4836f005abb8.png)
![simulator screen shot - iphone x - 2018-02-13 at 13 04 36](https://user-images.githubusercontent.com/625803/36165809-b6311f72-10be-11e8-9877-e654d24f6031.png)
![simulator screen shot - iphone x - 2018-02-13 at 13 04 13](https://user-images.githubusercontent.com/625803/36165811-b63dbac0-10be-11e8-9085-eeaf187c46b3.png)
![simulator screen shot - iphone x - 2018-02-13 at 13 04 02](https://user-images.githubusercontent.com/625803/36165812-b64ce810-10be-11e8-9bc9-10775921e766.png)
