### PR TITLE
Accept autocorrect suggestion before sending

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/ConversationInputToolbar.h
+++ b/Signal/src/ViewControllers/ConversationView/ConversationInputToolbar.h
@@ -48,6 +48,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSString *)messageText;
 - (void)setMessageText:(NSString *_Nullable)value animated:(BOOL)isAnimated;
+/// Makes the text field accept the current autocorrect suggestion from the keyboard.
+/// For instance, accept it when there is a suggestion when the send button is pressed.
+- (void)acceptAutocorrectSuggestion;
 - (void)clearTextMessageAnimated:(BOOL)isAnimated;
 - (void)toggleDefaultKeyboard;
 

--- a/Signal/src/ViewControllers/ConversationView/ConversationInputToolbar.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationInputToolbar.m
@@ -202,6 +202,13 @@ const CGFloat kMaxTextViewHeight = 98;
     [self updateHeightWithTextView:self.inputTextView];
 }
 
+- (void)acceptAutocorrectSuggestion
+{
+    // https://stackoverflow.com/a/27865136/4509555
+    [self.inputTextView.inputDelegate selectionWillChange:self.inputTextView];
+    [self.inputTextView.inputDelegate selectionDidChange:self.inputTextView];
+}
+
 - (void)clearTextMessageAnimated:(BOOL)isAnimated
 {
     [self setMessageText:nil animated:isAnimated];

--- a/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
@@ -4423,6 +4423,7 @@ typedef enum : NSUInteger {
 
 - (void)sendButtonPressed
 {
+    [self.inputToolbar acceptAutocorrectSuggestion];
     [self tryToSendTextMessage:self.inputToolbar.messageText updateKeyboardState:YES];
 }
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 8 Plus Simulator, iOS 11.3

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->
Previously, when we type a message in `ConversationViewController`, and then click "Send" when there is a pending autocorrect suggestion in the keyboard, the autocorrect suggestion is ignored. This results in messages being sent with typos. This commit accepts the autocorrect suggestion before the message is sent, emulating the behaviour in Apple Messages and Facebook Messenger.

Fixes #2875.

Unfortunately, I was unable to install this on an actual device. However, the expected behaviour can be tested in the Simulator.