### PR TITLE
Charlesmchen/i rate crashes

### DIFF
--- a/Libraries/iRate/iRate.m
+++ b/Libraries/iRate/iRate.m
@@ -1,10 +1,40 @@
 //
-//  Copyright (c) 2018 Open Whisper Systems. All rights reserved.
+//  iRate.m
+//
+//  Version 1.11.4
+//
+//  Created by Nick Lockwood on 26/01/2011.
+//  Copyright 2011 Charcoal Design
+//
+//  Distributed under the permissive zlib license
+//  Get the latest version from here:
+//
+//  https://github.com/nicklockwood/iRate
+//
+//  This software is provided 'as-is', without any express or implied
+//  warranty.  In no event will the authors be held liable for any damages
+//  arising from the use of this software.
+//
+//  Permission is granted to anyone to use this software for any purpose,
+//  including commercial applications, and to alter it and redistribute it
+//  freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not
+//  claim that you wrote the original software. If you use this software
+//  in a product, an acknowledgment in the product documentation would be
+//  appreciated but is not required.
+//
+//  2. Altered source versions must be plainly marked as such, and must not be
+//  misrepresented as being the original software.
+//
+//  3. This notice may not be removed or altered from any source distribution.
 //
 
-#import "iRate.h"
-#import <Availability.h>
 
+#import "iRate.h"
+
+
+#import <Availability.h>
 #if !__has_feature(objc_arc)
 #error This class requires automatic reference counting
 #endif


### PR DESCRIPTION
Synchronizing `[NSUserDefaults standardUserDefaults ]` should be safe when app is in background, but it's not.  This PR constitutes a fairly safe experiment.  Will this resolve this class of crash?  If so, we've learned something.

PTAL @michaelkirk 