### PR TITLE
Fix CI status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Signal for iOS [![Build Status](https://travis-ci.org/WhisperSystems/Signal-iOS.svg?branch=master)](https://travis-ci.org/WhisperSystems/Signal-iOS)
+# Signal for iOS [![Build Status](https://travis-ci.org/signalapp/Signal-iOS.svg?branch=master)](https://travis-ci.org/signalapp/Signal-iOS)
 
 Signal is a messaging app for simple private communication with friends.
 


### PR DESCRIPTION
GitHub organization name changed, somebody forgot to fix the CI badge in the readme.