### PR TITLE
Show migration screen at first launch.

### DIFF
--- a/Signal/src/ViewControllers/ExperienceUpgradesPageViewController.swift
+++ b/Signal/src/ViewControllers/ExperienceUpgradesPageViewController.swift
@@ -44,8 +44,8 @@ private class IntroducingCustomNotificationAudioExperienceUpgradeViewController:
         let button = addButton(title: buttonTitle) { _ in
             // dismiss the modally presented view controller, then proceed.
             self.experienceUpgradesPageViewController.dismiss(animated: true) {
-                guard let fromViewController = UIApplication.shared.frontmostViewController as? HomeViewController else {
-                    owsFail("unexpected frontmostViewController: \(String(describing: UIApplication.shared.frontmostViewController))")
+                guard let fromViewController = UIApplication.shared.frontmostViewController else {
+                    owsFail("frontmostViewController was unexectedly nil")
                     return
                 }
 

--- a/Signal/src/ViewControllers/HomeViewController.m
+++ b/Signal/src/ViewControllers/HomeViewController.m
@@ -287,6 +287,22 @@ typedef NS_ENUM(NSInteger, CellState) { kArchiveState, kInboxState };
     [self updateBarButtonItems];
 }
 
+- (void)viewDidAppear:(BOOL)animated
+{
+    [super viewDidAppear:animated];
+
+    // Keep in mind viewDidAppear is called while the app is in the background if the app was
+    // launched by a voip notification. This is fine - it will remain visible to the user
+    // when they eventually launch the app, but we shouldn't make any changes assuming
+    // the user has *seen* the upgrade experience at this point.
+    if (!self.hasShownAnyUnseenUpgradeExperiences) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self displayAnyUnseenUpgradeExperience];
+            self.hasShownAnyUnseenUpgradeExperiences = YES;
+        });
+    }
+}
+
 - (void)updateBarButtonItems
 {
     const CGFloat kBarButtonSize = 44;
@@ -509,19 +525,6 @@ typedef NS_ENUM(NSInteger, CellState) { kArchiveState, kInboxState };
                 [self updateReminderViews];
             });
         }];
-    }
-    
-    // We want to show the user the upgrade experience as soon as the app is visible to them.
-    // It cannot go in viewDidAppear, which is called while the app is in the background if
-    // we were launched from a voip notification.
-    if (!self.hasShownAnyUnseenUpgradeExperiences) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            if ([[UIApplication sharedApplication] applicationState] != UIApplicationStateActive) {
-                return;
-            }
-            [self displayAnyUnseenUpgradeExperience];
-            self.hasShownAnyUnseenUpgradeExperiences = YES;
-        });
     }
 }
 

--- a/SignalMessaging/environment/OWSSounds.h
+++ b/SignalMessaging/environment/OWSSounds.h
@@ -20,7 +20,7 @@ typedef NS_ENUM(NSUInteger, OWSSound) {
     OWSSound_Popcorn,
     OWSSound_Pulse,
     OWSSound_Synth,
-    OWSSound_ClassicNotification,
+    OWSSound_SignalClassic,
 
     // Ringtone Sounds
     OWSSound_Opening,

--- a/SignalMessaging/environment/OWSSounds.m
+++ b/SignalMessaging/environment/OWSSounds.m
@@ -74,8 +74,8 @@ NSString *const kOWSSoundsStorageGlobalNotificationKey = @"kOWSSoundsStorageGlob
         @(OWSSound_Keys),
         @(OWSSound_Popcorn),
         @(OWSSound_Pulse),
-        @(OWSSound_Synth),
         @(OWSSound_ClassicNotification),
+        @(OWSSound_Synth),
     ];
 }
 

--- a/SignalMessaging/environment/OWSSounds.m
+++ b/SignalMessaging/environment/OWSSounds.m
@@ -74,7 +74,7 @@ NSString *const kOWSSoundsStorageGlobalNotificationKey = @"kOWSSoundsStorageGlob
         @(OWSSound_Keys),
         @(OWSSound_Popcorn),
         @(OWSSound_Pulse),
-        @(OWSSound_ClassicNotification),
+        @(OWSSound_SignalClassic),
         @(OWSSound_Synth),
     ];
 }
@@ -112,7 +112,7 @@ NSString *const kOWSSoundsStorageGlobalNotificationKey = @"kOWSSoundsStorageGlob
             return @"Pulse";
         case OWSSound_Synth:
             return @"Synth";
-        case OWSSound_ClassicNotification:
+        case OWSSound_SignalClassic:
             return @"Signal Classic";
 
         // Call Audio
@@ -172,7 +172,7 @@ NSString *const kOWSSoundsStorageGlobalNotificationKey = @"kOWSSoundsStorageGlob
             return (quiet ? @"pulse-quiet.aifc" : @"pulse.aifc");
         case OWSSound_Synth:
             return (quiet ? @"synth-quiet.aifc" : @"synth.aifc");
-        case OWSSound_ClassicNotification:
+        case OWSSound_SignalClassic:
             return (quiet ? @"classic-quiet.aifc" : @"classic.aifc");
 
             // Ringtone Sounds

--- a/SignalMessaging/environment/migrations/OWS107LegacySounds.m
+++ b/SignalMessaging/environment/migrations/OWS107LegacySounds.m
@@ -22,7 +22,7 @@ static NSString *const OWS107LegacySoundsMigrationId = @"107";
 {
     OWSAssert(transaction);
 
-    [OWSSounds setGlobalNotificationSound:OWSSound_ClassicNotification transaction:transaction];
+    [OWSSounds setGlobalNotificationSound:OWSSound_SignalClassic transaction:transaction];
 }
 
 @end


### PR DESCRIPTION
There used to be a migration that ran when the experience upgrade view controller became visible. In an effort to make sure that didn't happen until the user actually had the app in the foreground, I inadvertently suppressed the presentation of the experience upgrade for users explicitly launching the app (until they backgrounded and re-foregrounded the app).

Now that the migration has been removed, I've reverted the presentation logic of the upgrade experience VC to occur when HomeViewController.viewDidAppear.

PTAL @charlesmchen 

