### PR TITLE
Fix blue new message dot

### DIFF
--- a/Signal.xcodeproj/project.pbxproj
+++ b/Signal.xcodeproj/project.pbxproj
@@ -215,7 +215,7 @@
 		34E3EF101EFC2684007F6822 /* DebugUIPage.m in Sources */ = {isa = PBXBuildFile; fileRef = 34E3EF0F1EFC2684007F6822 /* DebugUIPage.m */; };
 		34F308A21ECB469700BB7697 /* OWSBezierPathView.m in Sources */ = {isa = PBXBuildFile; fileRef = 34F308A11ECB469700BB7697 /* OWSBezierPathView.m */; };
 		34FD93701E3BD43A00109093 /* OWSAnyTouchGestureRecognizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 34FD936F1E3BD43A00109093 /* OWSAnyTouchGestureRecognizer.m */; };
-		35BF1A53204BF9B300AF5900 /* NeverClearView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35BF1A52204BF9B300AF5900 /* NeverClearView.swift */; };
+		35BC54F2205409B900283EF6 /* NeverClearView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35BF1A52204BF9B300AF5900 /* NeverClearView.swift */; };
 		4503F1BE20470A5B00CEE724 /* classic-quiet.aifc in Resources */ = {isa = PBXBuildFile; fileRef = 4503F1BB20470A5B00CEE724 /* classic-quiet.aifc */; };
 		4503F1BF20470A5B00CEE724 /* classic.aifc in Resources */ = {isa = PBXBuildFile; fileRef = 4503F1BC20470A5B00CEE724 /* classic.aifc */; };
 		4503F1C3204711D300CEE724 /* OWS107LegacySounds.m in Sources */ = {isa = PBXBuildFile; fileRef = 4503F1C1204711D200CEE724 /* OWS107LegacySounds.m */; };
@@ -3138,6 +3138,7 @@
 				B6B9ECFC198B31BA00C620D3 /* PushManager.m in Sources */,
 				45DF5DF21DDB843F00C936C7 /* CompareSafetyNumbersActivity.swift in Sources */,
 				458DE9D91DEE7B360071BB03 /* OWSWebRTCDataProtos.pb.m in Sources */,
+				35BC54F2205409B900283EF6 /* NeverClearView.swift in Sources */,
 				76EB063C18170B33006006FC /* NumberUtil.m in Sources */,
 				451166C01FD86B98000739BA /* AccountManager.swift in Sources */,
 				3430FE181F7751D4000EC51B /* GiphyAPI.swift in Sources */,

--- a/Signal.xcodeproj/project.pbxproj
+++ b/Signal.xcodeproj/project.pbxproj
@@ -215,6 +215,7 @@
 		34E3EF101EFC2684007F6822 /* DebugUIPage.m in Sources */ = {isa = PBXBuildFile; fileRef = 34E3EF0F1EFC2684007F6822 /* DebugUIPage.m */; };
 		34F308A21ECB469700BB7697 /* OWSBezierPathView.m in Sources */ = {isa = PBXBuildFile; fileRef = 34F308A11ECB469700BB7697 /* OWSBezierPathView.m */; };
 		34FD93701E3BD43A00109093 /* OWSAnyTouchGestureRecognizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 34FD936F1E3BD43A00109093 /* OWSAnyTouchGestureRecognizer.m */; };
+		35BF1A53204BF9B300AF5900 /* NeverClearView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35BF1A52204BF9B300AF5900 /* NeverClearView.swift */; };
 		4503F1BE20470A5B00CEE724 /* classic-quiet.aifc in Resources */ = {isa = PBXBuildFile; fileRef = 4503F1BB20470A5B00CEE724 /* classic-quiet.aifc */; };
 		4503F1BF20470A5B00CEE724 /* classic.aifc in Resources */ = {isa = PBXBuildFile; fileRef = 4503F1BC20470A5B00CEE724 /* classic.aifc */; };
 		4503F1C3204711D300CEE724 /* OWS107LegacySounds.m in Sources */ = {isa = PBXBuildFile; fileRef = 4503F1C1204711D200CEE724 /* OWS107LegacySounds.m */; };
@@ -832,6 +833,7 @@
 		34F308A11ECB469700BB7697 /* OWSBezierPathView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OWSBezierPathView.m; sourceTree = "<group>"; };
 		34FD936E1E3BD43A00109093 /* OWSAnyTouchGestureRecognizer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OWSAnyTouchGestureRecognizer.h; path = views/OWSAnyTouchGestureRecognizer.h; sourceTree = "<group>"; };
 		34FD936F1E3BD43A00109093 /* OWSAnyTouchGestureRecognizer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OWSAnyTouchGestureRecognizer.m; path = views/OWSAnyTouchGestureRecognizer.m; sourceTree = "<group>"; };
+		35BF1A52204BF9B300AF5900 /* NeverClearView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NeverClearView.swift; sourceTree = "<group>"; };
 		435EAC2E5E22D3F087EB3192 /* Pods-SignalShareExtension.app store release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SignalShareExtension.app store release.xcconfig"; path = "Pods/Target Support Files/Pods-SignalShareExtension/Pods-SignalShareExtension.app store release.xcconfig"; sourceTree = "<group>"; };
 		4503F1BB20470A5B00CEE724 /* classic-quiet.aifc */ = {isa = PBXFileReference; lastKnownFileType = file; path = "classic-quiet.aifc"; sourceTree = "<group>"; };
 		4503F1BC20470A5B00CEE724 /* classic.aifc */ = {isa = PBXFileReference; lastKnownFileType = file; path = classic.aifc; sourceTree = "<group>"; };
@@ -1654,6 +1656,7 @@
 		34D1F0BE1F8EC1760066283D /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				35BF1A52204BF9B300AF5900 /* NeverClearView.swift */,
 				34D1F0BF1F8EC1760066283D /* MessageRecipientStatusUtils.swift */,
 			);
 			path = Utils;

--- a/Signal/src/ViewControllers/InboxTableViewCell.m
+++ b/Signal/src/ViewControllers/InboxTableViewCell.m
@@ -106,7 +106,7 @@ const NSUInteger kAvatarViewDiameter = 52;
     [self.timeLabel setCompressionResistanceHigh];
 
     const int kunreadBadgeSize = 24;
-    self.unreadBadge = [[UIView alloc] initWithFrame:CGRectMake(0, 0, kunreadBadgeSize, kunreadBadgeSize)];
+    self.unreadBadge = [[NeverClearUIView alloc] initWithFrame:CGRectMake(0, 0, kunreadBadgeSize, kunreadBadgeSize)];
     self.unreadBadge.layer.cornerRadius = kunreadBadgeSize / 2;
     self.unreadBadge.backgroundColor = [UIColor ows_materialBlueColor];
     [self.contentView addSubview:self.unreadBadge];

--- a/Signal/src/ViewControllers/InboxTableViewCell.m
+++ b/Signal/src/ViewControllers/InboxTableViewCell.m
@@ -106,7 +106,7 @@ const NSUInteger kAvatarViewDiameter = 52;
     [self.timeLabel setCompressionResistanceHigh];
 
     const int kunreadBadgeSize = 24;
-    self.unreadBadge = [[NeverClearUIView alloc] initWithFrame:CGRectMake(0, 0, kunreadBadgeSize, kunreadBadgeSize)];
+    self.unreadBadge = [[NeverClearView alloc] initWithFrame:CGRectMake(0, 0, kunreadBadgeSize, kunreadBadgeSize)];
     self.unreadBadge.layer.cornerRadius = kunreadBadgeSize / 2;
     self.unreadBadge.backgroundColor = [UIColor ows_materialBlueColor];
     [self.contentView addSubview:self.unreadBadge];

--- a/Signal/src/ViewControllers/Utils/NeverClearView.swift
+++ b/Signal/src/ViewControllers/Utils/NeverClearView.swift
@@ -1,5 +1,6 @@
-// Created by Fredrik Lillejordet on 04.03.2018.
-// Copyright © 2018 Open Whisper Systems. All rights reserved.
+//
+//  Copyright (c) 2018 Open Whisper Systems. All rights reserved.
+//
 
 @objc class NeverClearView: UIView {
     override var backgroundColor: UIColor? {

--- a/Signal/src/ViewControllers/Utils/NeverClearView.swift
+++ b/Signal/src/ViewControllers/Utils/NeverClearView.swift
@@ -1,7 +1,7 @@
 // Created by Fredrik Lillejordet on 04.03.2018.
 // Copyright © 2018 Open Whisper Systems. All rights reserved.
 
-@objc class NeverClearUIView: UIView {
+@objc class NeverClearView: UIView {
     override var backgroundColor: UIColor? {
         didSet {
             if backgroundColor != nil && backgroundColor!.cgColor.alpha == 0 {

--- a/Signal/src/ViewControllers/Utils/NeverClearView.swift
+++ b/Signal/src/ViewControllers/Utils/NeverClearView.swift
@@ -1,0 +1,12 @@
+// Created by Fredrik Lillejordet on 04.03.2018.
+// Copyright © 2018 Open Whisper Systems. All rights reserved.
+
+@objc class NeverClearUIView: UIView {
+    override var backgroundColor: UIColor? {
+        didSet {
+            if backgroundColor != nil && backgroundColor!.cgColor.alpha == 0 {
+                backgroundColor = oldValue
+            }
+        }
+    }
+}

--- a/Signal/src/ViewControllers/Utils/NeverClearView.swift
+++ b/Signal/src/ViewControllers/Utils/NeverClearView.swift
@@ -5,7 +5,7 @@
 @objc class NeverClearView: UIView {
     override var backgroundColor: UIColor? {
         didSet {
-            if backgroundColor != nil && backgroundColor!.cgColor.alpha == 0 {
+            if backgroundColor?.cgColor.alpha == 0 {
                 backgroundColor = oldValue
             }
         }


### PR DESCRIPTION
// FREEBIE

### First time contributor checklist
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iDevice A, iPhone 7 Plus, iOS 11.2.6
 * iDevice B, iPhone 8, iOS 11.2.6
 * Simulator , iPhone 7 iOS 11.0
- - - - - - - - - -

### Description
Fixes #2901 

When a row is selected in UITableView, background colors of all UIView subviews gets changed. This class will prevent that from happening so that the blue dot can remain blue while the row is selected. 
Description and solution suggestions found in the following link:
https://stackoverflow.com/questions/6745919/uitableviewcell-subview-disappears-when-cell-is-selected/27717607

I've tested this, see provided before and after screenshot. I've removed my phone number from the images.

<img width="373" alt="before" src="https://user-images.githubusercontent.com/681234/36944701-ecb5e46e-1fa1-11e8-9748-49db1e0a28b6.png">

<img width="374" alt="after" src="https://user-images.githubusercontent.com/681234/36944703-f0266f60-1fa1-11e8-8171-6d98c038958a.png">

PS: I found an unrelated additional bug while debugging, the Norwegian word for Inbox "Innboks" is longer, so that label "Innboks (1)"-label in the segment control gets truncated. I've created this https://github.com/signalapp/Signal-iOS/issues/3096 