### PR TITLE
Update nullability

### DIFF
--- a/SignalServiceKit/src/Network/API/TSNetworkManager.h
+++ b/SignalServiceKit/src/Network/API/TSNetworkManager.h
@@ -10,7 +10,7 @@ extern NSString *const TSNetworkManagerDomain;
 
 BOOL IsNSErrorNetworkFailure(NSError *_Nullable error);
 
-typedef void (^TSNetworkManagerSuccess)(NSURLSessionDataTask *task, id responseObject);
+typedef void (^TSNetworkManagerSuccess)(NSURLSessionDataTask *task, _Nullable id responseObject);
 typedef void (^TSNetworkManagerFailure)(NSURLSessionDataTask *task, NSError *error);
 
 @class TSRequest;

--- a/SignalServiceKit/src/Network/API/TSNetworkManager.m
+++ b/SignalServiceKit/src/Network/API/TSNetworkManager.m
@@ -71,7 +71,7 @@ typedef void (^failureBlock)(NSURLSessionDataTask *task, NSError *error);
     DDLogInfo(@"%@ Making request: %@", self.logTag, request);
 
     // TODO: Remove this logging when the call connection issues have been resolved.
-    TSNetworkManagerSuccess success = ^(NSURLSessionDataTask *task, id responseObject) {
+    TSNetworkManagerSuccess success = ^(NSURLSessionDataTask *task, _Nullable id responseObject) {
         DDLogInfo(@"%@ request succeeded : %@", self.logTag, request);
         successBlock(task, responseObject);
     };


### PR DESCRIPTION
If object is nil, which it can be, Swift freaks out, since we'd promised
it would never be nil.

PTAL @charlesmchen 
