### PR TITLE
Call connection fixups

### DIFF
--- a/Signal/src/AppDelegate.m
+++ b/Signal/src/AppDelegate.m
@@ -1095,7 +1095,6 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
     [[OWSMessageReceiver sharedInstance] handleAnyUnprocessedEnvelopesAsync];
     [[OWSBatchMessageProcessor sharedInstance] handleAnyUnprocessedEnvelopesAsync];
 
-
 #ifdef DEBUG
     // A bug in orphan cleanup could be disastrous so let's only
     // run it in DEBUG builds for a few releases.

--- a/Signal/src/ViewControllers/CallViewController.swift
+++ b/Signal/src/ViewControllers/CallViewController.swift
@@ -15,8 +15,10 @@ class CallViewController: OWSViewController, CallObserver, CallServiceObserver, 
     let TAG = "[CallViewController]"
 
     // Dependencies
-
-    let callUIAdapter: CallUIAdapter
+    var callUIAdapter: CallUIAdapter {
+        return SignalApp.shared().callUIAdapter
+    }
+    
     let contactsManager: OWSContactsManager
 
     // MARK: Properties
@@ -97,7 +99,7 @@ class CallViewController: OWSViewController, CallObserver, CallServiceObserver, 
         return allAudioSources.count > 2
     }
 
-    var allAudioSources: Set<AudioSource>
+    var allAudioSources: Set<AudioSource> = Set()
 
     var appropriateAudioSources: Set<AudioSource> {
         if call.hasLocalVideo {
@@ -124,22 +126,16 @@ class CallViewController: OWSViewController, CallObserver, CallServiceObserver, 
 
     @available(*, unavailable, message: "use init(call:) constructor instead.")
     required init?(coder aDecoder: NSCoder) {
-        contactsManager = Environment.current().contactsManager
-        callUIAdapter = SignalApp.shared().callUIAdapter
-        allAudioSources = Set(callUIAdapter.audioService.availableInputs)
-        self.call = SignalCall.outgoingCall(localId: UUID(), remotePhoneNumber: "+1234567890")
-        self.thread = TSContactThread.getOrCreateThread(contactId: call.remotePhoneNumber)
-        super.init(coder: aDecoder)
-        observeNotifications()
+        fatalError("Unimplemented")
     }
 
     required init(call: SignalCall) {
         contactsManager = Environment.current().contactsManager
-        callUIAdapter = SignalApp.shared().callUIAdapter
-        allAudioSources = Set(callUIAdapter.audioService.availableInputs)
         self.call = call
         self.thread = TSContactThread.getOrCreateThread(contactId: call.remotePhoneNumber)
         super.init(nibName: nil, bundle: nil)
+        
+        allAudioSources = Set(callUIAdapter.audioService.availableInputs)
 
         assert(callUIAdapter.audioService.delegate == nil)
         callUIAdapter.audioService.delegate = self

--- a/Signal/src/call/CallService.swift
+++ b/Signal/src/call/CallService.swift
@@ -1643,7 +1643,7 @@ protocol CallServiceObserver: class {
             return
         }
 
-        let kMaxViewPresentationDelay = 2.5
+        let kMaxViewPresentationDelay: Double = 5
         guard fabs(connectedDate.timeIntervalSinceNow) > kMaxViewPresentationDelay else {
             // Ignore; call connected recently.
             return
@@ -1654,7 +1654,7 @@ protocol CallServiceObserver: class {
         guard nil != frontmostViewController as? CallViewController else {
             OWSProdError(OWSAnalyticsEvents.callServiceCallViewCouldNotPresent(), file: #file, function: #function, line: #line)
             owsFail("\(self.logTag) in \(#function) Call terminated due to call view presentation delay: \(frontmostViewController.debugDescription).")
-            self.terminateCall()
+            self.handleFailedCall(failedCall: call, error: CallError.assertionError(description: "Call view didn't present after \(kMaxViewPresentationDelay) seconds"))
             return
         }
     }

--- a/Signal/src/network/PushManager.m
+++ b/Signal/src/network/PushManager.m
@@ -38,7 +38,6 @@ NSString *const Signal_Message_MarkAsRead_Identifier = @"Signal_Message_MarkAsRe
 @property (nonatomic) UIBackgroundTaskIdentifier callBackgroundTask;
 @property (nonatomic, readonly) OWSMessageSender *messageSender;
 @property (nonatomic, readonly) OWSMessageFetcherJob *messageFetcherJob;
-@property (nonatomic, readonly) CallUIAdapter *callUIAdapter;
 @property (nonatomic, readonly) NotificationsManager *notificationsManager;
 
 @end
@@ -58,14 +57,12 @@ NSString *const Signal_Message_MarkAsRead_Identifier = @"Signal_Message_MarkAsRe
 {
     return [self initWithMessageFetcherJob:SignalApp.sharedApp.messageFetcherJob
                             storageManager:[TSStorageManager sharedManager]
-                             callUIAdapter:SignalApp.sharedApp.callService.callUIAdapter
                              messageSender:[Environment current].messageSender
                       notificationsManager:SignalApp.sharedApp.notificationsManager];
 }
 
 - (instancetype)initWithMessageFetcherJob:(OWSMessageFetcherJob *)messageFetcherJob
                            storageManager:(TSStorageManager *)storageManager
-                            callUIAdapter:(CallUIAdapter *)callUIAdapter
                             messageSender:(OWSMessageSender *)messageSender
                      notificationsManager:(NotificationsManager *)notificationsManager
 {
@@ -74,7 +71,6 @@ NSString *const Signal_Message_MarkAsRead_Identifier = @"Signal_Message_MarkAsRe
         return self;
     }
 
-    _callUIAdapter = callUIAdapter;
     _messageSender = messageSender;
     _messageFetcherJob = messageFetcherJob;
     _callBackgroundTask = UIBackgroundTaskInvalid;
@@ -90,6 +86,11 @@ NSString *const Signal_Message_MarkAsRead_Identifier = @"Signal_Message_MarkAsRe
                                                object:nil];
 
     return self;
+}
+
+- (CallUIAdapter *)callUIAdapter
+{
+    return SignalApp.sharedApp.callService.callUIAdapter;
 }
 
 - (void)handleMessageRead:(NSNotification *)notification

--- a/SignalMessaging/utils/OWSPreferences.m
+++ b/SignalMessaging/utils/OWSPreferences.m
@@ -280,7 +280,7 @@ NSString *const OWSPreferencesKeySystemCallLogEnabled = @"OWSPreferencesKeySyste
     }
 
     [self setValueForKey:OWSPreferencesKeyCallKitEnabled toValue:@(flag)];
-    OWSFail(@"Rev callUIAdaptee to get new setting");
+    // Rev callUIAdaptee to get new setting
 }
 
 - (BOOL)isCallKitEnabledSet


### PR DESCRIPTION
callUIAdapter is not a singleton (for better or for worse)

No one should hold a reference directly to it, but rather via the
CallService, which is a singleton

Wait a bit longer for initial call screen before terminating. Especially
first call can hit this limit.

When call *does* take too long to show, terminate properly to ensure
we're not left with a phantom call