### PR TITLE
Notification sounds should respect silent switch

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
@@ -2080,7 +2080,7 @@ typedef enum : NSUInteger {
     self.audioAttachmentPlayer = [[OWSAudioPlayer alloc] initWithMediaUrl:attachmentStream.mediaURL delegate:viewItem];
     // Associate the player with this media adapter.
     self.audioAttachmentPlayer.owner = viewItem;
-    [self.audioAttachmentPlayer play];
+    [self.audioAttachmentPlayer playWithPlaybackAudioCategory];
 }
 
 - (void)didTapTruncatedTextMessage:(ConversationViewItem *)conversationItem

--- a/Signal/src/ViewControllers/OWSSoundSettingsViewController.m
+++ b/Signal/src/ViewControllers/OWSSoundSettingsViewController.m
@@ -113,7 +113,7 @@ NS_ASSUME_NONNULL_BEGIN
     self.audioPlayer = [OWSSounds audioPlayerForSound:sound];
     // Suppress looping in this view.
     self.audioPlayer.isLooping = NO;
-    [self.audioPlayer play];
+    [self.audioPlayer playWithPlaybackAudioCategory];
 
     if (self.currentSound == sound) {
         return;

--- a/Signal/src/call/CallAudioService.swift
+++ b/Signal/src/call/CallAudioService.swift
@@ -400,7 +400,7 @@ protocol CallAudioServiceDelegate: class {
         // we're playing the same sound, since the player is memoized on the sound instance, we'd otherwise 
         // stop the sound we just started.
         self.currentPlayer?.stop()
-        newPlayer.play()
+        newPlayer.playWithCurrentAudioCategory()
         self.currentPlayer = newPlayer
     }
 

--- a/Signal/src/environment/NotificationsManager.m
+++ b/Signal/src/environment/NotificationsManager.m
@@ -238,7 +238,7 @@
         } else {
             if (shouldPlaySound && [Environment.preferences soundInForeground]) {
                 OWSSound sound = [OWSSounds notificationSoundForThread:thread];
-                [OWSSounds playSound:sound];
+                [OWSSounds playSound:sound quiet:YES shouldRespectSilentSwitch:YES];
             }
         }
     });
@@ -344,7 +344,7 @@
             if (shouldPlaySound && [Environment.preferences soundInForeground]) {
                 OWSSound sound = [OWSSounds notificationSoundForThread:thread];
                 // We play the "quiet" variation of sounds if possible for notifications in the foreground.
-                [OWSSounds playSound:sound quiet:YES];
+                [OWSSounds playSound:sound quiet:YES shouldRespectSilentSwitch:YES];
             }
         }
     });

--- a/SignalMessaging/environment/OWSSounds.h
+++ b/SignalMessaging/environment/OWSSounds.h
@@ -48,8 +48,8 @@ typedef NS_ENUM(NSUInteger, OWSSound) {
 
 + (nullable NSString *)filenameForSound:(OWSSound)sound;
 
-+ (void)playSound:(OWSSound)sound;
-+ (void)playSound:(OWSSound)sound quiet:(BOOL)quiet;
++ (void)playSound:(OWSSound)sound shouldRespectSilentSwitch:(BOOL)shouldRespectSilentSwitch;
++ (void)playSound:(OWSSound)sound quiet:(BOOL)quiet shouldRespectSilentSwitch:(BOOL)shouldRespectSilentSwitch;
 
 #pragma mark - Notifications
 

--- a/SignalMessaging/environment/OWSSounds.m
+++ b/SignalMessaging/environment/OWSSounds.m
@@ -209,21 +209,25 @@ NSString *const kOWSSoundsStorageGlobalNotificationKey = @"kOWSSoundsStorageGlob
     return url;
 }
 
-+ (void)playSound:(OWSSound)sound
++ (void)playSound:(OWSSound)sound shouldRespectSilentSwitch:(BOOL)shouldRespectSilentSwitch
 {
-    [self.sharedManager playSound:sound quiet:NO];
+    [self.sharedManager playSound:sound quiet:NO shouldRespectSilentSwitch:shouldRespectSilentSwitch];
 }
 
-+ (void)playSound:(OWSSound)sound quiet:(BOOL)quiet
++ (void)playSound:(OWSSound)sound quiet:(BOOL)quiet shouldRespectSilentSwitch:(BOOL)shouldRespectSilentSwitch
 {
-    [self.sharedManager playSound:sound quiet:quiet];
+    [self.sharedManager playSound:sound quiet:quiet shouldRespectSilentSwitch:shouldRespectSilentSwitch];
 }
 
-- (void)playSound:(OWSSound)sound quiet:(BOOL)quiet
+- (void)playSound:(OWSSound)sound quiet:(BOOL)quiet shouldRespectSilentSwitch:(BOOL)shouldRespectSilentSwitch
 {
     [self.audioPlayer stop];
     self.audioPlayer = [OWSSounds audioPlayerForSound:sound quiet:quiet];
-    [self.audioPlayer play];
+    if (shouldRespectSilentSwitch) {
+        [self.audioPlayer playWithCurrentAudioCategory];
+    } else {
+        [self.audioPlayer playWithPlaybackAudioCategory];
+    }
 }
 
 #pragma mark - Notifications

--- a/SignalMessaging/utils/OWSAudioPlayer.h
+++ b/SignalMessaging/utils/OWSAudioPlayer.h
@@ -35,7 +35,12 @@ typedef NS_ENUM(NSInteger, AudioPlaybackState) {
 
 - (instancetype)initWithMediaUrl:(NSURL *)mediaUrl delegate:(id<OWSAudioPlayerDelegate>)delegate;
 
-- (void)play;
+// respects silent switch
+- (void)playWithCurrentAudioCategory;
+
+// will ensure sound is audible, even if silent switch is enabled
+- (void)playWithPlaybackAudioCategory;
+
 - (void)pause;
 - (void)stop;
 - (void)togglePlayState;

--- a/SignalMessaging/utils/OWSAudioPlayer.m
+++ b/SignalMessaging/utils/OWSAudioPlayer.m
@@ -88,13 +88,27 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Methods
 
+- (void)playWithCurrentAudioCategory
+{
+    OWSAssertIsOnMainThread();
+    [OWSAudioSession.shared startAudioActivity:self.audioActivity];
+
+    [self play];
+}
+
+- (void)playWithPlaybackAudioCategory
+{
+    OWSAssertIsOnMainThread();
+    [OWSAudioSession.shared setPlaybackCategoryWithAudioActivity:self.audioActivity];
+
+    [self play];
+}
+
 - (void)play
 {
     OWSAssertIsOnMainThread();
     OWSAssert(self.mediaUrl);
     OWSAssert([self.delegate audioPlaybackState] != AudioPlaybackState_Playing);
-
-    [OWSAudioSession.shared setPlaybackCategoryWithAudioActivity:self.audioActivity];
 
     [self.audioPlayerPoller invalidate];
 


### PR DESCRIPTION
The audio player was setting the AudioCategory to playback.

The new API is a little more cumbersome, but I think we *should* be forcing ourselves to think about the category context whenever we're playing audio.

PTAL @charlesmchen 