### PR TITLE
Fix freeze in host app after "dismissing" select thread VC

### DIFF
--- a/SignalMessaging/attachments/SharingThreadPickerViewController.m
+++ b/SignalMessaging/attachments/SharingThreadPickerViewController.m
@@ -171,6 +171,13 @@ typedef void (^SendMessageBlock)(SendCompletionBlock completion);
     }
 }
 
+// override
+- (void)dismissPressed:(id)sender
+{
+    DDLogDebug(@"%@ tapped dismiss share button", self.logTag);
+    [self cancelShareExperience];
+}
+
 - (void)didTapCancelShareButton
 {
     DDLogDebug(@"%@ tapped cancel share button", self.logTag);


### PR DESCRIPTION
For 2.20.0

We must call these completion handlers whenever we exit the SAE

PTAL @charlesmchen 