### PR TITLE
Fix bubble layout in message details

### DIFF
--- a/Signal/src/ViewControllers/MessageDetailViewController.swift
+++ b/Signal/src/ViewControllers/MessageDetailViewController.swift
@@ -89,6 +89,8 @@ class MessageDetailViewController: OWSViewController, UIScrollViewDelegate, Medi
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
+        updateTextLayout()
+
         if mode == .focusOnMetadata {
             if let bubbleView = self.bubbleView {
                 // Force layout.


### PR DESCRIPTION
TextView size depends on the VC.view size, so it must be updated when
view is done laying out or changes bounds.

// FREEBIE
