### PR TITLE
Fix "lose messages received while in background"

### DIFF
--- a/SignalServiceKit/src/Util/OWSFileSystem.h
+++ b/SignalServiceKit/src/Util/OWSFileSystem.h
@@ -9,6 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init NS_UNAVAILABLE;
 
 + (BOOL)protectFileOrFolderAtPath:(NSString *)path;
++ (BOOL)protectRecursiveContentsAtPath:(NSString *)path;
 
 + (NSString *)appDocumentDirectoryPath;
 
@@ -36,6 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (nullable NSString *)writeDataToTemporaryFile:(NSData *)data fileExtension:(NSString *_Nullable)fileExtension;
 
 + (nullable NSNumber *)fileSizeOfPath:(NSString *)filePath;
++ (void)logAttributesOfItemAtPathRecursively:(NSString *)path;
 
 @end
 

--- a/SignalServiceKit/src/Util/OWSFileSystem.m
+++ b/SignalServiceKit/src/Util/OWSFileSystem.m
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     if (!isDirectory) {
-        [self protectFileOrFolderAtPath:path];
+        return [self protectFileOrFolderAtPath:path];
     }
     NSString *dirPath = path;
 
@@ -58,17 +58,6 @@ NS_ASSUME_NONNULL_BEGIN
     return YES;
 }
 
-+ (void)logAttributesOfItemAtPath:(NSString *)path
-{
-    NSDictionary<NSFileAttributeKey, id> *_Nullable attributes = [self attributesOfItemAtPath:path];
-    DDLogDebug(@"%@ path: %@ has attributes: %@", self.logTag, path, attributes);
-}
-
-+ (nullable NSDictionary<NSFileAttributeKey, id> *)attributesOfItemAtPath:(NSString *)path
-{
-    return [[NSFileManager defaultManager] attributesOfItemAtPath:path error:nil];
-}
-
 + (void)logAttributesOfItemAtPathRecursively:(NSString *)path
 {
     BOOL isDirectory;
@@ -81,7 +70,12 @@ NS_ASSUME_NONNULL_BEGIN
             DDLogDebug(@"%@ path: %@ has attributes: %@", self.logTag, path, directoryEnumerator.fileAttributes);
         }
     } else {
-        [self logAttributesOfItemAtPath:path];
+        NSError *error;
+        NSDictionary<NSFileAttributeKey, id> *_Nullable attributes =
+            [[NSFileManager defaultManager] attributesOfItemAtPath:path error:error];
+        OWSAssert(!error);
+
+        DDLogDebug(@"%@ path: %@ has attributes: %@", self.logTag, path, attributes);
     }
 }
 


### PR DESCRIPTION
A migrated DB file has the NSFileProtectionClassComplete, meaning it's never accessible while the device is locked. We want it to be accessible after first unlock.

Applying a data protection class to a directory only affects newly created files, not existing files in that directory nor files moved to that directory.

Presumably this has been an issue for a while in the 2.20 branch, but you'd only notice when receiving voip notifications.

PTAL: @charlesmchen 