### PR TITLE
Update footer when returning to details via Tile view

### DIFF
--- a/Signal/src/ViewControllers/MediaGalleryViewController.swift
+++ b/Signal/src/ViewControllers/MediaGalleryViewController.swift
@@ -377,11 +377,39 @@ class MediaGalleryViewController: UINavigationController, MediaGalleryDataSource
 
     func mediaTileViewController(_ viewController: MediaTileViewController, didTapView tappedView: UIView, mediaGalleryItem: MediaGalleryItem) {
         if self.fromNavController != nil {
-            // If from conversation settings view, we've already pushed
+            // If we got to the gallery via conversation settings, present the detail view
+            // on top of the tile view
+            //
+            // == ViewController Schematic ==
+            //
+            // [DetailView] <--,
+            // [TileView] -----'
+            // [ConversationSettingsView]
+            // [ConversationView]
+            //
+
             self.presentDetailView(fromViewController: mediaTileViewController, initialDetailItem: mediaGalleryItem, replacingView: tappedView)
         } else {
-            // If from conversation view
-            self.pageViewController!.currentItem = mediaGalleryItem
+            // If we got to the gallery via the conversation view, pop the tile view
+            // to return to the detail view
+            //
+            // == ViewController Schematic ==
+            //
+            // [TileView] -----,
+            // [DetailView] <--'
+            // [ConversationView]
+            //
+
+            guard let pageViewController = self.pageViewController else {
+                owsFail("\(logTag) in \(#function) pageeViewController was unexpectedly nil")
+                self.dismissSelf(animated: true)
+                return
+            }
+
+            pageViewController.currentItem = mediaGalleryItem
+            pageViewController.willBePresentedAgain()
+
+            // TODO fancy zoom animation
             self.popViewController(animated: true)
         }
     }

--- a/Signal/src/ViewControllers/MediaPageViewController.swift
+++ b/Signal/src/ViewControllers/MediaPageViewController.swift
@@ -179,6 +179,10 @@ class MediaPageViewController: UIPageViewController, UIPageViewControllerDataSou
 
     // MARK: View Helpers
 
+    public func willBePresentedAgain() {
+        updateFooterBarButtonItems(isPlayingVideo: false)
+    }
+
     public func wasPresented() {
         let currentViewController = self.currentViewController
 


### PR DESCRIPTION
Make sure to add/remove the video "play" button from the detail footer when bouncing around between the media tile view and the detail pager.

PTAL @charlesmchen 