### PR TITLE
Use profile name in quoted messages, fix "multi account" label

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSQuotedMessageView.m
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSQuotedMessageView.m
@@ -320,7 +320,7 @@ NS_ASSUME_NONNULL_BEGIN
         }
     } else {
         OWSContactsManager *contactsManager = Environment.current.contactsManager;
-        NSString *quotedAuthor = [contactsManager displayNameForPhoneIdentifier:self.quotedMessage.authorId];
+        NSString *quotedAuthor = [contactsManager contactOrProfileNameForPhoneIdentifier:self.quotedMessage.authorId];
         quotedAuthorText = [NSString
             stringWithFormat:
                 NSLocalizedString(@"QUOTED_REPLY_AUTHOR_INDICATOR_FORMAT",

--- a/SignalMessaging/contacts/OWSContactsManager.m
+++ b/SignalMessaging/contacts/OWSContactsManager.m
@@ -367,12 +367,26 @@ NSString *const OWSContactsManagerSignalAccountsDidChangeNotification
     return [OWSProfileManager sharedManager];
 }
 
-- (NSString *_Nullable)cachedDisplayNameForRecipientId:(NSString *)recipientId
+- (NSString *_Nullable)cachedContactNameForRecipientId:(NSString *)recipientId
 {
     OWSAssert(recipientId.length > 0);
 
-    SignalAccount *_Nullable signalAccount = [self signalAccountForRecipientId:recipientId];
-    return signalAccount.displayName;
+    SignalAccount *signalAccount = [self signalAccountForRecipientId:recipientId];
+    if (!signalAccount) {
+        return nil;
+    }
+
+    NSString *fullName = signalAccount.contactFullName;
+    if (fullName.length == 0) {
+        return nil;
+    }
+
+    NSString *multipleAccountLabelText = signalAccount.multipleAccountLabelText;
+    if (multipleAccountLabelText.length == 0) {
+        return fullName;
+    }
+
+    return [NSString stringWithFormat:@"%@ (%@)", fullName, multipleAccountLabelText];
 }
 
 - (NSString *_Nullable)cachedFirstNameForRecipientId:(NSString *)recipientId
@@ -440,7 +454,7 @@ NSString *const OWSContactsManagerSignalAccountsDidChangeNotification
 
 - (BOOL)hasNameInSystemContactsForRecipientId:(NSString *)recipientId
 {
-    return [self cachedDisplayNameForRecipientId:recipientId] != nil;
+    return [self cachedContactNameForRecipientId:recipientId].length > 0;
 }
 
 - (NSString *)unknownContactName
@@ -469,7 +483,7 @@ NSString *const OWSContactsManagerSignalAccountsDidChangeNotification
 
 - (nullable NSString *)nameFromSystemContactsForRecipientId:(NSString *)recipientId
 {
-    return [self cachedDisplayNameForRecipientId:recipientId];
+    return [self cachedContactNameForRecipientId:recipientId];
 }
 
 - (NSString *_Nonnull)displayNameForPhoneIdentifier:(NSString *_Nullable)recipientId
@@ -577,7 +591,7 @@ NSString *const OWSContactsManagerSignalAccountsDidChangeNotification
 - (NSString *)contactOrProfileNameForPhoneIdentifier:(NSString *)recipientId
 {
     // Prefer a saved name from system contacts, if available
-    NSString *_Nullable savedContactName = [self cachedDisplayNameForRecipientId:recipientId];
+    NSString *_Nullable savedContactName = [self cachedContactNameForRecipientId:recipientId];
     if (savedContactName.length > 0) {
         return savedContactName;
     }
@@ -608,7 +622,7 @@ NSString *const OWSContactsManagerSignalAccountsDidChangeNotification
                                                                   secondaryFont:(UIFont *)secondaryFont
 {
     // Prefer a saved name from system contacts, if available
-    NSString *_Nullable savedContactName = [self cachedDisplayNameForRecipientId:recipientId];
+    NSString *_Nullable savedContactName = [self cachedContactNameForRecipientId:recipientId];
     if (savedContactName.length > 0) {
         return [[NSAttributedString alloc] initWithString:savedContactName];
     }
@@ -640,7 +654,7 @@ NSString *const OWSContactsManagerSignalAccountsDidChangeNotification
 - (NSString *)stringForConversationTitleWithPhoneIdentifier:(NSString *)recipientId
 {
     // Prefer a saved name from system contacts, if available
-    NSString *_Nullable savedContactName = [self cachedDisplayNameForRecipientId:recipientId];
+    NSString *_Nullable savedContactName = [self cachedContactNameForRecipientId:recipientId];
     if (savedContactName.length > 0) {
         return savedContactName;
     }

--- a/SignalServiceKit/src/Contacts/SignalAccount.h
+++ b/SignalServiceKit/src/Contacts/SignalAccount.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//  Copyright (c) 2018 Open Whisper Systems. All rights reserved.
 //
 
 #import "TSYapDatabaseObject.h"
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 // this is a label for the account.
 @property (nonatomic) NSString *multipleAccountLabelText;
 
-- (NSString *)displayName;
+- (nullable NSString *)contactFullName;
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/SignalServiceKit/src/Contacts/SignalAccount.m
+++ b/SignalServiceKit/src/Contacts/SignalAccount.m
@@ -50,16 +50,9 @@ NS_ASSUME_NONNULL_BEGIN
     return _recipientId;
 }
 
-- (NSString *)displayName
+- (nullable NSString *)contactFullName
 {
-    NSString *baseName = (self.contact.fullName.length > 0 ? self.contact.fullName : self.recipientId);
-
-    OWSAssert(self.hasMultipleAccountContact == (self.multipleAccountLabelText != nil));
-    NSString *displayName = (self.multipleAccountLabelText
-            ? [NSString stringWithFormat:@"%@ (%@)", baseName, self.multipleAccountLabelText]
-            : baseName);
-
-    return displayName.filterStringForDisplay;
+    return self.contact.fullName.filterStringForDisplay;
 }
 
 - (NSString *)multipleAccountLabelText


### PR DESCRIPTION
Turned out to not be *quite* a one line change =/

PTAL @charlesmchen 