### PR TITLE
Respect system contact ringtones

### DIFF
--- a/Signal/src/call/Speakerbox/CallKitCallUIAdaptee.swift
+++ b/Signal/src/call/Speakerbox/CallKitCallUIAdaptee.swift
@@ -46,8 +46,6 @@ final class CallKitCallUIAdaptee: NSObject, CallUIAdaptee, CXProviderDelegate {
         let iconMaskImage = #imageLiteral(resourceName: "logoSignal")
         providerConfiguration.iconTemplateImageData = UIImagePNGRepresentation(iconMaskImage)
 
-        // We set the ringtoneSound property later.
-
         return providerConfiguration
     }
 
@@ -123,12 +121,6 @@ final class CallKitCallUIAdaptee: NSObject, CallUIAdaptee, CXProviderDelegate {
         update.hasVideo = call.hasLocalVideo
 
         disableUnsupportedFeatures(callUpdate: update)
-
-        // Update the provider configuration to reflect the caller's ringtone.
-        let sound = OWSSounds.ringtoneSound(for: call.thread)
-        let providerConfiguration = provider.configuration
-        providerConfiguration.ringtoneSound = OWSSounds.filename(for: sound)
-        provider.configuration =  providerConfiguration
 
         // Report the incoming call to the system
         provider.reportNewIncomingCall(with: call.localId, update: update) { error in


### PR DESCRIPTION
If CallKit privacy is enabled, we'll always use the system default ringtone.

If CallKit privacy is *not* enabled we'll use any ringtone specified for that contact in the address book, else fall back to the default.

I know we haven't yet agreed to this approach, but wanted to put it up for proposal, as it contradicts some of the work in https://github.com/signalapp/Signal-iOS/pull/3048.

PTAL @charlesmchen 