### PR TITLE
autoresize label in segmentControl to avoid unwanted truncation

### DIFF
--- a/Signal/src/ViewControllers/HomeViewController.m
+++ b/Signal/src/ViewControllers/HomeViewController.m
@@ -764,6 +764,7 @@ typedef NS_ENUM(NSInteger, CellState) { kArchiveState, kInboxState };
     }
 
     [_segmentedControl setTitle:unreadString forSegmentAtIndex:0];
+    [_segmentedControl sizeToFit];
     [_segmentedControl.superview setNeedsLayout];
     [_segmentedControl reloadInputViews];
 }


### PR DESCRIPTION
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * Simulator iPhone 7 iOS 11.0 

- - - - - - - - - -

### Description
fixes #3096

Tiny fix to resize the label in segmentation control in "Conversation View". 
Changed iOS language settings to Norwegian and verified that the labels in segment controls resizes depending on text length. This will work with other languages as well.

See screenshots:

Before:
<img width="371" alt="before" src="https://user-images.githubusercontent.com/681234/36997844-40793d84-20bb-11e8-825b-3423f5ef19a8.png">

After(no new messages)
<img width="375" alt="after0" src="https://user-images.githubusercontent.com/681234/36997892-6d95c008-20bb-11e8-8028-0cd96dc701aa.png">


After(8 new messages)
<img width="372" alt="after 8" src="https://user-images.githubusercontent.com/681234/36997850-441fae0a-20bb-11e8-98b5-a87cb9b74416.png">

After(21 new messages)
<img width="377" alt="after 21" src="https://user-images.githubusercontent.com/681234/36997851-46383ba8-20bb-11e8-9c10-5fda4d3099d2.png">