### PR TITLE
truncate tail for both preview and message bubble

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSQuotedMessageView.m
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSQuotedMessageView.m
@@ -268,7 +268,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     UILabel *quotedTextLabel = [UILabel new];
     quotedTextLabel.numberOfLines = self.isForPreview ? 1 : 3;
-    quotedTextLabel.lineBreakMode = NSLineBreakByWordWrapping;
+    quotedTextLabel.lineBreakMode = NSLineBreakByTruncatingTail;
     quotedTextLabel.text = text;
     quotedTextLabel.textColor = textColor;
     quotedTextLabel.font = font;


### PR DESCRIPTION
PTAL @charlesmchen 

**Before**
<img width="457" alt="screen shot 2018-04-11 at 3 07 37 pm" src="https://user-images.githubusercontent.com/36971200/38637794-374a83de-3d9a-11e8-889e-baea38fdd78a.png">

**After**
<img width="457" alt="screen shot 2018-04-11 at 3 01 52 pm" src="https://user-images.githubusercontent.com/36971200/38637533-66e94518-3d99-11e8-9bce-99aae0201663.png">
