### PR TITLE
Fix crash on launch in debug.

### DIFF
--- a/SignalServiceKit/src/Util/AppReadiness.m
+++ b/SignalServiceKit/src/Util/AppReadiness.m
@@ -3,6 +3,7 @@
 //
 
 #import "AppReadiness.h"
+#import "Threading.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -48,9 +49,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (void)runNowOrWhenAppIsReady:(AppReadyBlock)block
 {
-    OWSAssertIsOnMainThread();
-
-    [self.sharedManager runNowOrWhenAppIsReady:block];
+    DispatchMainThreadSafe(^{
+        [self.sharedManager runNowOrWhenAppIsReady:block];
+    });
 }
 
 - (void)runNowOrWhenAppIsReady:(AppReadyBlock)block

--- a/SignalServiceKit/src/Util/Threading.h
+++ b/SignalServiceKit/src/Util/Threading.h
@@ -4,16 +4,14 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef void (^SimpleBlock)(void);
-
 // The block is executed immediately if called from the
 // main thread; otherwise it is dispatched async to the
 // main thread.
-void DispatchMainThreadSafe(SimpleBlock block);
+void DispatchMainThreadSafe(dispatch_block_t block);
 
 // The block is executed immediately if called from the
 // main thread; otherwise it is dispatched sync to the
 // main thread.
-void DispatchSyncMainThreadSafe(SimpleBlock block);
+void DispatchSyncMainThreadSafe(dispatch_block_t block);
 
 NS_ASSUME_NONNULL_END

--- a/SignalServiceKit/src/Util/Threading.m
+++ b/SignalServiceKit/src/Util/Threading.m
@@ -6,7 +6,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-void DispatchMainThreadSafe(SimpleBlock block)
+void DispatchMainThreadSafe(dispatch_block_t block)
 {
     OWSCAssert(block);
 
@@ -19,7 +19,7 @@ void DispatchMainThreadSafe(SimpleBlock block)
     }
 }
 
-void DispatchSyncMainThreadSafe(SimpleBlock block)
+void DispatchSyncMainThreadSafe(dispatch_block_t block)
 {
     OWSCAssert(block);
 


### PR DESCRIPTION
OWSReadReceiptManager is not `init` on the main thread; however, because
it "schedules" it's own processing during init, it crashes.

https://github.com/signalapp/Signal-iOS/blob/master/SignalServiceKit/src/Messages/OWSReadReceiptManager.m#L181

I considered dispatching to main, but since AppReadiness already *can*
resolve async if the app isn't yet ready, it should be no less safe to
also dispatch async when it's off the main thread.

PTAL @charlesmchen 