### PR TITLE
Remove "Share" from edit menu

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
@@ -549,6 +549,18 @@ typedef NS_ENUM(NSInteger, MessagesRangeSizeMode) {
     [self.loadMoreHeader autoSetDimension:ALDimensionHeight toSize:kLoadMoreHeaderHeight];
 }
 
+- (BOOL)becomeFirstResponder
+{
+    DDLogDebug(@"%@ in %s", self.logTag, __PRETTY_FUNCTION__);
+    return [super becomeFirstResponder];
+}
+
+- (BOOL)resignFirstResponder
+{
+    DDLogDebug(@"%@ in %s", self.logTag, __PRETTY_FUNCTION__);
+    return [super resignFirstResponder];
+}
+
 - (BOOL)canBecomeFirstResponder
 {
     return YES;

--- a/Signal/src/ViewControllers/ConversationView/ConversationViewItem.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewItem.m
@@ -465,9 +465,6 @@ NSString *NSStringForOWSMessageCellType(OWSMessageCellType cellType)
         [[UIMenuItem alloc] initWithTitle:NSLocalizedString(@"EDIT_ITEM_COPY_ACTION",
                                               @"Short name for edit menu item to copy contents of media message.")
                                    action:self.copyTextActionSelector],
-        [[UIMenuItem alloc] initWithTitle:NSLocalizedString(@"EDIT_ITEM_SHARE_ACTION",
-                                              @"Short name for edit menu item to share contents of media message.")
-                                   action:self.shareTextActionSelector],
         [[UIMenuItem alloc] initWithTitle:NSLocalizedString(@"EDIT_ITEM_MESSAGE_METADATA_ACTION",
                                               @"Short name for edit menu item to show message metadata.")
                                    action:self.metadataActionSelector],
@@ -482,9 +479,6 @@ NSString *NSStringForOWSMessageCellType(OWSMessageCellType cellType)
 - (NSArray<UIMenuItem *> *)mediaMenuControllerItems
 {
     return @[
-        [[UIMenuItem alloc] initWithTitle:NSLocalizedString(@"EDIT_ITEM_SHARE_ACTION",
-                                              @"Short name for edit menu item to share contents of media message.")
-                                   action:self.shareMediaActionSelector],
         [[UIMenuItem alloc] initWithTitle:NSLocalizedString(@"EDIT_ITEM_MESSAGE_METADATA_ACTION",
                                               @"Short name for edit menu item to show message metadata.")
                                    action:self.metadataActionSelector],


### PR DESCRIPTION
Sharing media is still possible from the full screen media view and the message detail view. Sharing text would be accomplished via copy/paste.


Motivation:

Showing the share UI *from* the conversation view conflicts with the conversation view's input toolbar, and can cause behavior like:

- input toolbar not visible after completing share (must leave and re-enter thread)
- input toolbar is visible *over* the share sheet

I believe this is an iOS bug and will be filing a radar.

Specifically:

- long pressing shows the edit menu, which entails the message cell acquiring first responder status (meaning the conversation view controller is no longer the first responder)
- tapping share presents the activity view
- at this point, the input toolbar is hidden
- launching a share extension hides the activity view, presents the
  share extension (could be the Signal share extension or another app's
  share extension)
- the conversation view (which is rendered behind the share extension)
  regains first responder, causing the input toolbar to appear above the
  share extension

A fix which would allow us to keep the share item in the longpress menu would be to re-implement an interface similar UIMenuController, which does not require mucking with the responder chain, but that's going to be more involved, and I'm not sure that it's worth the effort, given we're the only app I know of which includes a "share" item in this menu.

WDYT @charlesmchen, @riyapenn 
