### PR TITLE
A lighter touch for the fix-call connect.

### DIFF
--- a/Signal/src/AppDelegate.m
+++ b/Signal/src/AppDelegate.m
@@ -1063,9 +1063,6 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
 
     // TODO: Once "app ready" logic is moved into AppSetup, move this line there.
     [[OWSProfileManager sharedManager] ensureLocalProfileCached];
-
-    // Incase anything changed while migrations ran
-    [[SignalApp sharedApp].callService createCallUIAdapter];
     
     // Note that this does much more than set a flag;
     // it will also run all deferred blocks.

--- a/Signal/src/call/NonCallKitCallUIAdaptee.swift
+++ b/Signal/src/call/NonCallKitCallUIAdaptee.swift
@@ -26,8 +26,6 @@ class NonCallKitCallUIAdaptee: NSObject, CallUIAdaptee {
         self.notificationsAdapter = notificationsAdapter
 
         super.init()
-
-        SwiftSingletons.register(self)
     }
 
     func startOutgoingCall(handle: String) -> SignalCall {

--- a/Signal/src/environment/SignalApp.m
+++ b/Signal/src/environment/SignalApp.m
@@ -76,6 +76,8 @@
             OWSAssert(self.accountManager);
             OWSAssert(Environment.current.contactsManager);
             OWSAssert(Environment.current.messageSender);
+            [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didChangeCallLoggingPreference:) name:OWSPreferencesCallLoggingDidChangeNotification object:nil];
+            
             _callService = [[CallService alloc] initWithAccountManager:self.accountManager
                                                        contactsManager:Environment.current.contactsManager
                                                          messageSender:Environment.current.messageSender
@@ -232,6 +234,11 @@
                        keyboardOnViewAppearing:keyboardOnViewAppearing
                            callOnViewAppearing:callOnViewAppearing];
     });
+}
+
+- (void)didChangeCallLoggingPreference:(NSNotification *)notitication
+{
+    [self.callService createCallUIAdapter];
 }
 
 #pragma mark - Methods

--- a/SignalMessaging/utils/OWSPreferences.h
+++ b/SignalMessaging/utils/OWSPreferences.h
@@ -16,6 +16,7 @@ typedef NS_ENUM(NSUInteger, NotificationType) {
 // Used when migrating logging to NSUserDefaults.
 extern NSString *const OWSPreferencesSignalDatabaseCollection;
 extern NSString *const OWSPreferencesKeyEnableDebugLog;
+extern NSString *const OWSPreferencesCallLoggingDidChangeNotification;
 
 @class YapDatabaseReadWriteTransaction;
 

--- a/SignalMessaging/utils/OWSPreferences.m
+++ b/SignalMessaging/utils/OWSPreferences.m
@@ -8,10 +8,12 @@
 #import <SignalServiceKit/TSStorageHeaders.h>
 #import <SignalServiceKit/YapDatabaseConnection+OWS.h>
 #import <SignalServiceKit/YapDatabaseTransaction+OWS.h>
+#import <SignalServiceKit/NSNotificationCenter+OWS.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 NSString *const OWSPreferencesSignalDatabaseCollection = @"SignalPreferences";
+NSString *const OWSPreferencesCallLoggingDidChangeNotification = @"OWSPreferencesCallLoggingDidChangeNotification";
 
 NSString *const OWSPreferencesKeyScreenSecurity = @"Screen Security Key";
 NSString *const OWSPreferencesKeyEnableDebugLog = @"Debugging Log Enabled Key";
@@ -259,6 +261,11 @@ NSString *const OWSPreferencesKeySystemCallLogEnabled = @"OWSPreferencesKeySyste
     [self setValueForKey:OWSPreferencesKeySystemCallLogEnabled
                  toValue:@(shouldLogCallsInRecents)
              transaction:transaction];
+    
+    // We need to reload the callService.callUIAdapter here, but SignalMessaging doesn't know about CallService, so we use
+    // notifications to decouple the code. This is admittedly awkward, but it only happens once, and the alternative would
+    // be importing all the call related classes into SignalMessaging.
+    [[NSNotificationCenter defaultCenter] postNotificationNameAsync:OWSPreferencesCallLoggingDidChangeNotification object:nil];
 }
 
 - (BOOL)isCallKitEnabled


### PR DESCRIPTION
Though it should be fine, reloading the callUIAdapter is a bit heavy
handed. And the current implementation is prone to being broken, since
we sometimes forget not to treat callUIAdapter as a singleton.

Longer term we can find a way to either: make callUIAdapter a true
singleton or possibly make callUIAdapter a private member of something
which *is* a true singleton.

Since we only *need* it to be reloaded the one time the migration runs
(or when a user changes settings which should be rare) it makes sense to
remove it from the happy path.