### PR TITLE
Don't enqueue sender read receipts from self-sent messages

### DIFF
--- a/SignalServiceKit/src/Messages/OWSReadReceiptManager.m
+++ b/SignalServiceKit/src/Messages/OWSReadReceiptManager.m
@@ -12,6 +12,7 @@
 #import "OWSSignalServiceProtos.pb.h"
 #import "OWSStorage.h"
 #import "OWSSyncConfigurationMessage.h"
+#import "TSAccountManager.h"
 #import "TSContactThread.h"
 #import "TSDatabaseView.h"
 #import "TSIncomingMessage.h"
@@ -316,6 +317,11 @@ NSString *const OWSReadReceiptManagerAreReadReceiptsEnabled = @"areReadReceiptsE
             } else {
                 DDLogVerbose(@"%@ Enqueuing read receipt for linked devices.", self.logTag);
                 self.toLinkedDevicesReadReceiptMap[threadUniqueId] = newReadReceipt;
+            }
+
+            if ([message.messageAuthorId isEqualToString:[TSAccountManager localNumber]]) {
+                DDLogVerbose(@"%@ Ignoring read receipt for self-sender.", self.logTag);
+                return;
             }
 
             if ([self areReadReceiptsEnabled]) {


### PR DESCRIPTION
Not for 2.20.0

These messages are always already read.

Reminder, there are two types of read receipts:

1. One informs our linked devices that we've read a message on another
device.
2. The other informs the sender that we've read their message.

This change is about the latter, we'll continue to send the former to
ourself.

The proximate cause for this change was a failing assert in
OWSMessageSender#handleSendToMyself:(TSOutgoingMessage *)outgoingMessage

The assert was failing because we were sending a message to ourself
which had no body or attachment (the sender-read receipt). Rather than
filtering them out from the message sender, we should never ask the
message sender to do nonsense work (send a senderReadReceipt to ourself)

PTAL @charlesmchen 
