### PR TITLE
Ensure inputAccessory doesn't obscure the SN alert

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
@@ -1356,9 +1356,28 @@ typedef NS_ENUM(NSInteger, MessagesRangeSizeMode) {
                                                          completion:(void (^)(BOOL didConfirmIdentity))completionHandler
 {
     return [SafetyNumberConfirmationAlert presentAlertIfNecessaryWithRecipientIds:self.thread.recipientIdentifiers
-                                                                 confirmationText:confirmationText
-                                                                  contactsManager:self.contactsManager
-                                                                       completion:completionHandler];
+        confirmationText:confirmationText
+        contactsManager:self.contactsManager
+        completion:^(BOOL didShowAlert) {
+            // Pre iOS-11, the keyboard and inputAccessoryView will obscure the alert if the keyboard is up when the
+            // alert is presented, so after hiding it, we regain first responder here.
+            if (@available(iOS 11.0, *)) {
+                // do nothing
+            } else {
+                [self becomeFirstResponder];
+            }
+            completionHandler(didShowAlert);
+        }
+        beforePresentationHandler:^(void) {
+            if (@available(iOS 11.0, *)) {
+                // do nothing
+            } else {
+                // Pre iOS-11, the keyboard and inputAccessoryView will obscure the alert if the keyboard is up when the
+                // alert is presented.
+                [self dismissKeyBoard];
+                [self resignFirstResponder];
+            }
+        }];
 }
 
 - (void)showFingerprintWithRecipientId:(NSString *)recipientId

--- a/Signal/src/call/OutboundCallInitiator.swift
+++ b/Signal/src/call/OutboundCallInitiator.swift
@@ -1,5 +1,5 @@
 //
-//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//  Copyright (c) 2018 Open Whisper Systems. All rights reserved.
 //
 
 import Foundation
@@ -55,11 +55,12 @@ import SignalMessaging
 
         let showedAlert = SafetyNumberConfirmationAlert.presentAlertIfNecessary(recipientId: recipientId,
                                                                                 confirmationText: CallStrings.confirmAndCallButtonTitle,
-                                                                                contactsManager: self.contactsManager) { didConfirmIdentity in
+                                                                                contactsManager: self.contactsManager,
+                                                                                completion: { didConfirmIdentity in
                                                                                     if didConfirmIdentity {
                                                                                         _ = self.initiateCall(recipientId: recipientId)
                                                                                     }
-        }
+        })
         guard !showedAlert else {
             return false
         }


### PR DESCRIPTION
This affects iOS 8, 9, and to a lesser degree iOS10.
On iOS11, presenting an alert causes the keyboard/inputAccessoryView to
temporarily dismiss.

PTAL @charlesmchen 