### PR TITLE
Reduce Giphy page size.

### DIFF
--- a/Signal/src/network/GiphyAPI.swift
+++ b/Signal/src/network/GiphyAPI.swift
@@ -327,7 +327,7 @@ extension GiphyError: LocalizedError {
 
         // This is the Signal iOS API key.
         let kGiphyApiKey = "ZsUpUm2L6cVbvei347EQNp7HrROjbOdc"
-        let kGiphyPageSize = 200
+        let kGiphyPageSize = 100
         let kGiphyPageOffset = 0
         guard let queryEncoded = query.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
             Logger.error("\(TAG) Could not URL encode query: \(query).")


### PR DESCRIPTION
PTAL @michaelkirk 

This will reduce the max number of search results in half (from 200 -> 100), but:

* search results with load faster.
* we'll be less likely to stumble across bugs that only affect queries with lots of results (as we did this week).
* I suspect most users only look at the first ~20 results anyway.