### PR TITLE
Keeps original background color of a subview in during row selection

### DIFF
--- a/Signal/src/ViewControllers/InboxTableViewCell.m
+++ b/Signal/src/ViewControllers/InboxTableViewCell.m
@@ -106,7 +106,7 @@ const NSUInteger kAvatarViewDiameter = 52;
     [self.timeLabel setCompressionResistanceHigh];
 
     const int kunreadBadgeSize = 24;
-    self.unreadBadge = [[UIView alloc] initWithFrame:CGRectMake(0, 0, kunreadBadgeSize, kunreadBadgeSize)];
+    self.unreadBadge = [[NeverClearUIView alloc] initWithFrame:CGRectMake(0, 0, kunreadBadgeSize, kunreadBadgeSize)];
     self.unreadBadge.layer.cornerRadius = kunreadBadgeSize / 2;
     self.unreadBadge.backgroundColor = [UIColor ows_materialBlueColor];
     [self.contentView addSubview:self.unreadBadge];

--- a/Signal/src/ViewControllers/Utils/NeverClearView.swift
+++ b/Signal/src/ViewControllers/Utils/NeverClearView.swift
@@ -1,0 +1,12 @@
+// Created by Fredrik Lillejordet on 04.03.2018.
+// Copyright © 2018 Open Whisper Systems. All rights reserved.
+
+@objc class NeverClearUIView: UIView {
+    override var backgroundColor: UIColor? {
+        didSet {
+            if backgroundColor != nil && backgroundColor!.cgColor.alpha == 0 {
+                backgroundColor = oldValue
+            }
+        }
+    }
+}


### PR DESCRIPTION
// FREEBIE

### First time contributor checklist
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iDevice A, iPhone 7 Plus, iOS 11.2.6
 * iDevice B, iPhone 8, iOS 11.2.6
 * Simulator , iPhone 7 iOS 11.0
- - - - - - - - - -

### Description
Fixes #2901 

When a row is selected in UITableView, background colors of all UIView subviews gets changed. This class will prevent that from happening so that the blue dot can remain blue while the row is selected. 
Description and solution suggestions found in the following link:
https://stackoverflow.com/questions/6745919/uitableviewcell-subview-disappears-when-cell-is-selected/27717607

I've tested this, see provided before and after screenshot. I've removed my phone number from the images.

<img width="373" alt="before" src="https://user-images.githubusercontent.com/681234/36944701-ecb5e46e-1fa1-11e8-9748-49db1e0a28b6.png">

<img width="374" alt="after" src="https://user-images.githubusercontent.com/681234/36944703-f0266f60-1fa1-11e8-8171-6d98c038958a.png">

PS: I found an unrelated additional bug while debugging, the Norwegian word for Inbox "Innboks" is longer, so that label "Innboks (1)"-label in the segment control gets wrong. I will submit a issue and create an additional PR to fix this.