### PR TITLE
Mkirk/call audio fixups

### DIFF
--- a/Signal/src/ViewControllers/AboutTableViewController.m
+++ b/Signal/src/ViewControllers/AboutTableViewController.m
@@ -90,6 +90,13 @@
     NSString *_Nullable voipToken = [preferences getVoipToken];
     [debugSection addItem:[OWSTableItem labelItemWithText:[NSString stringWithFormat:@"Push Token: %@", pushToken ?: @"None" ]]];
     [debugSection addItem:[OWSTableItem labelItemWithText:[NSString stringWithFormat:@"VOIP Token: %@", voipToken ?: @"None" ]]];
+
+    // Strip prefix from category, otherwise it's too long to fit into cell on a small device.
+    NSString *audioCategory =
+        [AVAudioSession.sharedInstance.category stringByReplacingOccurrencesOfString:@"AVAudioSessionCategory"
+                                                                          withString:@""];
+    [debugSection
+        addItem:[OWSTableItem labelItemWithText:[NSString stringWithFormat:@"Audio Category: %@", audioCategory]]];
 #endif
 
     self.contents = contents;

--- a/Signal/src/call/CallAudioService.swift
+++ b/Signal/src/call/CallAudioService.swift
@@ -159,6 +159,7 @@ protocol CallAudioServiceDelegate: class {
 
         super.init()
 
+        // This fails when someone toggles iOS Call Integration
         SwiftSingletons.register(self)
 
         // Configure audio session so we don't prompt user with Record permission until call is connected.
@@ -242,7 +243,8 @@ protocol CallAudioServiceDelegate: class {
     private func ensureProperAudioSession(call: SignalCall?) {
         AssertIsOnMainThread()
 
-        guard let call = call else {
+        guard let call = call, !call.isTerminated else {
+            // Revert to default audio
             setAudioSession(category: AVAudioSessionCategorySoloAmbient,
                             mode: AVAudioSessionModeDefault)
             return

--- a/Signal/src/call/CallService.swift
+++ b/Signal/src/call/CallService.swift
@@ -1507,6 +1507,9 @@ protocol CallServiceObserver: class {
         Logger.info("\(self.logTag) clearing pendingIceUpdateMessages")
         self.pendingIceUpdateMessages = []
         self.fulfillCallConnectedPromise = nil
+
+        // In case we're still waiting on this promise somewhere, we need to reject it to avoid a memory leak.
+        // There is no harm in rejecting a previously fulfilled promise.
         if let rejectCallConnectedPromise = self.rejectCallConnectedPromise {
             rejectCallConnectedPromise(CallError.obsoleteCall(description: "Terminating call"))
         }

--- a/Signal/src/call/SignalCall.swift
+++ b/Signal/src/call/SignalCall.swift
@@ -43,6 +43,15 @@ protocol CallObserver: class {
     var observers = [Weak<CallObserver>]()
     let remotePhoneNumber: String
 
+    var isTerminated: Bool {
+        switch state {
+        case .localFailure, .localHangup, .remoteHangup, .remoteBusy:
+            return true
+        case .idle, .dialing, .answering, .remoteRinging, .localRinging, .connected:
+            return false
+        }
+    }
+
     // Signal Service identifier for this Call. Used to coordinate the call across remote clients.
     let signalingId: UInt64
 

--- a/Signal/src/call/Speakerbox/CallKitCallUIAdaptee.swift
+++ b/Signal/src/call/Speakerbox/CallKitCallUIAdaptee.swift
@@ -25,6 +25,7 @@ final class CallKitCallUIAdaptee: NSObject, CallUIAdaptee, CXProviderDelegate {
     internal let notificationsAdapter: CallNotificationsAdapter
     internal let contactsManager: OWSContactsManager
     private let provider: CXProvider
+    let audioActivity: AudioActivity
 
     // CallKit handles incoming ringer stop/start for us. Yay!
     let hasManualRinger = false
@@ -60,6 +61,7 @@ final class CallKitCallUIAdaptee: NSObject, CallUIAdaptee, CXProviderDelegate {
         self.contactsManager = contactsManager
         self.notificationsAdapter = notificationsAdapter
         self.provider = CXProvider(configuration: type(of: self).providerConfiguration)
+        self.audioActivity = AudioActivity(audioDescription: "[CallKitCallUIAdaptee]")
 
         super.init()
 
@@ -348,6 +350,7 @@ final class CallKitCallUIAdaptee: NSObject, CallUIAdaptee, CXProviderDelegate {
 
         Logger.debug("\(TAG) Received \(#function)")
 
+        OWSAudioSession.shared.startAudioActivity(self.audioActivity)
         OWSAudioSession.shared.isRTCAudioEnabled = true
     }
 
@@ -356,6 +359,7 @@ final class CallKitCallUIAdaptee: NSObject, CallUIAdaptee, CXProviderDelegate {
 
         Logger.debug("\(TAG) Received \(#function)")
         OWSAudioSession.shared.isRTCAudioEnabled = false
+        OWSAudioSession.shared.endAudioActivity(self.audioActivity)
     }
 
     // MARK: - Util


### PR DESCRIPTION
1. Fixes a race condition where we were terminating the audio session while the call hasn't quite torn down.

2. Ensures call leaves session category at SoloAmbient when it's done.

PTAL @charlesmchen 