### PR TITLE
Don't create redundant caption for sync'd transcripts.

### DIFF
--- a/SignalServiceKit/src/Devices/OWSRecordTranscriptJob.m
+++ b/SignalServiceKit/src/Devices/OWSRecordTranscriptJob.m
@@ -125,21 +125,6 @@ NS_ASSUME_NONNULL_BEGIN
                                    self.logTag,
                                    outgoingMessage);
                            }];
-
-    // If there is an attachment + text, render the text here, as Signal-iOS renders two messages.
-    if (attachmentsProcessor.hasSupportedAttachments && transcript.body && ![transcript.body isEqualToString:@""]) {
-        // We want the text to appear after the attachment.
-        uint64_t textMessageTimestamp = transcript.timestamp + 1;
-        TSOutgoingMessage *textMessage = [[TSOutgoingMessage alloc] initWithTimestamp:textMessageTimestamp
-                                                                             inThread:thread
-                                                                          messageBody:transcript.body
-                                                                        attachmentIds:[NSMutableArray new]
-                                                                     expiresInSeconds:transcript.expirationDuration
-                                                                      expireStartedAt:transcript.expirationStartedAt];
-        // Since textMessage is a new message, updateWithWasSentAndDelivered will save it.
-        [textMessage saveWithTransaction:transaction];
-        [textMessage updateWithWasSentFromLinkedDeviceWithTransaction:transaction];
-    }
 }
 
 @end


### PR DESCRIPTION
Note: For test devices running HEAD, there may have already been some
redundant captions created for sync'd transcripts.

However the existing `TSMessage#initWithCoder:` [migration](https://github.com/signalapp/Signal-iOS/blob/master/SignalServiceKit/src/Messages/Interactions/TSMessage.m#L143) will address
this for our production users, so I'm not going to bother with a second
migration just for our test devices.

PTAL @charlesmchen 