### PR TITLE
Constant time compare

### DIFF
--- a/SignalServiceKit/src/Util/NSData+OWSConstantTimeCompare.m
+++ b/SignalServiceKit/src/Util/NSData+OWSConstantTimeCompare.m
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)ows_constantTimeIsEqualToData:(NSData *)other
 {
-    BOOL isEqual = YES;
+    volatile UInt8 isEqual = 0;
 
     if (self.length != other.length) {
         return NO;
@@ -21,10 +21,10 @@ NS_ASSUME_NONNULL_BEGIN
     for (int i = 0; i < self.length; i++) {
         // rather than returning as soon as we find a discrepency, we compare the rest of
         // the byte stream to maintain a constant time comparison
-        isEqual = isEqual && (leftBytes[i] == rightBytes[i]);
+        isEqual |= leftBytes[i] ^ rightBytes[i];
     }
 
-    return isEqual;
+    return isEqual == 0;
 }
 
 @end


### PR DESCRIPTION
- fix case when second part of the && conditional is skipped when data is not equal
- isEqual variable marked volatile to prevent case when it doesn't equal 0, the loop can break early since it can never be 0 again
- tested with Fastest O3 and Whole Module optimization (App Store Release)

// FREEBIE


### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 5C, iOS 10.3.3
 * iPhone 6S, iOS 11.1

- - - - - - - - - -

### Description
This pull request reduces the possibility for compiler optimizations/loop short-circuiting. Testing was done with the Fastest O3 release configuration. 

FWIW there is also a const-time comparison function in the Curve25519Kit library under [compare.c](https://github.com/signalapp/Signal-Pods/blob/a8334500da7c8180341043d84b0b41145e6619e1/Curve25519Kit/Sources/ed25519/additions/compare.c) that also works on unsigned char *.

fixes #29 
