### PR TITLE
Fix Tile -> Detail -> Swipe -> Dismiss -> Detail flow.

### DIFF
--- a/Signal/src/ViewControllers/MediaGalleryViewController.swift
+++ b/Signal/src/ViewControllers/MediaGalleryViewController.swift
@@ -283,6 +283,9 @@ class MediaGalleryViewController: UINavigationController, MediaGalleryDataSource
         self.presentationView.image = initialDetailItem.fullSizedImage
         self.applyInitialMediaViewConstraints()
 
+        // Restore presentationView.alpha in case a previous dismiss left us in a bad state.
+        self.presentationView.alpha = 1
+
         // We want to animate the tapped media from it's position in the previous VC
         // to it's resting place in the center of this view controller.
         //

--- a/Signal/src/ViewControllers/MediaGalleryViewController.swift
+++ b/Signal/src/ViewControllers/MediaGalleryViewController.swift
@@ -174,7 +174,7 @@ protocol MediaGalleryDataSource: class {
     func galleryItem(after currentItem: MediaGalleryItem) -> MediaGalleryItem?
 
     func showAllMedia(focusedItem: MediaGalleryItem)
-    func dismissDetailView(_ pageViewController: MediaPageViewController, animated isAnimated: Bool, completion: (() -> Void)?)
+    func dismissMediaDetailViewController(_ mediaDetailViewController: MediaPageViewController, animated isAnimated: Bool, completion: (() -> Void)?)
 }
 
 class MediaGalleryViewController: UINavigationController, MediaGalleryDataSource, MediaTileViewControllerDelegate {
@@ -423,11 +423,11 @@ class MediaGalleryViewController: UINavigationController, MediaGalleryDataSource
         }
     }
 
-    public func dismissDetailView(_ pageViewController: MediaPageViewController, animated isAnimated: Bool, completion: (() -> Void)?) {
+    public func dismissMediaDetailViewController(_ mediaDetailViewController: MediaPageViewController, animated isAnimated: Bool, completion: (() -> Void)?) {
         self.view.isUserInteractionEnabled = false
         UIApplication.shared.isStatusBarHidden = false
 
-        guard let detailView = pageViewController.view else {
+        guard let detailView = mediaDetailViewController.view else {
             owsFail("\(logTag) in \(#function) detailView was unexpectedly nil")
             self.presentingViewController?.dismiss(animated: false, completion: completion)
             return

--- a/Signal/src/ViewControllers/MediaGalleryViewController.swift
+++ b/Signal/src/ViewControllers/MediaGalleryViewController.swift
@@ -174,7 +174,7 @@ protocol MediaGalleryDataSource: class {
     func galleryItem(after currentItem: MediaGalleryItem) -> MediaGalleryItem?
 
     func showAllMedia(focusedItem: MediaGalleryItem)
-    func dismissSelf(animated isAnimated: Bool, completion: (() -> Void)?)
+    func dismissDetailView(_ pageViewController: MediaPageViewController, animated isAnimated: Bool, completion: (() -> Void)?)
 }
 
 class MediaGalleryViewController: UINavigationController, MediaGalleryDataSource, MediaTileViewControllerDelegate {
@@ -284,6 +284,7 @@ class MediaGalleryViewController: UINavigationController, MediaGalleryDataSource
         self.applyInitialMediaViewConstraints()
 
         // Restore presentationView.alpha in case a previous dismiss left us in a bad state.
+        pageViewController.navigationController?.setNavigationBarHidden(false, animated: false)
         self.presentationView.alpha = 1
 
         // We want to animate the tapped media from it's position in the previous VC
@@ -408,8 +409,9 @@ class MediaGalleryViewController: UINavigationController, MediaGalleryDataSource
             //
 
             guard let pageViewController = self.pageViewController else {
-                owsFail("\(logTag) in \(#function) pageeViewController was unexpectedly nil")
-                self.dismissSelf(animated: true)
+                owsFail("\(logTag) in \(#function) pageViewController was unexpectedly nil")
+                self.dismiss(animated: true)
+
                 return
             }
 
@@ -421,11 +423,11 @@ class MediaGalleryViewController: UINavigationController, MediaGalleryDataSource
         }
     }
 
-    public func dismissSelf(animated isAnimated: Bool, completion: (() -> Void)? = nil) {
+    public func dismissDetailView(_ pageViewController: MediaPageViewController, animated isAnimated: Bool, completion: (() -> Void)?) {
         self.view.isUserInteractionEnabled = false
         UIApplication.shared.isStatusBarHidden = false
 
-        guard let detailView = pageViewController?.view else {
+        guard let detailView = pageViewController.view else {
             owsFail("\(logTag) in \(#function) detailView was unexpectedly nil")
             self.presentingViewController?.dismiss(animated: false, completion: completion)
             return

--- a/Signal/src/ViewControllers/MediaPageViewController.swift
+++ b/Signal/src/ViewControllers/MediaPageViewController.swift
@@ -454,7 +454,7 @@ class MediaPageViewController: UIPageViewController, UIPageViewControllerDataSou
             return
         }
 
-        mediaGalleryDataSource.dismissDetailView(self, animated: isAnimated, completion: completion)
+        mediaGalleryDataSource.dismissMediaDetailViewController(self, animated: isAnimated, completion: completion)
     }
 
     public func mediaDetailViewController(_ mediaDetailViewController: MediaDetailViewController, isPlayingVideo: Bool) {

--- a/Signal/src/ViewControllers/MediaPageViewController.swift
+++ b/Signal/src/ViewControllers/MediaPageViewController.swift
@@ -203,6 +203,7 @@ class MediaPageViewController: UIPageViewController, UIPageViewControllerDataSou
             currentViewController.playVideo()
         }
     }
+
     @objc
     public func didPressAllMediaButton(sender: Any) {
         Logger.debug("\(logTag) in \(#function)")
@@ -255,7 +256,7 @@ class MediaPageViewController: UIPageViewController, UIPageViewControllerDataSou
     private func updateFooterBarButtonItems(isPlayingVideo: Bool) {
         // TODO do we still need this? seems like a vestige
         // from when media detail view was used for attachment approval
-        if (self.footerBar == nil) {
+        if self.footerBar == nil {
             owsFail("\(logTag) No footer bar visible.")
             return
         }
@@ -453,7 +454,7 @@ class MediaPageViewController: UIPageViewController, UIPageViewControllerDataSou
             return
         }
 
-        mediaGalleryDataSource.dismissSelf(animated: isAnimated, completion: completion)
+        mediaGalleryDataSource.dismissDetailView(self, animated: isAnimated, completion: completion)
     }
 
     public func mediaDetailViewController(_ mediaDetailViewController: MediaDetailViewController, isPlayingVideo: Bool) {


### PR DESCRIPTION
We weren't doing a good job of cleaning up state upon dismissing the DetailView when presented *from* the tile view.

Basically the repro was:

Go to Conversation Settings -> All Media
Tap on a tile, swipe to a different piece of media, dismiss

That dismiss would be fine.

However, when tapping on a *subsequent* tile. That presentation (and eventual dismissal) would not show the presentationView.

And another similar problem, if you'd dismissed the detail view while the navbar was hidden, the next presentation of the detail view would be missing the navbar.

PTAL @charlesmchen 
