### PR TITLE
Charlesmchen/message sender deadlocks

### DIFF
--- a/SignalServiceKit/src/Messages/OWSMessageSender.m
+++ b/SignalServiceKit/src/Messages/OWSMessageSender.m
@@ -1310,7 +1310,7 @@ NSString *const OWSMessageSenderRateLimitedException = @"RateLimitedException";
         TSRequest *request =
             [[TSRecipientPrekeyRequest alloc] initWithRecipient:identifier deviceId:[deviceNumber stringValue]];
         [self.networkManager makeRequest:request
-            shouldCompleteOnMainQueue:NO
+            completionQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)
             success:^(NSURLSessionDataTask *task, id responseObject) {
                 bundle = [PreKeyBundle preKeyBundleFromDictionary:responseObject forDeviceNumber:deviceNumber];
                 dispatch_semaphore_signal(sema);

--- a/SignalServiceKit/src/Messages/OWSMessageSender.m
+++ b/SignalServiceKit/src/Messages/OWSMessageSender.m
@@ -1303,8 +1303,14 @@ NSString *const OWSMessageSenderRateLimitedException = @"RateLimitedException";
         __block dispatch_semaphore_t sema = dispatch_semaphore_create(0);
         __block PreKeyBundle *_Nullable bundle;
         __block NSException *_Nullable exception;
-        [self.networkManager makeRequest:[[TSRecipientPrekeyRequest alloc] initWithRecipient:identifier
-                                                                                    deviceId:[deviceNumber stringValue]]
+        // It's not ideal that we're using a semaphore inside a read/write transaction.
+        // To avoid deadlock, we need to ensure that our success/failure completions
+        // are called _off_ the main thread.  Otherwise we'll deadlock if the main
+        // thread is blocked on opening a transaction.
+        TSRequest *request =
+            [[TSRecipientPrekeyRequest alloc] initWithRecipient:identifier deviceId:[deviceNumber stringValue]];
+        [self.networkManager makeRequest:request
+            shouldCompleteOnMainQueue:NO
             success:^(NSURLSessionDataTask *task, id responseObject) {
                 bundle = [PreKeyBundle preKeyBundleFromDictionary:responseObject forDeviceNumber:deviceNumber];
                 dispatch_semaphore_signal(sema);

--- a/SignalServiceKit/src/Network/API/TSNetworkManager.h
+++ b/SignalServiceKit/src/Network/API/TSNetworkManager.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//  Copyright (c) 2018 Open Whisper Systems. All rights reserved.
 //
 
 /**
@@ -27,6 +27,9 @@ extern NSString *const TSNetworkManagerDomain;
 
 BOOL IsNSErrorNetworkFailure(NSError *_Nullable error);
 
+typedef void (^TSNetworkManagerSuccess)(NSURLSessionDataTask *task, id responseObject);
+typedef void (^TSNetworkManagerFailure)(NSURLSessionDataTask *task, NSError *error);
+
 @interface TSNetworkManager : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -34,8 +37,13 @@ BOOL IsNSErrorNetworkFailure(NSError *_Nullable error);
 + (instancetype)sharedManager;
 
 - (void)makeRequest:(TSRequest *)request
-            success:(void (^)(NSURLSessionDataTask *task, id responseObject))success
-            failure:(void (^)(NSURLSessionDataTask *task, NSError *error))failure NS_SWIFT_NAME(makeRequest(_:success:failure:));
+            success:(TSNetworkManagerSuccess)success
+            failure:(TSNetworkManagerFailure)failure NS_SWIFT_NAME(makeRequest(_:success:failure:));
+
+- (void)makeRequest:(TSRequest *)request
+    shouldCompleteOnMainQueue:(BOOL)shouldCompleteOnMainQueue
+                      success:(TSNetworkManagerSuccess)success
+                      failure:(TSNetworkManagerFailure)failure NS_SWIFT_NAME(makeRequest(_:shouldCompleteOnMainQueue:success:failure:));
 
 @end
 

--- a/SignalServiceKit/src/Network/API/TSNetworkManager.h
+++ b/SignalServiceKit/src/Network/API/TSNetworkManager.h
@@ -41,9 +41,12 @@ typedef void (^TSNetworkManagerFailure)(NSURLSessionDataTask *task, NSError *err
             failure:(TSNetworkManagerFailure)failure NS_SWIFT_NAME(makeRequest(_:success:failure:));
 
 - (void)makeRequest:(TSRequest *)request
-    shouldCompleteOnMainQueue:(BOOL)shouldCompleteOnMainQueue
-                      success:(TSNetworkManagerSuccess)success
-                      failure:(TSNetworkManagerFailure)failure NS_SWIFT_NAME(makeRequest(_:shouldCompleteOnMainQueue:success:failure:));
+    completionQueue:(dispatch_queue_t)completionQueue
+            success:(TSNetworkManagerSuccess)success
+            failure:(TSNetworkManagerFailure)failure NS_SWIFT_NAME(makeRequest(_:shouldCompleteOnMainQueue
+:success
+:failure
+:));
 
 @end
 

--- a/SignalServiceKit/src/Network/API/TSNetworkManager.m
+++ b/SignalServiceKit/src/Network/API/TSNetworkManager.m
@@ -58,13 +58,13 @@ typedef void (^failureBlock)(NSURLSessionDataTask *task, NSError *error);
             success:(TSNetworkManagerSuccess)success
             failure:(TSNetworkManagerFailure)failure
 {
-    return [self makeRequest:request shouldCompleteOnMainQueue:YES success:success failure:failure];
+    return [self makeRequest:request completionQueue:dispatch_get_main_queue() success:success failure:failure];
 }
 
 - (void)makeRequest:(TSRequest *)request
-    shouldCompleteOnMainQueue:(BOOL)shouldCompleteOnMainQueue
-                      success:(TSNetworkManagerSuccess)success
-                      failure:(TSNetworkManagerFailure)failureBlock
+    completionQueue:(dispatch_queue_t)completionQueue
+            success:(TSNetworkManagerSuccess)success
+            failure:(TSNetworkManagerFailure)failureBlock
 {
     OWSAssert(request);
     OWSAssert(success);
@@ -87,11 +87,7 @@ typedef void (^failureBlock)(NSURLSessionDataTask *task, NSError *error);
     AFHTTPSessionManager *sessionManager = [OWSSignalService sharedInstance].signalServiceSessionManager;
     // [OWSSignalService signalServiceSessionManager] always returns a new instance of
     // session manager, so its safe to reconfigure it here.
-    if (shouldCompleteOnMainQueue) {
-        sessionManager.completionQueue = dispatch_get_main_queue();
-    } else {
-        sessionManager.completionQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
-    }
+    sessionManager.completionQueue = completionQueue;
 
     if ([request isKindOfClass:[TSVerifyCodeRequest class]]) {
         // We plant the Authorization parameter ourselves, no need to double add.

--- a/SignalServiceKit/src/Network/API/TSNetworkManager.m
+++ b/SignalServiceKit/src/Network/API/TSNetworkManager.m
@@ -85,6 +85,8 @@ typedef void (^failureBlock)(NSURLSessionDataTask *task, NSError *error);
         [TSNetworkManager errorPrettifyingForFailureBlock:failureBlock];
 
     AFHTTPSessionManager *sessionManager = [OWSSignalService sharedInstance].signalServiceSessionManager;
+    // [OWSSignalService signalServiceSessionManager] always returns a new instance of
+    // session manager, so its safe to reconfigure it here.
     if (shouldCompleteOnMainQueue) {
         sessionManager.completionQueue = dispatch_get_main_queue();
     } else {

--- a/SignalServiceKit/src/Network/OWSSignalService.m
+++ b/SignalServiceKit/src/Network/OWSSignalService.m
@@ -205,7 +205,6 @@ NSString *const kNSNotificationName_IsCensorshipCircumventionActiveDidChange =
 
     sessionManager.requestSerializer = [AFJSONRequestSerializer serializer];
     [sessionManager.requestSerializer setValue:self.censorshipConfiguration.signalServiceReflectorHost forHTTPHeaderField:@"Host"];
-
     sessionManager.responseSerializer = [AFJSONResponseSerializer serializer];
 
     return sessionManager;


### PR DESCRIPTION
The deadlocks occur because the network manager completions were getting enqueued on the main thread and deadlocking if the main thread was blocked trying to open a r/w transaction.

PTAL @michaelkirk 