### PR TITLE
Don't adjust inset when fully zoomed in.

### DIFF
--- a/Signal/src/ViewControllers/MediaDetailViewController.m
+++ b/Signal/src/ViewControllers/MediaDetailViewController.m
@@ -250,7 +250,12 @@ NS_ASSUME_NONNULL_BEGIN
     scrollView.showsVerticalScrollIndicator = NO;
     scrollView.showsHorizontalScrollIndicator = NO;
     scrollView.decelerationRate = UIScrollViewDecelerationRateFast;
-    self.automaticallyAdjustsScrollViewInsets = NO;
+
+    if (@available(iOS 11.0, *)) {
+        scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
+    } else {
+        self.automaticallyAdjustsScrollViewInsets = NO;
+    }
 
     [scrollView autoPinToSuperviewEdges];
 


### PR DESCRIPTION
On iOS11, when looking at the full-screen media details, if you'd zoomed
far enough that the media content is behind the status bar, tapping to
hide the status bar would cause an undesirable change in content offset.

PTAL @charlesmchen 