### PR TITLE
Only update file protection for db files.

### DIFF
--- a/SignalServiceKit/src/Storage/TSStorageManager.m
+++ b/SignalServiceKit/src/Storage/TSStorageManager.m
@@ -237,6 +237,9 @@ void runAsyncRegistrationsForStorage(OWSStorage *storage)
     [OWSFileSystem moveAppFilePath:self.legacyDatabaseFilePath_WAL
                 sharedDataFilePath:self.sharedDataDatabaseFilePath_WAL
                      exceptionName:TSStorageManagerExceptionName_CouldNotMoveDatabaseFile];
+
+    // Ensure all files moved have the proper data protection class.
+    [OWSFileSystem protectRecursiveContentsAtPath:self.sharedDataDatabaseFilePath];
 }
 
 + (NSString *)databaseFilePath

--- a/SignalServiceKit/src/Util/OWSFileSystem.m
+++ b/SignalServiceKit/src/Util/OWSFileSystem.m
@@ -145,9 +145,6 @@ NS_ASSUME_NONNULL_BEGIN
         oldFilePath,
         newFilePath,
         fabs([startDate timeIntervalSinceNow]));
-
-    // Ensure all files moved have the proper data protection class.
-    [self protectRecursiveContentsAtPath:newFilePath];
 }
 
 + (BOOL)ensureDirectoryExists:(NSString *)dirPath


### PR DESCRIPTION
There are potentially many files in Attachments/Profiles, and since movement happens during launch, it must be fast.

PTAL @charlesmchen 