### PR TITLE
Fix small text usage.

### DIFF
--- a/Signal/src/ViewControllers/ProfileViewController.m
+++ b/Signal/src/ViewControllers/ProfileViewController.m
@@ -179,7 +179,7 @@ NSString *const kProfileView_LastPresentedDate = @"kProfileView_LastPresentedDat
 
     UILabel *infoLabel = [UILabel new];
     infoLabel.textColor = [UIColor ows_darkGrayColor];
-    infoLabel.font = [UIFont ows_dynamicTypeFootnoteFont];
+    infoLabel.font = [UIFont ows_regularFontWithSize:11.f];
     infoLabel.textAlignment = NSTextAlignmentCenter;
     NSMutableAttributedString *text = [NSMutableAttributedString new];
     [text appendAttributedString:[[NSAttributedString alloc]

--- a/Signal/src/ViewControllers/ThreadSettings/OWSConversationSettingsViewController.m
+++ b/Signal/src/ViewControllers/ThreadSettings/OWSConversationSettingsViewController.m
@@ -382,7 +382,7 @@ NS_ASSUME_NONNULL_BEGIN
             subtitleLabel.text
                 = NSLocalizedString(@"DISAPPEARING_MESSAGES_DESCRIPTION", @"subheading in conversation settings");
             subtitleLabel.textColor = [UIColor blackColor];
-            subtitleLabel.font = [UIFont ows_dynamicTypeFootnoteFont];
+            subtitleLabel.font = [UIFont ows_regularFontWithSize:11.f];
             subtitleLabel.numberOfLines = 0;
             subtitleLabel.lineBreakMode = NSLineBreakByWordWrapping;
             [cell.contentView addSubview:subtitleLabel];
@@ -421,7 +421,7 @@ NS_ASSUME_NONNULL_BEGIN
                             UILabel *rowLabel = strongSelf.disappearingMessagesDurationLabel;
                             [strongSelf updateDisappearingMessagesDurationLabel];
                             rowLabel.textColor = [UIColor blackColor];
-                            rowLabel.font = [UIFont ows_dynamicTypeFootnoteFont];
+                            rowLabel.font = [UIFont ows_regularFontWithSize:11.f];
                             rowLabel.lineBreakMode = NSLineBreakByTruncatingTail;
                             [topView addSubview:rowLabel];
                             [rowLabel autoVCenterInSuperview];

--- a/Signal/src/views/AttachmentPointerView.swift
+++ b/Signal/src/views/AttachmentPointerView.swift
@@ -118,7 +118,7 @@ class AttachmentPointerView: UIView {
         statusLabel.numberOfLines = 2
 
         statusLabel.textColor = self.textColor
-        statusLabel.font = .ows_dynamicTypeFootnote
+        statusLabel.font = UIFont.ows_regularFont(withSize: 11.0)
 
         statusLabel.autoPinWidthToSuperview()
         statusLabel.autoPinEdge(.top, to: .bottom, of: progressView, withOffset: 4)

--- a/Signal/src/views/GroupTableViewCell.swift
+++ b/Signal/src/views/GroupTableViewCell.swift
@@ -25,7 +25,7 @@ import SignalServiceKit
 
         // Font config
         nameLabel.font = .ows_dynamicTypeBody
-        subtitleLabel.font = .ows_dynamicTypeFootnote
+        subtitleLabel.font = UIFont.ows_regularFont(withSize: 11.0)
         subtitleLabel.textColor = UIColor.ows_darkGray
 
         // Listen to notifications...

--- a/SignalMessaging/Views/ContactTableViewCell.m
+++ b/SignalMessaging/Views/ContactTableViewCell.m
@@ -83,12 +83,12 @@ const CGFloat kContactTableViewCellAvatarTextMargin = 12;
 
     _profileNameLabel = [UILabel new];
     _profileNameLabel.lineBreakMode = NSLineBreakByTruncatingTail;
-    _profileNameLabel.font = [UIFont ows_dynamicTypeFootnoteFont];
+    _profileNameLabel.font = [UIFont ows_regularFontWithSize:11.f];
     _profileNameLabel.textColor = [UIColor grayColor];
     [_nameContainerView addSubview:_profileNameLabel];
 
     _subtitle = [UILabel new];
-    _subtitle.font = [UIFont ows_dynamicTypeFootnoteFont];
+    _subtitle.font = [UIFont ows_regularFontWithSize:11.f];
     _subtitle.textColor = [UIColor ows_darkGrayColor];
     [_nameContainerView addSubview:self.subtitle];
 


### PR DESCRIPTION
I was too aggressive with applying dynamic text in some cases.  Fixing these issues is out of scope for this sprint, so reverting.

PTAL @michaelkirk 