### PR TITLE
fix message details media

### DIFF
--- a/Signal/src/Signal-Bridging-Header.h
+++ b/Signal/src/Signal-Bridging-Header.h
@@ -52,6 +52,7 @@
 #import <SignalMessaging/ContactTableViewCell.h>
 #import <SignalMessaging/Environment.h>
 #import <SignalMessaging/NSString+OWS.h>
+#import <SignalMessaging/OWSAudioPlayer.h>
 #import <SignalMessaging/OWSContactAvatarBuilder.h>
 #import <SignalMessaging/OWSContactsManager.h>
 #import <SignalMessaging/OWSFormat.h>

--- a/Signal/src/ViewControllers/ConversationView/Cells/ConversationViewCell.h
+++ b/Signal/src/ViewControllers/ConversationView/Cells/ConversationViewCell.h
@@ -16,18 +16,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol ConversationViewCellDelegate <NSObject>
 
-- (void)didTapImageViewItem:(ConversationViewItem *)viewItem
-           attachmentStream:(TSAttachmentStream *)attachmentStream
-                  imageView:(UIView *)imageView;
-- (void)didTapVideoViewItem:(ConversationViewItem *)viewItem
-           attachmentStream:(TSAttachmentStream *)attachmentStream
-                  imageView:(UIView *)imageView;
-- (void)didTapAudioViewItem:(ConversationViewItem *)viewItem attachmentStream:(TSAttachmentStream *)attachmentStream;
-- (void)didTapTruncatedTextMessage:(ConversationViewItem *)conversationItem;
-- (void)didTapFailedIncomingAttachment:(ConversationViewItem *)viewItem
-                     attachmentPointer:(TSAttachmentPointer *)attachmentPointer;
-- (void)didTapFailedOutgoingMessage:(TSOutgoingMessage *)message;
-- (void)didTapQuotedMessage:(ConversationViewItem *)viewItem quotedMessage:(TSQuotedMessage *)quotedMessage;
 - (void)didPanWithGestureRecognizer:(UIPanGestureRecognizer *)gestureRecognizer
                            viewItem:(ConversationViewItem *)conversationItem;
 

--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageBubbleView.h
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageBubbleView.h
@@ -5,6 +5,10 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class ConversationViewItem;
+@class TSAttachmentPointer;
+@class TSAttachmentStream;
+@class TSOutgoingMessage;
+@class TSQuotedMessage;
 
 typedef NS_ENUM(NSUInteger, OWSMessageGestureLocation) {
     // Message text, etc.
@@ -13,6 +17,29 @@ typedef NS_ENUM(NSUInteger, OWSMessageGestureLocation) {
     OWSMessageGestureLocation_Media,
     OWSMessageGestureLocation_QuotedReply,
 };
+
+@protocol OWSMessageBubbleViewDelegate
+
+- (void)didTapImageViewItem:(ConversationViewItem *)viewItem
+           attachmentStream:(TSAttachmentStream *)attachmentStream
+                  imageView:(UIView *)imageView;
+
+- (void)didTapVideoViewItem:(ConversationViewItem *)viewItem
+           attachmentStream:(TSAttachmentStream *)attachmentStream
+                  imageView:(UIView *)imageView;
+
+- (void)didTapAudioViewItem:(ConversationViewItem *)viewItem attachmentStream:(TSAttachmentStream *)attachmentStream;
+
+- (void)didTapTruncatedTextMessage:(ConversationViewItem *)conversationItem;
+
+- (void)didTapFailedIncomingAttachment:(ConversationViewItem *)viewItem
+                     attachmentPointer:(TSAttachmentPointer *)attachmentPointer;
+
+- (void)didTapFailedOutgoingMessage:(TSOutgoingMessage *)message;
+
+- (void)didTapQuotedMessage:(ConversationViewItem *)viewItem quotedMessage:(TSQuotedMessage *)quotedMessage;
+
+@end
 
 @interface OWSMessageBubbleView : UIView
 
@@ -25,6 +52,8 @@ typedef NS_ENUM(NSUInteger, OWSMessageGestureLocation) {
 @property (nonatomic, nullable, readonly) UIView *bodyMediaView;
 
 @property (nonatomic) BOOL alwaysShowBubbleTail;
+
+@property (nonatomic, weak) id<OWSMessageBubbleViewDelegate> delegate;
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageBubbleView.m
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageBubbleView.m
@@ -59,12 +59,16 @@ NS_ASSUME_NONNULL_BEGIN
     _viewConstraints = [NSMutableArray new];
 
     self.layoutMargins = UIEdgeInsetsZero;
-    self.userInteractionEnabled = NO;
+    self.userInteractionEnabled = YES;
 
     self.bubbleView = [OWSBubbleView new];
     self.bubbleView.layoutMargins = UIEdgeInsetsZero;
     [self addSubview:self.bubbleView];
     [self.bubbleView autoPinEdgesToSuperviewEdges];
+
+    UITapGestureRecognizer *tap =
+        [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTapGesture:)];
+    [self addGestureRecognizer:tap];
 
     self.bodyTextView = [self newTextView];
     // Setting dataDetectorTypes is expensive.  Do it just once.
@@ -148,6 +152,13 @@ NS_ASSUME_NONNULL_BEGIN
     OWSAssert(self.viewItem.attachmentPointer);
 
     return self.viewItem.attachmentPointer;
+}
+
+- (TSMessage *)message
+{
+    OWSAssert([self.viewItem.interaction isKindOfClass:[TSMessage class]]);
+
+    return (TSMessage *)self.viewItem.interaction;
 }
 
 - (CGSize)mediaSize
@@ -1017,6 +1028,8 @@ NS_ASSUME_NONNULL_BEGIN
     [NSLayoutConstraint deactivateConstraints:self.viewConstraints];
     self.viewConstraints = [NSMutableArray new];
 
+    self.delegate = nil;
+
     [self.bodyTextView removeFromSuperview];
     self.bodyTextView.text = nil;
     self.bodyTextView.hidden = YES;
@@ -1042,6 +1055,142 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 #pragma mark - Gestures
+
+- (void)handleTapGesture:(UITapGestureRecognizer *)sender
+{
+    OWSAssert(self.delegate);
+
+    if (sender.state != UIGestureRecognizerStateRecognized) {
+        DDLogVerbose(@"%@ Ignoring tap on message: %@", self.logTag, self.viewItem.interaction.debugDescription);
+        return;
+    }
+
+    if (self.viewItem.interaction.interactionType == OWSInteractionType_OutgoingMessage) {
+        TSOutgoingMessage *outgoingMessage = (TSOutgoingMessage *)self.viewItem.interaction;
+        if (outgoingMessage.messageState == TSOutgoingMessageStateUnsent) {
+            [self.delegate didTapFailedOutgoingMessage:outgoingMessage];
+            return;
+        } else if (outgoingMessage.messageState == TSOutgoingMessageStateAttemptingOut) {
+            // Ignore taps on outgoing messages being sent.
+            return;
+        }
+    }
+
+    CGPoint locationInMessageBubble = [sender locationInView:self];
+    switch ([self gestureLocationForLocation:locationInMessageBubble]) {
+        case OWSMessageGestureLocation_Default:
+            // Do nothing.
+            return;
+        case OWSMessageGestureLocation_OversizeText:
+            [self.delegate didTapTruncatedTextMessage:self.viewItem];
+            return;
+        case OWSMessageGestureLocation_Media:
+            [self handleMediaTapGesture];
+            break;
+        case OWSMessageGestureLocation_QuotedReply:
+            if (self.message.quotedMessage) {
+                [self.delegate didTapQuotedMessage:self.viewItem quotedMessage:self.message.quotedMessage];
+            } else {
+                OWSFail(@"%@ Missing quoted message.", self.logTag)
+            }
+            break;
+    }
+}
+//
+//- (void)handleLongPressGesture:(UILongPressGestureRecognizer *)sender
+//{
+//    OWSAssert(self.delegate);
+//
+//    if (sender.state != UIGestureRecognizerStateBegan) {
+//        return;
+//    }
+//
+//    if (self.viewItem.interaction.interactionType == OWSInteractionType_OutgoingMessage) {
+//        TSOutgoingMessage *outgoingMessage = (TSOutgoingMessage *)self.viewItem.interaction;
+//        if (outgoingMessage.messageState == TSOutgoingMessageStateUnsent) {
+//            // Ignore long press on unsent messages.
+//            return;
+//        } else if (outgoingMessage.messageState == TSOutgoingMessageStateAttemptingOut) {
+//            // Ignore long press on outgoing messages being sent.
+//            return;
+//        }
+//    }
+//
+//    CGPoint locationInMessageBubble = [sender locationInView:self];
+//    switch ([self gestureLocationForLocation:locationInMessageBubble]) {
+//        case OWSMessageGestureLocation_Default:
+//        case OWSMessageGestureLocation_OversizeText: {
+//            CGPoint location = [sender locationInView:self];
+//            [self showTextMenuController:location];
+//            break;
+//        }
+//        case OWSMessageGestureLocation_Media: {
+//            CGPoint location = [sender locationInView:self];
+//            [self showMediaMenuController:location];
+//            break;
+//        }
+//        case OWSMessageGestureLocation_QuotedReply:
+//            // TODO:
+//            break;
+//    }
+//}
+
+- (void)handleMediaTapGesture
+{
+    OWSAssert(self.delegate);
+
+    TSAttachmentStream *_Nullable attachmentStream = self.viewItem.attachmentStream;
+
+    switch (self.cellType) {
+        case OWSMessageCellType_Unknown:
+        case OWSMessageCellType_TextMessage:
+        case OWSMessageCellType_OversizeTextMessage:
+            break;
+        case OWSMessageCellType_StillImage:
+            OWSAssert(self.bodyMediaView);
+            OWSAssert(attachmentStream);
+
+            [self.delegate didTapImageViewItem:self.viewItem
+                              attachmentStream:attachmentStream
+                                     imageView:self.bodyMediaView];
+            break;
+        case OWSMessageCellType_AnimatedImage:
+            OWSAssert(self.bodyMediaView);
+            OWSAssert(attachmentStream);
+
+            [self.delegate didTapImageViewItem:self.viewItem
+                              attachmentStream:attachmentStream
+                                     imageView:self.bodyMediaView];
+            break;
+        case OWSMessageCellType_Audio:
+            OWSAssert(attachmentStream);
+
+            [self.delegate didTapAudioViewItem:self.viewItem attachmentStream:attachmentStream];
+            return;
+        case OWSMessageCellType_Video:
+            OWSAssert(self.bodyMediaView);
+            OWSAssert(attachmentStream);
+
+            [self.delegate didTapVideoViewItem:self.viewItem
+                              attachmentStream:attachmentStream
+                                     imageView:self.bodyMediaView];
+            return;
+        case OWSMessageCellType_GenericAttachment:
+            OWSAssert(attachmentStream);
+
+            [AttachmentSharing showShareUIForAttachment:attachmentStream];
+            break;
+        case OWSMessageCellType_DownloadingAttachment: {
+            TSAttachmentPointer *_Nullable attachmentPointer = self.viewItem.attachmentPointer;
+            OWSAssert(attachmentPointer);
+
+            if (attachmentPointer.state == TSAttachmentPointerStateFailed) {
+                [self.delegate didTapFailedIncomingAttachment:self.viewItem attachmentPointer:attachmentPointer];
+            }
+            break;
+        }
+    }
+}
 
 - (OWSMessageGestureLocation)gestureLocationForLocation:(CGPoint)locationInMessageBubble
 {

--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageBubbleView.m
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageBubbleView.m
@@ -1096,44 +1096,6 @@ NS_ASSUME_NONNULL_BEGIN
             break;
     }
 }
-//
-//- (void)handleLongPressGesture:(UILongPressGestureRecognizer *)sender
-//{
-//    OWSAssert(self.delegate);
-//
-//    if (sender.state != UIGestureRecognizerStateBegan) {
-//        return;
-//    }
-//
-//    if (self.viewItem.interaction.interactionType == OWSInteractionType_OutgoingMessage) {
-//        TSOutgoingMessage *outgoingMessage = (TSOutgoingMessage *)self.viewItem.interaction;
-//        if (outgoingMessage.messageState == TSOutgoingMessageStateUnsent) {
-//            // Ignore long press on unsent messages.
-//            return;
-//        } else if (outgoingMessage.messageState == TSOutgoingMessageStateAttemptingOut) {
-//            // Ignore long press on outgoing messages being sent.
-//            return;
-//        }
-//    }
-//
-//    CGPoint locationInMessageBubble = [sender locationInView:self];
-//    switch ([self gestureLocationForLocation:locationInMessageBubble]) {
-//        case OWSMessageGestureLocation_Default:
-//        case OWSMessageGestureLocation_OversizeText: {
-//            CGPoint location = [sender locationInView:self];
-//            [self showTextMenuController:location];
-//            break;
-//        }
-//        case OWSMessageGestureLocation_Media: {
-//            CGPoint location = [sender locationInView:self];
-//            [self showMediaMenuController:location];
-//            break;
-//        }
-//        case OWSMessageGestureLocation_QuotedReply:
-//            // TODO:
-//            break;
-//    }
-//}
 
 - (void)handleMediaTapGesture
 {

--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageCell.h
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageCell.h
@@ -4,9 +4,13 @@
 
 #import "ConversationViewCell.h"
 
+@class OWSMessageBubbleView;
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface OWSMessageCell : ConversationViewCell
+
+@property (nonatomic, readonly) OWSMessageBubbleView *messageBubbleView;
 
 + (NSString *)cellReuseIdentifier;
 

--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageCell.m
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageCell.m
@@ -83,10 +83,6 @@ NS_ASSUME_NONNULL_BEGIN
 
     self.contentView.userInteractionEnabled = YES;
 
-    //    UITapGestureRecognizer *tap =
-    //        [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTapGesture:)];
-    //    [self.contentView addGestureRecognizer:tap];
-
     UILongPressGestureRecognizer *longPress =
         [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleLongPressGesture:)];
     [self.contentView addGestureRecognizer:longPress];
@@ -483,47 +479,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Gesture recognizers
 
-//- (void)handleTapGesture:(UITapGestureRecognizer *)sender
-//{
-//    OWSAssert(self.delegate);
-//
-//    if (sender.state != UIGestureRecognizerStateRecognized) {
-//        DDLogVerbose(@"%@ Ignoring tap on message: %@", self.logTag, self.viewItem.interaction.debugDescription);
-//        return;
-//    }
-//
-//    if (self.viewItem.interaction.interactionType == OWSInteractionType_OutgoingMessage) {
-//        TSOutgoingMessage *outgoingMessage = (TSOutgoingMessage *)self.viewItem.interaction;
-//        if (outgoingMessage.messageState == TSOutgoingMessageStateUnsent) {
-//            [self.delegate didTapFailedOutgoingMessage:outgoingMessage];
-//            return;
-//        } else if (outgoingMessage.messageState == TSOutgoingMessageStateAttemptingOut) {
-//            // Ignore taps on outgoing messages being sent.
-//            return;
-//        }
-//    }
-//
-//    CGPoint locationInMessageBubble = [sender locationInView:self.messageBubbleView];
-//    switch ([self.messageBubbleView gestureLocationForLocation:locationInMessageBubble]) {
-//        case OWSMessageGestureLocation_Default:
-//            // Do nothing.
-//            return;
-//        case OWSMessageGestureLocation_OversizeText:
-//            [self.delegate didTapTruncatedTextMessage:self.viewItem];
-//            return;
-//        case OWSMessageGestureLocation_Media:
-//            [self handleMediaTapGesture];
-//            break;
-//        case OWSMessageGestureLocation_QuotedReply:
-//            if (self.message.quotedMessage) {
-//                [self.delegate didTapQuotedMessage:self.viewItem quotedMessage:self.message.quotedMessage];
-//            } else {
-//                OWSFail(@"%@ Missing quoted message.", self.logTag)
-//            }
-//            break;
-//    }
-//}
-//
 - (void)handleLongPressGesture:(UILongPressGestureRecognizer *)sender
 {
     OWSAssert(self.delegate);

--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageCell.m
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageCell.m
@@ -83,9 +83,9 @@ NS_ASSUME_NONNULL_BEGIN
 
     self.contentView.userInteractionEnabled = YES;
 
-    UITapGestureRecognizer *tap =
-        [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTapGesture:)];
-    [self.contentView addGestureRecognizer:tap];
+    //    UITapGestureRecognizer *tap =
+    //        [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTapGesture:)];
+    //    [self.contentView addGestureRecognizer:tap];
 
     UILongPressGestureRecognizer *longPress =
         [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleLongPressGesture:)];
@@ -483,104 +483,47 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Gesture recognizers
 
-- (void)handleTapGesture:(UITapGestureRecognizer *)sender
-{
-    OWSAssert(self.delegate);
-
-    if (sender.state != UIGestureRecognizerStateRecognized) {
-        DDLogVerbose(@"%@ Ignoring tap on message: %@", self.logTag, self.viewItem.interaction.debugDescription);
-        return;
-    }
-
-    if (self.viewItem.interaction.interactionType == OWSInteractionType_OutgoingMessage) {
-        TSOutgoingMessage *outgoingMessage = (TSOutgoingMessage *)self.viewItem.interaction;
-        if (outgoingMessage.messageState == TSOutgoingMessageStateUnsent) {
-            [self.delegate didTapFailedOutgoingMessage:outgoingMessage];
-            return;
-        } else if (outgoingMessage.messageState == TSOutgoingMessageStateAttemptingOut) {
-            // Ignore taps on outgoing messages being sent.
-            return;
-        }
-    }
-
-    CGPoint locationInMessageBubble = [sender locationInView:self.messageBubbleView];
-    switch ([self.messageBubbleView gestureLocationForLocation:locationInMessageBubble]) {
-        case OWSMessageGestureLocation_Default:
-            // Do nothing.
-            return;
-        case OWSMessageGestureLocation_OversizeText:
-            [self.delegate didTapTruncatedTextMessage:self.viewItem];
-            return;
-        case OWSMessageGestureLocation_Media:
-            [self handleMediaTapGesture];
-            break;
-        case OWSMessageGestureLocation_QuotedReply:
-            if (self.message.quotedMessage) {
-                [self.delegate didTapQuotedMessage:self.viewItem quotedMessage:self.message.quotedMessage];
-            } else {
-                OWSFail(@"%@ Missing quoted message.", self.logTag)
-            }
-            break;
-    }
-}
-
-- (void)handleMediaTapGesture
-{
-    OWSAssert(self.delegate);
-
-    TSAttachmentStream *_Nullable attachmentStream = self.viewItem.attachmentStream;
-
-    switch (self.cellType) {
-        case OWSMessageCellType_Unknown:
-        case OWSMessageCellType_TextMessage:
-        case OWSMessageCellType_OversizeTextMessage:
-            break;
-        case OWSMessageCellType_StillImage:
-            OWSAssert(self.messageBubbleView.bodyMediaView);
-            OWSAssert(attachmentStream);
-
-            [self.delegate didTapImageViewItem:self.viewItem
-                              attachmentStream:attachmentStream
-                                     imageView:self.messageBubbleView.bodyMediaView];
-            break;
-        case OWSMessageCellType_AnimatedImage:
-            OWSAssert(self.messageBubbleView.bodyMediaView);
-            OWSAssert(attachmentStream);
-
-            [self.delegate didTapImageViewItem:self.viewItem
-                              attachmentStream:attachmentStream
-                                     imageView:self.messageBubbleView.bodyMediaView];
-            break;
-        case OWSMessageCellType_Audio:
-            OWSAssert(attachmentStream);
-
-            [self.delegate didTapAudioViewItem:self.viewItem attachmentStream:attachmentStream];
-            return;
-        case OWSMessageCellType_Video:
-            OWSAssert(self.messageBubbleView.bodyMediaView);
-            OWSAssert(attachmentStream);
-
-            [self.delegate didTapVideoViewItem:self.viewItem
-                              attachmentStream:attachmentStream
-                                     imageView:self.messageBubbleView.bodyMediaView];
-            return;
-        case OWSMessageCellType_GenericAttachment:
-            OWSAssert(attachmentStream);
-
-            [AttachmentSharing showShareUIForAttachment:attachmentStream];
-            break;
-        case OWSMessageCellType_DownloadingAttachment: {
-            TSAttachmentPointer *_Nullable attachmentPointer = self.viewItem.attachmentPointer;
-            OWSAssert(attachmentPointer);
-
-            if (attachmentPointer.state == TSAttachmentPointerStateFailed) {
-                [self.delegate didTapFailedIncomingAttachment:self.viewItem attachmentPointer:attachmentPointer];
-            }
-            break;
-        }
-    }
-}
-
+//- (void)handleTapGesture:(UITapGestureRecognizer *)sender
+//{
+//    OWSAssert(self.delegate);
+//
+//    if (sender.state != UIGestureRecognizerStateRecognized) {
+//        DDLogVerbose(@"%@ Ignoring tap on message: %@", self.logTag, self.viewItem.interaction.debugDescription);
+//        return;
+//    }
+//
+//    if (self.viewItem.interaction.interactionType == OWSInteractionType_OutgoingMessage) {
+//        TSOutgoingMessage *outgoingMessage = (TSOutgoingMessage *)self.viewItem.interaction;
+//        if (outgoingMessage.messageState == TSOutgoingMessageStateUnsent) {
+//            [self.delegate didTapFailedOutgoingMessage:outgoingMessage];
+//            return;
+//        } else if (outgoingMessage.messageState == TSOutgoingMessageStateAttemptingOut) {
+//            // Ignore taps on outgoing messages being sent.
+//            return;
+//        }
+//    }
+//
+//    CGPoint locationInMessageBubble = [sender locationInView:self.messageBubbleView];
+//    switch ([self.messageBubbleView gestureLocationForLocation:locationInMessageBubble]) {
+//        case OWSMessageGestureLocation_Default:
+//            // Do nothing.
+//            return;
+//        case OWSMessageGestureLocation_OversizeText:
+//            [self.delegate didTapTruncatedTextMessage:self.viewItem];
+//            return;
+//        case OWSMessageGestureLocation_Media:
+//            [self handleMediaTapGesture];
+//            break;
+//        case OWSMessageGestureLocation_QuotedReply:
+//            if (self.message.quotedMessage) {
+//                [self.delegate didTapQuotedMessage:self.viewItem quotedMessage:self.message.quotedMessage];
+//            } else {
+//                OWSFail(@"%@ Missing quoted message.", self.logTag)
+//            }
+//            break;
+//    }
+//}
+//
 - (void)handleLongPressGesture:(UILongPressGestureRecognizer *)sender
 {
     OWSAssert(self.delegate);

--- a/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
@@ -128,6 +128,7 @@ typedef enum : NSUInteger {
     ConversationViewLayoutDelegate,
     ConversationViewCellDelegate,
     ConversationInputTextViewDelegate,
+    OWSMessageBubbleViewDelegate,
     UICollectionViewDelegate,
     UICollectionViewDataSource,
     UIDocumentMenuDelegate,
@@ -2020,7 +2021,7 @@ typedef enum : NSUInteger {
                                                                   success:successHandler];
 }
 
-#pragma mark - Message Events
+#pragma mark - OWSMessageBubbleViewDelegate
 
 - (void)didTapImageViewItem:(ConversationViewItem *)viewItem
            attachmentStream:(TSAttachmentStream *)attachmentStream
@@ -4718,6 +4719,10 @@ typedef enum : NSUInteger {
     }
     cell.viewItem = viewItem;
     cell.delegate = self;
+    if ([cell isKindOfClass:[OWSMessageCell class]]) {
+        OWSMessageCell *messageCell = (OWSMessageCell *)cell;
+        messageCell.messageBubbleView.delegate = self;
+    }
     cell.contentWidth = self.layout.contentWidth;
 
     [cell loadForDisplay];

--- a/Signal/src/ViewControllers/ConversationView/ConversationViewItem.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewItem.m
@@ -560,9 +560,6 @@ NSString *NSStringForOWSMessageCellType(OWSMessageCellType cellType)
         [[UIMenuItem alloc] initWithTitle:NSLocalizedString(@"REPLY_ITEM_ACTION",
                                               @"Short name for edit menu item to reply to a message.")
                                    action:self.replyActionSelector],
-        // FIXME: when deleting a caption, users will be surprised that it also deletes the attachment.
-        // We either need to implement a way to remove the caption separate from the attachment
-        // or make a design change which clarifies that the whole message is getting deleted.
         [[UIMenuItem alloc] initWithTitle:NSLocalizedString(@"EDIT_ITEM_DELETE_ACTION",
                                               @"Short name for edit menu item to delete contents of media message.")
                                    action:self.deleteActionSelector]

--- a/Signal/src/ViewControllers/MessageDetailViewController.swift
+++ b/Signal/src/ViewControllers/MessageDetailViewController.swift
@@ -12,7 +12,6 @@ enum MessageMetadataViewMode: UInt {
     case focusOnMetadata
 }
 
-//class MessageDetailViewController: OWSViewController, MediaDetailPresenter, MediaGalleryDataSourceDelegate {
 class MessageDetailViewController: OWSViewController, MediaGalleryDataSourceDelegate, OWSMessageBubbleViewDelegate {
 
     // MARK: Properties
@@ -330,7 +329,6 @@ class MessageDetailViewController: OWSViewController, MediaGalleryDataSourceDele
         messageBubbleView.loadContent()
 
         assert(messageBubbleView.isUserInteractionEnabled)
-//        messageBubbleView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(messageBubbleTapped)))
 
         let row = UIView()
         row.addSubview(messageBubbleView)
@@ -587,42 +585,6 @@ class MessageDetailViewController: OWSViewController, MediaGalleryDataSourceDele
         messageBubbleViewHeightLayoutConstraint.constant = messageBubbleSize.height
     }
 
-//    // MARK: - Event Handlers
-//
-//    func messageBubbleTapped(sender: UIGestureRecognizer) {
-//        guard let messageBubbleView = messageBubbleView else {
-//            return
-//        }
-//        guard sender.state == .recognized else {
-//            return
-//        }
-//        if let outgoingMessage = viewItem.interaction as? TSOutgoingMessage {
-//            switch outgoingMessage.messageState {
-//            case .attemptingOut,
-//                 .unsent:
-//                // Ignore taps on "unsent" and "sending" messages.
-//                return
-//            default:
-//                break
-//            }
-//        }
-//
-//    let locationInMessageBubble = sender.location(in: messageBubbleView)
-//        switch messageBubbleView.gestureLocation(forLocation: locationInMessageBubble) {
-//        case .default:
-//            break
-//        case .oversizeText:
-//            let viewController = LongTextViewController(viewItem: viewItem)
-//            self.navigationController?.pushViewController(viewController, animated: true)
-//            break
-//        case .media:
-//            // TODO: We could show MediaGalleryViewController?
-//            break
-//        case .quotedReply:
-//            break
-//        }
-//    }
-
     // MARK: OWSMessageBubbleViewDelegate
 
     func didTapImageViewItem(_ viewItem: ConversationViewItem, attachmentStream: TSAttachmentStream, imageView: UIView) {
@@ -714,17 +676,4 @@ class MessageDetailViewController: OWSViewController, MediaGalleryDataSourceDele
             self.navigationController?.popViewController(animated: true)
         }
     }
-
-//    // MARK: MediaDetailPresenter
-//
-//    public func presentDetails(mediaMessageView: MediaMessageView, fromView: UIView) {
-//        guard self.attachmentStream != nil else {
-//            owsFail("attachment stream unexpectedly nil")
-//            return
-//        }
-//
-//        let mediaGalleryViewController = MediaGalleryViewController(thread: self.thread, uiDatabaseConnection: self.uiDatabaseConnection)
-//        mediaGalleryViewController.addDataSourceDelegate(self)
-//        mediaGalleryViewController.presentDetailView(fromViewController: self, mediaMessage: self.message, replacingView: fromView)
-//    }
 }

--- a/SignalMessaging/SignalMessaging.h
+++ b/SignalMessaging/SignalMessaging.h
@@ -30,6 +30,7 @@ FOUNDATION_EXPORT const unsigned char SignalMessagingVersionString[];
 #import <SignalMessaging/OWSLogger.h>
 #import <SignalMessaging/OWSMath.h>
 #import <SignalMessaging/OWSProfileManager.h>
+#import <SignalMessaging/OWSQuotedReplyModel.h>
 #import <SignalMessaging/OWSSounds.h>
 #import <SignalMessaging/OWSTableViewController.h>
 #import <SignalMessaging/OWSUserProfile.h>

--- a/SignalMessaging/attachments/MediaMessageView.swift
+++ b/SignalMessaging/attachments/MediaMessageView.swift
@@ -14,11 +14,6 @@ public enum MediaMessageViewMode: UInt {
     case attachmentApproval
 }
 
-//@objc
-//public protocol MediaDetailPresenter: class {
-//    func presentDetails(mediaMessageView: MediaMessageView, fromView: UIView)
-//}
-
 @objc
 public class MediaMessageView: UIView, OWSAudioPlayerDelegate {
 
@@ -59,8 +54,6 @@ public class MediaMessageView: UIView, OWSAudioPlayerDelegate {
     @objc
     public var contentView: UIView?
 
-//    private weak var mediaDetailPresenter: MediaDetailPresenter?
-
     // MARK: Initializers
 
     @available(*, unavailable, message:"use other constructor instead.")
@@ -68,18 +61,13 @@ public class MediaMessageView: UIView, OWSAudioPlayerDelegate {
         fatalError("\(#function) is unimplemented.")
     }
 
-//    @objc
-//    public convenience init(attachment: SignalAttachment, mode: MediaMessageViewMode) {
-//        self.init(attachment: attachment, mode: mode, mediaDetailPresenter: nil)
-//    }
-
-    // TODO there's only one mode now, used by the AttachmentApprovalView
+    // Currently we only use one mode (AttachmentApproval), so we could simplify this class, but it's kind
+    // of nice that it's written in a flexible way in case we'd want to use it elsewhere again in the future.
     @objc
-    public required init(attachment: SignalAttachment, mode: MediaMessageViewMode) { //}, mediaDetailPresenter: MediaDetailPresenter?) {
+    public required init(attachment: SignalAttachment, mode: MediaMessageViewMode) {
         assert(!attachment.hasError)
         self.attachment = attachment
         self.mode = mode
-//        self.mediaDetailPresenter = mediaDetailPresenter
         super.init(frame: CGRect.zero)
 
         createViews()
@@ -205,9 +193,6 @@ public class MediaMessageView: UIView, OWSAudioPlayerDelegate {
         let aspectRatio = image.size.width / image.size.height
         addSubviewWithScaleAspectFitLayout(view: animatedImageView, aspectRatio: aspectRatio)
         contentView = animatedImageView
-//
-//        animatedImageView.isUserInteractionEnabled = true
-//        animatedImageView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(imageTapped)))
     }
 
     private func addSubviewWithScaleAspectFitLayout(view: UIView, aspectRatio: CGFloat) {
@@ -239,9 +224,6 @@ public class MediaMessageView: UIView, OWSAudioPlayerDelegate {
         let aspectRatio = image.size.width / image.size.height
         addSubviewWithScaleAspectFitLayout(view: imageView, aspectRatio: aspectRatio)
         contentView = imageView
-//
-//        imageView.isUserInteractionEnabled = true
-//        imageView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(imageTapped)))
     }
 
     private func createVideoPreview() {
@@ -270,9 +252,6 @@ public class MediaMessageView: UIView, OWSAudioPlayerDelegate {
             videoPlayButton.contentMode = .scaleAspectFit
             self.addSubview(videoPlayButton)
             videoPlayButton.autoCenterInSuperview()
-
-//            imageView.isUserInteractionEnabled = true
-//            imageView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(videoTapped)))
         }
     }
 
@@ -447,43 +426,4 @@ public class MediaMessageView: UIView, OWSAudioPlayerDelegate {
         audioPlayButton?.setImage(image, for: .normal)
         audioPlayButton?.imageView?.tintColor = controlTintColor
     }
-//
-//    // MARK: - Full Screen Image
-//
-//    @objc
-//    func imageTapped(sender: UIGestureRecognizer) {
-//        // Approval view handles it's own zooming gesture
-//        guard mode != .attachmentApproval else {
-//            return
-//        }
-//        guard sender.state == .recognized else {
-//            return
-//        }
-//        guard let fromView = sender.view else {
-//            return
-//        }
-//
-//        showMediaDetailViewController(fromView: fromView)
-//    }
-//
-//    // MARK: - Video Playback
-//
-//    @objc
-//    func videoTapped(sender: UIGestureRecognizer) {
-//        // Approval view handles it's own play gesture
-//        guard mode != .attachmentApproval else {
-//            return
-//        }
-//        guard sender.state == .recognized else {
-//            return
-//        }
-//        guard let fromView = sender.view else {
-//            return
-//        }
-//
-//        showMediaDetailViewController(fromView: fromView)
-//    }
-//    func showMediaDetailViewController(fromView: UIView) {
-//        self.mediaDetailPresenter?.presentDetails(mediaMessageView: self, fromView: fromView)
-//    }
 }

--- a/SignalMessaging/attachments/MediaMessageView.swift
+++ b/SignalMessaging/attachments/MediaMessageView.swift
@@ -14,10 +14,10 @@ public enum MediaMessageViewMode: UInt {
     case attachmentApproval
 }
 
-@objc
-public protocol MediaDetailPresenter: class {
-    func presentDetails(mediaMessageView: MediaMessageView, fromView: UIView)
-}
+//@objc
+//public protocol MediaDetailPresenter: class {
+//    func presentDetails(mediaMessageView: MediaMessageView, fromView: UIView)
+//}
 
 @objc
 public class MediaMessageView: UIView, OWSAudioPlayerDelegate {
@@ -59,7 +59,7 @@ public class MediaMessageView: UIView, OWSAudioPlayerDelegate {
     @objc
     public var contentView: UIView?
 
-    private weak var mediaDetailPresenter: MediaDetailPresenter?
+//    private weak var mediaDetailPresenter: MediaDetailPresenter?
 
     // MARK: Initializers
 
@@ -68,16 +68,18 @@ public class MediaMessageView: UIView, OWSAudioPlayerDelegate {
         fatalError("\(#function) is unimplemented.")
     }
 
-    @objc
-    public convenience init(attachment: SignalAttachment, mode: MediaMessageViewMode) {
-        self.init(attachment: attachment, mode: mode, mediaDetailPresenter: nil)
-    }
+//    @objc
+//    public convenience init(attachment: SignalAttachment, mode: MediaMessageViewMode) {
+//        self.init(attachment: attachment, mode: mode, mediaDetailPresenter: nil)
+//    }
 
-    public required init(attachment: SignalAttachment, mode: MediaMessageViewMode, mediaDetailPresenter: MediaDetailPresenter?) {
+    // TODO there's only one mode now, used by the AttachmentApprovalView
+    @objc
+    public required init(attachment: SignalAttachment, mode: MediaMessageViewMode) { //}, mediaDetailPresenter: MediaDetailPresenter?) {
         assert(!attachment.hasError)
         self.attachment = attachment
         self.mode = mode
-        self.mediaDetailPresenter = mediaDetailPresenter
+//        self.mediaDetailPresenter = mediaDetailPresenter
         super.init(frame: CGRect.zero)
 
         createViews()
@@ -203,9 +205,9 @@ public class MediaMessageView: UIView, OWSAudioPlayerDelegate {
         let aspectRatio = image.size.width / image.size.height
         addSubviewWithScaleAspectFitLayout(view: animatedImageView, aspectRatio: aspectRatio)
         contentView = animatedImageView
-
-        animatedImageView.isUserInteractionEnabled = true
-        animatedImageView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(imageTapped)))
+//
+//        animatedImageView.isUserInteractionEnabled = true
+//        animatedImageView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(imageTapped)))
     }
 
     private func addSubviewWithScaleAspectFitLayout(view: UIView, aspectRatio: CGFloat) {
@@ -237,9 +239,9 @@ public class MediaMessageView: UIView, OWSAudioPlayerDelegate {
         let aspectRatio = image.size.width / image.size.height
         addSubviewWithScaleAspectFitLayout(view: imageView, aspectRatio: aspectRatio)
         contentView = imageView
-
-        imageView.isUserInteractionEnabled = true
-        imageView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(imageTapped)))
+//
+//        imageView.isUserInteractionEnabled = true
+//        imageView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(imageTapped)))
     }
 
     private func createVideoPreview() {
@@ -269,8 +271,8 @@ public class MediaMessageView: UIView, OWSAudioPlayerDelegate {
             self.addSubview(videoPlayButton)
             videoPlayButton.autoCenterInSuperview()
 
-            imageView.isUserInteractionEnabled = true
-            imageView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(videoTapped)))
+//            imageView.isUserInteractionEnabled = true
+//            imageView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(videoTapped)))
         }
     }
 
@@ -445,44 +447,43 @@ public class MediaMessageView: UIView, OWSAudioPlayerDelegate {
         audioPlayButton?.setImage(image, for: .normal)
         audioPlayButton?.imageView?.tintColor = controlTintColor
     }
-
-    // MARK: - Full Screen Image
-
-    @objc
-    func imageTapped(sender: UIGestureRecognizer) {
-        // Approval view handles it's own zooming gesture
-        guard mode != .attachmentApproval else {
-            return
-        }
-        guard sender.state == .recognized else {
-            return
-        }
-        guard let fromView = sender.view else {
-            return
-        }
-
-        showMediaDetailViewController(fromView: fromView)
-    }
-
-    // MARK: - Video Playback
-
-    @objc
-    func videoTapped(sender: UIGestureRecognizer) {
-        // Approval view handles it's own play gesture
-        guard mode != .attachmentApproval else {
-            return
-        }
-        guard sender.state == .recognized else {
-            return
-        }
-        guard let fromView = sender.view else {
-            return
-        }
-
-        showMediaDetailViewController(fromView: fromView)
-    }
-
-    func showMediaDetailViewController(fromView: UIView) {
-        self.mediaDetailPresenter?.presentDetails(mediaMessageView: self, fromView: fromView)
-    }
+//
+//    // MARK: - Full Screen Image
+//
+//    @objc
+//    func imageTapped(sender: UIGestureRecognizer) {
+//        // Approval view handles it's own zooming gesture
+//        guard mode != .attachmentApproval else {
+//            return
+//        }
+//        guard sender.state == .recognized else {
+//            return
+//        }
+//        guard let fromView = sender.view else {
+//            return
+//        }
+//
+//        showMediaDetailViewController(fromView: fromView)
+//    }
+//
+//    // MARK: - Video Playback
+//
+//    @objc
+//    func videoTapped(sender: UIGestureRecognizer) {
+//        // Approval view handles it's own play gesture
+//        guard mode != .attachmentApproval else {
+//            return
+//        }
+//        guard sender.state == .recognized else {
+//            return
+//        }
+//        guard let fromView = sender.view else {
+//            return
+//        }
+//
+//        showMediaDetailViewController(fromView: fromView)
+//    }
+//    func showMediaDetailViewController(fromView: UIView) {
+//        self.mediaDetailPresenter?.presentDetails(mediaMessageView: self, fromView: fromView)
+//    }
 }


### PR DESCRIPTION
Fixes image, video, and audio interactions in the message detail view.

The basic problem was that these interactions were being handled on the OWSMessageCell, so I've moved them to the OWSMessageBubbleView, which allowed simplifying a few things elsewhere.

PTAL @charlesmchen 