### PR TITLE
unjank homescreen

### DIFF
--- a/Signal.xcodeproj/project.pbxproj
+++ b/Signal.xcodeproj/project.pbxproj
@@ -302,6 +302,7 @@
 		45360B901F9527DA00FA666C /* SearcherTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45360B8F1F9527DA00FA666C /* SearcherTest.swift */; };
 		45360B911F952AA900FA666C /* MarqueeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E5A6981F61E6DD001E4A8A /* MarqueeLabel.swift */; };
 		4539B5861F79348F007141FF /* PushRegistrationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4539B5851F79348F007141FF /* PushRegistrationManager.swift */; };
+		4542DF52208B82E9007B4E76 /* ThreadModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4542DF51208B82E9007B4E76 /* ThreadModel.swift */; };
 		45464DBC1DFA041F001D3FD6 /* DataChannelMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45464DBB1DFA041F001D3FD6 /* DataChannelMessage.swift */; };
 		454A84042059C787008B8C75 /* MediaTileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 454A84032059C787008B8C75 /* MediaTileViewController.swift */; };
 		454A965A1FD6017E008D2A0E /* SignalAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34D913491F62D4A500722898 /* SignalAttachment.swift */; };
@@ -919,6 +920,7 @@
 		45360B8F1F9527DA00FA666C /* SearcherTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearcherTest.swift; sourceTree = "<group>"; };
 		4539B5851F79348F007141FF /* PushRegistrationManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PushRegistrationManager.swift; sourceTree = "<group>"; };
 		453CC0361D08E1A60040EBA3 /* sn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sn; path = translations/sn.lproj/Localizable.strings; sourceTree = "<group>"; };
+		4542DF51208B82E9007B4E76 /* ThreadModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadModel.swift; sourceTree = "<group>"; };
 		45464DBB1DFA041F001D3FD6 /* DataChannelMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataChannelMessage.swift; sourceTree = "<group>"; };
 		454A84032059C787008B8C75 /* MediaTileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaTileViewController.swift; sourceTree = "<group>"; };
 		454A965E1FD60EA2008D2A0E /* OWSFlatButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = OWSFlatButton.swift; path = SignalMessaging/Views/OWSFlatButton.swift; sourceTree = SOURCE_ROOT; };
@@ -1898,6 +1900,7 @@
 				45DF5DF11DDB843F00C936C7 /* CompareSafetyNumbersActivity.swift */,
 				458E38351D668EBF0094BD24 /* OWSDeviceProvisioningURLParser.h */,
 				458E38361D668EBF0094BD24 /* OWSDeviceProvisioningURLParser.m */,
+				4542DF51208B82E9007B4E76 /* ThreadModel.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -3199,6 +3202,7 @@
 				34D1F0501F7D45A60066283D /* GifPickerCell.swift in Sources */,
 				34D99C931F2937CC00D284D6 /* OWSAnalytics.swift in Sources */,
 				340FC8B8204DAC8D007AEB0F /* AddToGroupViewController.m in Sources */,
+				4542DF52208B82E9007B4E76 /* ThreadModel.swift in Sources */,
 				341F2C0F1F2B8AE700D07D6B /* DebugUIMisc.m in Sources */,
 				340FC8AF204DAC8D007AEB0F /* OWSLinkDeviceViewController.m in Sources */,
 				34E3EF0D1EFC235B007F6822 /* DebugUIDiskUsage.m in Sources */,

--- a/Signal/src/Models/ThreadModel.swift
+++ b/Signal/src/Models/ThreadModel.swift
@@ -1,0 +1,101 @@
+//
+//  Copyright (c) 2018 Open Whisper Systems. All rights reserved.
+//
+
+import Foundation
+
+@objc
+public class ThreadModel: NSObject {
+    let hasUnreadMessages: Bool
+    let lastMessageDate: Date
+    let isGroupThread: Bool
+    let threadRecord: TSThread
+    let unreadCount: UInt
+    let contactIdentifier: String?
+    let name: String
+    let isMuted: Bool
+    var isContactThread: Bool {
+        return !isGroupThread
+    }
+
+    let lastMessageText: String?
+
+//    func attributedSnippet(blockedPhoneNumberSet: Set<String>) {
+//        let isBlocked: Bool = {
+//            guard let contactIdentifier = self.contactIdentifier else {
+//                return false
+//            }
+//            assert(isContactThread)
+//            return blockedPhoneNumberSet.contains(self.contactIdentifier)
+//        }()
+//            
+//        
+//            
+////            BOOL hasUnreadMessages = thread.hasUnreadMessages;
+//        
+////            NSMutableAttributedString *snippetText = [NSMutableAttributedString new];
+//        var snippetText = NSMutableAttributedString()
+//        if isBlocked {
+//            // If thread is blocked, don't show a snippet or mute status.
+//            let append = NSAttributedString(string: NSLocalizedString("HOME_VIEW_BLOCKED_CONTACT_CONVERSATION",
+//                                                                      comment: "A label for conversations with blocked users."),
+//                attributes: <#T##[String : Any]?#>)
+//            
+////            if (isBlocked) {
+////                // If thread is blocked, don't show a snippet or mute status.
+////                [snippetText
+////                    appendAttributedString:[[NSAttributedString alloc]
+////                    initWithString:NSLocalizedString(@"HOME_VIEW_BLOCKED_CONTACT_CONVERSATION",
+////                    @"A label for conversations with blocked users.")
+////                    attributes:@{
+////                    NSFontAttributeName : self.snippetFont.ows_mediumWeight,
+////                    NSForegroundColorAttributeName : [UIColor ows_blackColor],
+////                    }]];
+////            } else {
+////                if ([thread isMuted]) {
+////                    [snippetText appendAttributedString:[[NSAttributedString alloc]
+////                        initWithString:@"\ue067  "
+////                        attributes:@{
+////                        NSFontAttributeName : [UIFont ows_elegantIconsFont:9.f],
+////                        NSForegroundColorAttributeName : (hasUnreadMessages
+////                        ? [UIColor colorWithWhite:0.1f alpha:1.f]
+////                        : [UIColor lightGrayColor]),
+////                        }]];
+////                }
+////                NSString *displayableText = thread.lastMessageText;
+////                if (displayableText) {
+////                    [snippetText appendAttributedString:[[NSAttributedString alloc]
+////                        initWithString:displayableText
+////                        attributes:@{
+////                        NSFontAttributeName :
+////                        (hasUnreadMessages ? self.snippetFont.ows_mediumWeight
+////                        : self.snippetFont),
+////                        NSForegroundColorAttributeName :
+////                        (hasUnreadMessages ? [UIColor ows_blackColor]
+////                        : [UIColor lightGrayColor]),
+////                        }]];
+////                }
+////            }
+////
+////            return snippetText;
+//        }
+//    }
+
+    init(thread: TSThread, transaction: YapDatabaseReadTransaction) {
+        self.threadRecord = thread
+        self.lastMessageDate = thread.lastMessageDate()
+        self.isGroupThread = thread.isGroupThread()
+        self.name = thread.name()
+        self.isMuted = thread.isMuted
+        self.lastMessageText = thread.lastMessageText(transaction: transaction)
+
+        if let contactThread = thread as? TSContactThread {
+            self.contactIdentifier = contactThread.contactIdentifier()
+        } else {
+            self.contactIdentifier = nil
+        }
+
+        self.unreadCount = thread.unreadMessageCount(transaction: transaction)
+        self.hasUnreadMessages = unreadCount > 0
+    }
+}

--- a/Signal/src/Models/ThreadModel.swift
+++ b/Signal/src/Models/ThreadModel.swift
@@ -20,67 +20,6 @@ public class ThreadModel: NSObject {
 
     let lastMessageText: String?
 
-//    func attributedSnippet(blockedPhoneNumberSet: Set<String>) {
-//        let isBlocked: Bool = {
-//            guard let contactIdentifier = self.contactIdentifier else {
-//                return false
-//            }
-//            assert(isContactThread)
-//            return blockedPhoneNumberSet.contains(self.contactIdentifier)
-//        }()
-//            
-//        
-//            
-////            BOOL hasUnreadMessages = thread.hasUnreadMessages;
-//        
-////            NSMutableAttributedString *snippetText = [NSMutableAttributedString new];
-//        var snippetText = NSMutableAttributedString()
-//        if isBlocked {
-//            // If thread is blocked, don't show a snippet or mute status.
-//            let append = NSAttributedString(string: NSLocalizedString("HOME_VIEW_BLOCKED_CONTACT_CONVERSATION",
-//                                                                      comment: "A label for conversations with blocked users."),
-//                attributes: <#T##[String : Any]?#>)
-//            
-////            if (isBlocked) {
-////                // If thread is blocked, don't show a snippet or mute status.
-////                [snippetText
-////                    appendAttributedString:[[NSAttributedString alloc]
-////                    initWithString:NSLocalizedString(@"HOME_VIEW_BLOCKED_CONTACT_CONVERSATION",
-////                    @"A label for conversations with blocked users.")
-////                    attributes:@{
-////                    NSFontAttributeName : self.snippetFont.ows_mediumWeight,
-////                    NSForegroundColorAttributeName : [UIColor ows_blackColor],
-////                    }]];
-////            } else {
-////                if ([thread isMuted]) {
-////                    [snippetText appendAttributedString:[[NSAttributedString alloc]
-////                        initWithString:@"\ue067  "
-////                        attributes:@{
-////                        NSFontAttributeName : [UIFont ows_elegantIconsFont:9.f],
-////                        NSForegroundColorAttributeName : (hasUnreadMessages
-////                        ? [UIColor colorWithWhite:0.1f alpha:1.f]
-////                        : [UIColor lightGrayColor]),
-////                        }]];
-////                }
-////                NSString *displayableText = thread.lastMessageText;
-////                if (displayableText) {
-////                    [snippetText appendAttributedString:[[NSAttributedString alloc]
-////                        initWithString:displayableText
-////                        attributes:@{
-////                        NSFontAttributeName :
-////                        (hasUnreadMessages ? self.snippetFont.ows_mediumWeight
-////                        : self.snippetFont),
-////                        NSForegroundColorAttributeName :
-////                        (hasUnreadMessages ? [UIColor ows_blackColor]
-////                        : [UIColor lightGrayColor]),
-////                        }]];
-////                }
-////            }
-////
-////            return snippetText;
-//        }
-//    }
-
     init(thread: TSThread, transaction: YapDatabaseReadTransaction) {
         self.threadRecord = thread
         self.lastMessageDate = thread.lastMessageDate()

--- a/Signal/src/Models/ThreadModel.swift
+++ b/Signal/src/Models/ThreadModel.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 @objc
-public class ThreadModel: NSObject {
+public class ThreadViewModel: NSObject {
     let hasUnreadMessages: Bool
     let lastMessageDate: Date
     let isGroupThread: Bool

--- a/Signal/src/ViewControllers/ConversationView/Cells/ConversationViewCell.h
+++ b/Signal/src/ViewControllers/ConversationView/Cells/ConversationViewCell.h
@@ -13,6 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class TSMessage;
 @class TSOutgoingMessage;
 @class TSQuotedMessage;
+@class YapDatabaseReadTransaction;
 
 @protocol ConversationViewCellDelegate <NSObject>
 
@@ -71,7 +72,7 @@ NS_ASSUME_NONNULL_BEGIN
 // The width of the collection view.
 @property (nonatomic) int contentWidth;
 
-- (void)loadForDisplay;
+- (void)loadForDisplayWithTransaction:(YapDatabaseReadTransaction *)transaction;
 
 - (CGSize)cellSizeForViewWidth:(int)viewWidth contentWidth:(int)contentWidth;
 

--- a/Signal/src/ViewControllers/ConversationView/Cells/ConversationViewCell.m
+++ b/Signal/src/ViewControllers/ConversationView/Cells/ConversationViewCell.m
@@ -1,5 +1,5 @@
 //
-//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//  Copyright (c) 2018 Open Whisper Systems. All rights reserved.
 //
 
 #import "ConversationViewCell.h"
@@ -19,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
     self.contentWidth = 0;
 }
 
-- (void)loadForDisplay
+- (void)loadForDisplayWithTransaction:(YapDatabaseReadTransaction *)transaction
 {
     OWSFail(@"%@ This method should be overridden.", self.logTag);
 }

--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSContactOffersCell.m
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSContactOffersCell.m
@@ -85,7 +85,7 @@ NS_ASSUME_NONNULL_BEGIN
     return NSStringFromClass([self class]);
 }
 
-- (void)loadForDisplay
+- (void)loadForDisplayWithTransaction:(YapDatabaseReadTransaction *)transaction
 {
     OWSAssert(self.viewItem);
     OWSAssert([self.viewItem.interaction isKindOfClass:[OWSContactOffersInteraction class]]);

--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageCell.m
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageCell.m
@@ -150,7 +150,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Load
 
-- (void)loadForDisplay
+- (void)loadForDisplayWithTransaction:(YapDatabaseReadTransaction *)transaction
 {
     OWSAssert(self.viewItem);
     OWSAssert(self.viewItem.interaction);

--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSUnreadIndicatorCell.m
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSUnreadIndicatorCell.m
@@ -84,7 +84,7 @@ NS_ASSUME_NONNULL_BEGIN
     return NSStringFromClass([self class]);
 }
 
-- (void)loadForDisplay
+- (void)loadForDisplayWithTransaction:(YapDatabaseReadTransaction *)transaction
 {
     OWSAssert(self.viewItem);
     OWSAssert([self.viewItem.interaction isKindOfClass:[TSUnreadIndicatorInteraction class]]);

--- a/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
@@ -4757,7 +4757,9 @@ typedef enum : NSUInteger {
     }
     cell.contentWidth = self.layout.contentWidth;
 
-    [cell loadForDisplay];
+    [self.uiDatabaseConnection readWithBlock:^(YapDatabaseReadTransaction *_Nonnull transaction) {
+        [cell loadForDisplayWithTransaction:transaction];
+    }];
 
     return cell;
 }

--- a/Signal/src/ViewControllers/DebugUI/DebugUIMessages.m
+++ b/Signal/src/ViewControllers/DebugUI/DebugUIMessages.m
@@ -3223,7 +3223,7 @@ NS_ASSUME_NONNULL_BEGIN
 
                   TSContactThread *contactThread = [TSContactThread getOrCreateThreadWithContactId:phoneNumber.toE164];
                   [self sendFakeMessages:messageCount thread:contactThread];
-                  DDLogError(@"Create fake thread: %@, interactions: %zd",
+                  DDLogError(@"Create fake thread: %@, interactions: %tu",
                       phoneNumber.toE164,
                       contactThread.numberOfInteractions);
               }];
@@ -3251,7 +3251,7 @@ NS_ASSUME_NONNULL_BEGIN
                         [self sendFakeMessages:batchSize thread:thread isTextOnly:isTextOnly transaction:transaction];
                     }];
                 remainder -= batchSize;
-                DDLogInfo(@"%@ sendFakeMessages %zd / %zd", self.logTag, counter - remainder, counter);
+                DDLogInfo(@"%@ sendFakeMessages %td / %tu", self.logTag, counter - remainder, counter);
             }
         });
     }
@@ -3263,7 +3263,7 @@ NS_ASSUME_NONNULL_BEGIN
               isTextOnly:(BOOL)isTextOnly
              transaction:(YapDatabaseReadWriteTransaction *)transaction
 {
-    DDLogInfo(@"%@ sendFakeMessages: %zd", self.logTag, counter);
+    DDLogInfo(@"%@ sendFakeMessages: %tu", self.logTag, counter);
 
     for (NSUInteger i = 0; i < counter; i++) {
         NSString *randomText = [self randomText];
@@ -3411,7 +3411,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     OWSAssert(thread);
 
-    DDLogInfo(@"%@ injectIncomingMessageInThread: %zd", self.logTag, counter);
+    DDLogInfo(@"%@ injectIncomingMessageInThread: %tu", self.logTag, counter);
 
     NSString *randomText = [self randomText];
     NSString *text = [[[@(counter) description] stringByAppendingString:@" "] stringByAppendingString:randomText];

--- a/Signal/src/ViewControllers/HomeView/HomeViewCell.h
+++ b/Signal/src/ViewControllers/HomeView/HomeViewCell.h
@@ -5,7 +5,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class OWSContactsManager;
-@class ThreadModel;
+@class ThreadViewModel;
 @class YapDatabaseReadTransaction;
 
 @interface HomeViewCell : UITableViewCell
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (NSString *)cellReuseIdentifier;
 
-- (void)configureWithThread:(ThreadModel *)thread
+- (void)configureWithThread:(ThreadViewModel *)thread
             contactsManager:(OWSContactsManager *)contactsManager
       blockedPhoneNumberSet:(NSSet<NSString *> *)blockedPhoneNumberSet;
 

--- a/Signal/src/ViewControllers/HomeView/HomeViewCell.h
+++ b/Signal/src/ViewControllers/HomeView/HomeViewCell.h
@@ -5,7 +5,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class OWSContactsManager;
-@class TSThread;
+@class ThreadModel;
 @class YapDatabaseReadTransaction;
 
 @interface HomeViewCell : UITableViewCell
@@ -14,10 +14,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (NSString *)cellReuseIdentifier;
 
-- (void)configureWithThread:(TSThread *)thread
+- (void)configureWithThread:(ThreadModel *)thread
             contactsManager:(OWSContactsManager *)contactsManager
-      blockedPhoneNumberSet:(NSSet<NSString *> *)blockedPhoneNumberSet
-                transaction:(YapDatabaseReadTransaction *)transaction;
+      blockedPhoneNumberSet:(NSSet<NSString *> *)blockedPhoneNumberSet;
 
 @end
 

--- a/Signal/src/ViewControllers/HomeView/HomeViewCell.h
+++ b/Signal/src/ViewControllers/HomeView/HomeViewCell.h
@@ -6,6 +6,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class OWSContactsManager;
 @class TSThread;
+@class YapDatabaseReadTransaction;
 
 @interface HomeViewCell : UITableViewCell
 
@@ -15,7 +16,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)configureWithThread:(TSThread *)thread
             contactsManager:(OWSContactsManager *)contactsManager
-      blockedPhoneNumberSet:(NSSet<NSString *> *)blockedPhoneNumberSet;
+      blockedPhoneNumberSet:(NSSet<NSString *> *)blockedPhoneNumberSet
+                transaction:(YapDatabaseReadTransaction *)transaction;
 
 @end
 

--- a/Signal/src/ViewControllers/HomeView/HomeViewCell.m
+++ b/Signal/src/ViewControllers/HomeView/HomeViewCell.m
@@ -146,11 +146,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)configureWithThread:(TSThread *)thread
               contactsManager:(OWSContactsManager *)contactsManager
         blockedPhoneNumberSet:(NSSet<NSString *> *)blockedPhoneNumberSet
+                transaction:(YapDatabaseReadTransaction *)transaction
 {
     OWSAssertIsOnMainThread();
     OWSAssert(thread);
     OWSAssert(contactsManager);
     OWSAssert(blockedPhoneNumberSet);
+    OWSAssert(transaction);
 
     self.thread = thread;
     self.contactsManager = contactsManager;
@@ -171,7 +173,9 @@ NS_ASSUME_NONNULL_BEGIN
     // changes to the dynamic type settings are reflected.
     self.snippetLabel.font = [self snippetFont];
     self.snippetLabel.attributedText =
-        [self attributedSnippetForThread:thread blockedPhoneNumberSet:blockedPhoneNumberSet];
+        [self attributedSnippetForThread:thread
+                   blockedPhoneNumberSet:blockedPhoneNumberSet
+                             transaction:transaction];
 
     self.dateTimeLabel.text = [self stringForDate:thread.lastMessageDate];
 
@@ -253,6 +257,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSAttributedString *)attributedSnippetForThread:(TSThread *)thread
                              blockedPhoneNumberSet:(NSSet<NSString *> *)blockedPhoneNumberSet
+                                       transaction:(YapDatabaseReadTransaction *)transaction
 {
     OWSAssert(thread);
 
@@ -285,7 +290,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                                     : [UIColor lightGrayColor]),
                                                         }]];
         }
-        NSString *displayableText = thread.lastMessageLabel.filterStringForDisplay;
+        NSString *displayableText = [thread lastMessageLabelWithTransaction:transaction];
         if (displayableText) {
             [snippetText appendAttributedString:[[NSAttributedString alloc]
                                                     initWithString:displayableText

--- a/Signal/src/ViewControllers/HomeView/HomeViewCell.m
+++ b/Signal/src/ViewControllers/HomeView/HomeViewCell.m
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) UIView *unreadBadge;
 @property (nonatomic) UILabel *unreadLabel;
 
-@property (nonatomic, nullable) ThreadModel *thread;
+@property (nonatomic, nullable) ThreadViewModel *thread;
 @property (nonatomic, nullable) OWSContactsManager *contactsManager;
 
 @property (nonatomic, readonly) NSMutableArray<NSLayoutConstraint *> *viewConstraints;
@@ -142,7 +142,7 @@ NS_ASSUME_NONNULL_BEGIN
     return NSStringFromClass(self.class);
 }
 
-- (void)configureWithThread:(ThreadModel *)thread
+- (void)configureWithThread:(ThreadViewModel *)thread
             contactsManager:(OWSContactsManager *)contactsManager
       blockedPhoneNumberSet:(NSSet<NSString *> *)blockedPhoneNumberSet
 {
@@ -239,7 +239,7 @@ NS_ASSUME_NONNULL_BEGIN
         return;
     }
 
-    ThreadModel *thread = self.thread;
+    ThreadViewModel *thread = self.thread;
     if (thread == nil) {
         OWSFail(@"%@ thread should not be nil", self.logTag);
         self.avatarView.image = nil;
@@ -251,7 +251,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                   contactsManager:contactsManager];
 }
 
-- (NSAttributedString *)attributedSnippetForThread:(ThreadModel *)thread
+- (NSAttributedString *)attributedSnippetForThread:(ThreadViewModel *)thread
                              blockedPhoneNumberSet:(NSSet<NSString *> *)blockedPhoneNumberSet
 {
     OWSAssert(thread);
@@ -447,7 +447,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     self.nameLabel.font = self.nameFont;
 
-    ThreadModel *thread = self.thread;
+    ThreadViewModel *thread = self.thread;
     if (thread == nil) {
         OWSFail(@"%@ thread should not be nil", self.logTag);
         self.nameLabel.attributedText = nil;

--- a/Signal/src/ViewControllers/HomeView/HomeViewCell.m
+++ b/Signal/src/ViewControllers/HomeView/HomeViewCell.m
@@ -12,7 +12,6 @@
 #import <SignalServiceKit/OWSMessageManager.h>
 #import <SignalServiceKit/TSContactThread.h>
 #import <SignalServiceKit/TSGroupThread.h>
-#import <SignalServiceKit/TSThread.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -27,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) UIView *unreadBadge;
 @property (nonatomic) UILabel *unreadLabel;
 
-@property (nonatomic, nullable) TSThread *thread;
+@property (nonatomic, nullable) ThreadModel *thread;
 @property (nonatomic, nullable) OWSContactsManager *contactsManager;
 
 @property (nonatomic, readonly) NSMutableArray<NSLayoutConstraint *> *viewConstraints;
@@ -143,16 +142,14 @@ NS_ASSUME_NONNULL_BEGIN
     return NSStringFromClass(self.class);
 }
 
-- (void)configureWithThread:(TSThread *)thread
-              contactsManager:(OWSContactsManager *)contactsManager
-        blockedPhoneNumberSet:(NSSet<NSString *> *)blockedPhoneNumberSet
-                transaction:(YapDatabaseReadTransaction *)transaction
+- (void)configureWithThread:(ThreadModel *)thread
+            contactsManager:(OWSContactsManager *)contactsManager
+      blockedPhoneNumberSet:(NSSet<NSString *> *)blockedPhoneNumberSet
 {
     OWSAssertIsOnMainThread();
     OWSAssert(thread);
     OWSAssert(contactsManager);
     OWSAssert(blockedPhoneNumberSet);
-    OWSAssert(transaction);
 
     self.thread = thread;
     self.contactsManager = contactsManager;
@@ -173,9 +170,7 @@ NS_ASSUME_NONNULL_BEGIN
     // changes to the dynamic type settings are reflected.
     self.snippetLabel.font = [self snippetFont];
     self.snippetLabel.attributedText =
-        [self attributedSnippetForThread:thread
-                   blockedPhoneNumberSet:blockedPhoneNumberSet
-                             transaction:transaction];
+        [self attributedSnippetForThread:thread blockedPhoneNumberSet:blockedPhoneNumberSet];
 
     self.dateTimeLabel.text = [self stringForDate:thread.lastMessageDate];
 
@@ -187,7 +182,7 @@ NS_ASSUME_NONNULL_BEGIN
         self.dateTimeLabel.font = self.unreadFont;
     }
 
-    NSUInteger unreadCount = [[OWSMessageUtils sharedManager] unreadMessagesInThread:thread];
+    NSUInteger unreadCount = thread.unreadCount;
     if (unreadCount == 0) {
         [self.viewConstraints addObject:[self.payloadView autoPinTrailingToSuperviewMargin]];
     } else {
@@ -244,20 +239,20 @@ NS_ASSUME_NONNULL_BEGIN
         return;
     }
 
-    TSThread *thread = self.thread;
+    ThreadModel *thread = self.thread;
     if (thread == nil) {
         OWSFail(@"%@ thread should not be nil", self.logTag);
         self.avatarView.image = nil;
         return;
     }
 
-    self.avatarView.image =
-        [OWSAvatarBuilder buildImageForThread:thread diameter:self.avatarSize contactsManager:contactsManager];
+    self.avatarView.image = [OWSAvatarBuilder buildImageForThread:thread.threadRecord
+                                                         diameter:self.avatarSize
+                                                  contactsManager:contactsManager];
 }
 
-- (NSAttributedString *)attributedSnippetForThread:(TSThread *)thread
+- (NSAttributedString *)attributedSnippetForThread:(ThreadModel *)thread
                              blockedPhoneNumberSet:(NSSet<NSString *> *)blockedPhoneNumberSet
-                                       transaction:(YapDatabaseReadTransaction *)transaction
 {
     OWSAssert(thread);
 
@@ -290,7 +285,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                                     : [UIColor lightGrayColor]),
                                                         }]];
         }
-        NSString *displayableText = [thread lastMessageLabelWithTransaction:transaction];
+        NSString *displayableText = thread.lastMessageText;
         if (displayableText) {
             [snippetText appendAttributedString:[[NSAttributedString alloc]
                                                     initWithString:displayableText
@@ -452,7 +447,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     self.nameLabel.font = self.nameFont;
 
-    TSThread *thread = self.thread;
+    ThreadModel *thread = self.thread;
     if (thread == nil) {
         OWSFail(@"%@ thread should not be nil", self.logTag);
         self.nameLabel.attributedText = nil;

--- a/Signal/src/ViewControllers/HomeView/HomeViewController.m
+++ b/Signal/src/ViewControllers/HomeView/HomeViewController.m
@@ -947,6 +947,8 @@ typedef NS_ENUM(NSInteger, CellState) { kArchiveState, kInboxState };
 
     if (!_uiDatabaseConnection) {
         _uiDatabaseConnection = [OWSPrimaryStorage.sharedManager newDatabaseConnection];
+        // default is 250
+        _uiDatabaseConnection.objectCacheLimit = 500;
         [_uiDatabaseConnection beginLongLivedReadTransaction];
     }
     return _uiDatabaseConnection;

--- a/Signal/src/ViewControllers/HomeView/HomeViewController.m
+++ b/Signal/src/ViewControllers/HomeView/HomeViewController.m
@@ -156,14 +156,14 @@ typedef NS_ENUM(NSInteger, CellState) { kArchiveState, kInboxState };
 
     _blockedPhoneNumberSet = [NSSet setWithArray:[_blockingManager blockedPhoneNumbers]];
 
-    [self.tableView reloadData];
+    [self reloadTableViewData];
 }
 
 - (void)signalAccountsDidChange:(id)notification
 {
     OWSAssertIsOnMainThread();
 
-    [self.tableView reloadData];
+    [self reloadTableViewData];
 }
 
 #pragma mark - View Life Cycle
@@ -473,6 +473,13 @@ typedef NS_ENUM(NSInteger, CellState) { kArchiveState, kInboxState };
     }
 }
 
+- (void)reloadTableViewData
+{
+    // PERF: come up with a more nuanced cache clearing scheme
+    [self.threadModelCache removeAllObjects];
+    [self.tableView reloadData];
+}
+
 - (void)resetMappings
 {
     // If we're entering "active" mode (e.g. view is visible and app is in foreground),
@@ -489,7 +496,8 @@ typedef NS_ENUM(NSInteger, CellState) { kArchiveState, kInboxState };
         }];
     }
 
-    [[self tableView] reloadData];
+    [self reloadTableViewData];
+
     [self checkIfEmptyView];
     [self updateInboxCountLabel];
 
@@ -926,7 +934,7 @@ typedef NS_ENUM(NSInteger, CellState) { kArchiveState, kInboxState };
 
     [self resetMappings];
 
-    [[self tableView] reloadData];
+    [self reloadTableViewData];
     [self checkIfEmptyView];
     [self updateReminderViews];
 }

--- a/SignalMessaging/contacts/OWSContactsManager.m
+++ b/SignalMessaging/contacts/OWSContactsManager.m
@@ -371,9 +371,15 @@ NSString *const OWSContactsManagerSignalAccountsDidChangeNotification
 {
     OWSAssert(recipientId.length > 0);
 
-    SignalAccount *signalAccount = [self signalAccountForRecipientId:recipientId];
+    SignalAccount *_Nullable signalAccount = [self signalAccountForRecipientId:recipientId];
     if (!signalAccount) {
-        return nil;
+        // search system contacts for no-longer-registered signal users, for which there will be no SignalAccount
+        DDLogDebug(@"%@ no signal account", self.logTag);
+        Contact *_Nullable nonSignalContact = self.allContactsMap[recipientId];
+        if (!nonSignalContact) {
+            return nil;
+        }
+        return nonSignalContact.fullName;
     }
 
     NSString *fullName = signalAccount.contactFullName;

--- a/SignalMessaging/environment/NoopNotificationsManager.swift
+++ b/SignalMessaging/environment/NoopNotificationsManager.swift
@@ -7,11 +7,11 @@ import SignalServiceKit
 @objc
 public class NoopNotificationsManager: NSObject, NotificationsProtocol {
 
-    public func notifyUser(for incomingMessage: TSIncomingMessage!, in thread: TSThread!, contactsManager: ContactsManagerProtocol!, transaction: YapDatabaseReadTransaction!) {
+    public func notifyUser(for incomingMessage: TSIncomingMessage, in thread: TSThread, contactsManager: ContactsManagerProtocol, transaction: YapDatabaseReadTransaction) {
         owsFail("\(self.logTag) in \(#function).")
     }
 
-    public func notifyUser(for error: TSErrorMessage!, in thread: TSThread!) {
+    public func notifyUser(for error: TSErrorMessage, thread: TSThread, transaction: YapDatabaseReadWriteTransaction) {
         Logger.warn("\(self.logTag) in \(#function), skipping notification for: \(error.description)")
     }
 }

--- a/SignalServiceKit/src/Contacts/TSThread.h
+++ b/SignalServiceKit/src/Contacts/TSThread.h
@@ -70,7 +70,10 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @return YES if it has unread TSIncomingMessages, NO otherwise.
  */
-- (BOOL)hasUnreadMessages;
+- (BOOL)hasUnreadMessagesWithTransaction:(YapDatabaseReadTransaction *)transaction
+    NS_SWIFT_NAME(hasUnreadMessages(transaction:));
+- (NSUInteger)unreadMessageCountWithTransaction:(YapDatabaseReadTransaction *)transaction
+    NS_SWIFT_NAME(unreadMessageCount(transaction:));
 
 - (BOOL)hasSafetyNumbers;
 
@@ -90,7 +93,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @return Thread preview string.
  */
-- (NSString *)lastMessageLabelWithTransaction:(YapDatabaseReadTransaction *)transaction;
+- (NSString *)lastMessageTextWithTransaction:(YapDatabaseReadTransaction *)transaction
+    NS_SWIFT_NAME(lastMessageText(transaction:));
 
 /**
  *  Updates the thread's caches of the latest interaction.

--- a/SignalServiceKit/src/Contacts/TSThread.h
+++ b/SignalServiceKit/src/Contacts/TSThread.h
@@ -90,7 +90,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @return Thread preview string.
  */
-- (NSString *)lastMessageLabel;
+- (NSString *)lastMessageLabelWithTransaction:(YapDatabaseReadTransaction *)transaction;
 
 /**
  *  Updates the thread's caches of the latest interaction.

--- a/SignalServiceKit/src/Contacts/TSThread.h
+++ b/SignalServiceKit/src/Contacts/TSThread.h
@@ -65,13 +65,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (NSArray<TSInvalidIdentityKeyReceivingErrorMessage *> *)receivedMessagesForInvalidKey:(NSData *)key;
 
-/**
- *  Returns whether or not the thread has unread messages.
- *
- *  @return YES if it has unread TSIncomingMessages, NO otherwise.
- */
-- (BOOL)hasUnreadMessagesWithTransaction:(YapDatabaseReadTransaction *)transaction
-    NS_SWIFT_NAME(hasUnreadMessages(transaction:));
 - (NSUInteger)unreadMessageCountWithTransaction:(YapDatabaseReadTransaction *)transaction
     NS_SWIFT_NAME(unreadMessageCount(transaction:));
 

--- a/SignalServiceKit/src/Contacts/Threads/TSContactThread.m
+++ b/SignalServiceKit/src/Contacts/Threads/TSContactThread.m
@@ -114,6 +114,7 @@ NS_ASSUME_NONNULL_BEGIN
     return !![[OWSIdentityManager sharedManager] identityKeyForRecipientId:self.contactIdentifier];
 }
 
+// TODO deprecate this? seems weird to access the displayName in the DB model
 - (NSString *)name
 {
     return [[TextSecureKitEnv sharedEnv].contactsManager displayNameForPhoneIdentifier:self.contactIdentifier];

--- a/SignalServiceKit/src/Messages/Interactions/OWSDisappearingConfigurationUpdateInfoMessage.m
+++ b/SignalServiceKit/src/Messages/Interactions/OWSDisappearingConfigurationUpdateInfoMessage.m
@@ -56,7 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
     return NO;
 }
 
-- (NSString *)description
+-(NSString *)previewTextWithTransaction:(YapDatabaseReadTransaction *)transaction
 {
     if (self.createdByRemoteName) {
         if (self.configurationIsEnabled && self.configurationDurationSeconds > 0) {

--- a/SignalServiceKit/src/Messages/Interactions/TSErrorMessage.m
+++ b/SignalServiceKit/src/Messages/Interactions/TSErrorMessage.m
@@ -97,7 +97,8 @@ NSUInteger TSErrorMessageSchemaVersion = 1;
     return OWSInteractionType_Error;
 }
 
-- (NSString *)description {
+- (NSString *)previewTextWithTransaction:(YapDatabaseReadTransaction *)transaction
+{
     switch (_errorType) {
         case TSErrorMessageNoSession:
             return NSLocalizedString(@"ERROR_MESSAGE_NO_SESSION", @"");

--- a/SignalServiceKit/src/Messages/Interactions/TSInfoMessage.m
+++ b/SignalServiceKit/src/Messages/Interactions/TSInfoMessage.m
@@ -91,7 +91,8 @@ NSUInteger TSInfoMessageSchemaVersion = 1;
     return OWSInteractionType_Info;
 }
 
-- (NSString *)description {
+- (NSString *)previewTextWithTransaction:(YapDatabaseReadTransaction *)transaction
+{
     switch (_messageType) {
         case TSInfoMessageTypeSessionDidEnd:
             return NSLocalizedString(@"SECURE_SESSION_RESET", nil);

--- a/SignalServiceKit/src/Messages/Interactions/TSInteraction.h
+++ b/SignalServiceKit/src/Messages/Interactions/TSInteraction.h
@@ -19,6 +19,12 @@ typedef NS_ENUM(NSInteger, OWSInteractionType) {
     OWSInteractionType_Offer,
 };
 
+@protocol OWSPreviewText
+
+- (NSString *)previewTextWithTransaction:(YapDatabaseReadTransaction *)transaction;
+
+@end
+
 @interface TSInteraction : TSYapDatabaseObject
 
 - (instancetype)initInteractionWithTimestamp:(uint64_t)timestamp inThread:(TSThread *)thread;

--- a/SignalServiceKit/src/Messages/Interactions/TSInteraction.m
+++ b/SignalServiceKit/src/Messages/Interactions/TSInteraction.m
@@ -127,9 +127,10 @@ NS_ASSUME_NONNULL_BEGIN
     return OWSInteractionType_Unknown;
 }
 
-- (NSString *)description {
-    OWSFail(@"Abstract Method");
-    return @"Interaction description";
+- (NSString *)description
+{
+    return [NSString
+        stringWithFormat:@"%@ in thread: %@ timestamp: %tu", [super description], self.uniqueThreadId, self.timestamp];
 }
 
 - (void)saveWithTransaction:(YapDatabaseReadWriteTransaction *)transaction {

--- a/SignalServiceKit/src/Messages/Interactions/TSInteraction.m
+++ b/SignalServiceKit/src/Messages/Interactions/TSInteraction.m
@@ -128,6 +128,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (NSString *)description {
+    OWSFail(@"Abstract Method");
     return @"Interaction description";
 }
 

--- a/SignalServiceKit/src/Messages/Interactions/TSMessage.h
+++ b/SignalServiceKit/src/Messages/Interactions/TSMessage.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class TSQuotedMessage;
 @class YapDatabaseReadWriteTransaction;
 
-@interface TSMessage : TSInteraction
+@interface TSMessage : TSInteraction <OWSPreviewText>
 
 @property (nonatomic, readonly) NSMutableArray<NSString *> *attachmentIds;
 @property (nonatomic, readonly, nullable) NSString *body;
@@ -39,7 +39,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)hasAttachments;
 - (nullable TSAttachment *)attachmentWithTransaction:(YapDatabaseReadTransaction *)transaction;
-- (NSString *)previewTextWithTransaction:(YapDatabaseReadTransaction *)transaction;
 - (void)setQuotedMessageThumbnailAttachmentStream:(TSAttachmentStream *)attachmentStream;
 
 - (BOOL)shouldStartExpireTimer;

--- a/SignalServiceKit/src/Messages/Interactions/TSMessage.m
+++ b/SignalServiceKit/src/Messages/Interactions/TSMessage.m
@@ -265,14 +265,11 @@ static const NSUInteger OWSMessageSchemaVersion = 4;
     }
 }
 
-// TODO deprecate this and implement something like previewTextWithTransaction: for all TSInteractions
 - (NSString *)description
 {
-    __block NSString *result;
-    [self.dbReadConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
-        result = [self previewTextWithTransaction:transaction];
-    }];
-    return result;
+    // TODO verify this isn't exposed in the UI
+    OWSFail(@"%@ in %s verify this isn't being used anywhere except logging.", self.logTag, __PRETTY_FUNCTION__);
+    return [super description];
 }
 
 - (void)removeWithTransaction:(YapDatabaseReadWriteTransaction *)transaction

--- a/SignalServiceKit/src/Messages/Interactions/TSMessage.m
+++ b/SignalServiceKit/src/Messages/Interactions/TSMessage.m
@@ -265,13 +265,6 @@ static const NSUInteger OWSMessageSchemaVersion = 4;
     }
 }
 
-- (NSString *)description
-{
-    // TODO verify this isn't exposed in the UI
-    OWSFail(@"%@ in %s verify this isn't being used anywhere except logging.", self.logTag, __PRETTY_FUNCTION__);
-    return [super description];
-}
-
 - (void)removeWithTransaction:(YapDatabaseReadWriteTransaction *)transaction
 {
     [super removeWithTransaction:transaction];

--- a/SignalServiceKit/src/Messages/Interactions/TSOutgoingMessage.m
+++ b/SignalServiceKit/src/Messages/Interactions/TSOutgoingMessage.m
@@ -437,7 +437,7 @@ NSString *const kTSOutgoingMessageSentRecipientAll = @"kTSOutgoingMessageSentRec
         [builder setBody:self.body];
     } else {
         OWSFail(@"%@ message body length too long.", self.logTag);
-        NSMutableString *truncatedBody = [self.body mutableCopy];
+        NSString *truncatedBody = self.body;
         while ([truncatedBody lengthOfBytesUsingEncoding:NSUTF8StringEncoding] > kOversizeTextMessageSizeThreshold) {
             DDLogError(@"%@ truncating body which is too long: %tu",
                 self.logTag,

--- a/SignalServiceKit/src/Messages/OWSIdentityManager.m
+++ b/SignalServiceKit/src/Messages/OWSIdentityManager.m
@@ -545,7 +545,9 @@ NSString *const kNSNotificationName_IdentityStateDidChange = @"kNSNotificationNa
         [message saveWithTransaction:transaction];
     }
 
-    [[TextSecureKitEnv sharedEnv].notificationsManager notifyUserForErrorMessage:errorMessage inThread:contactThread];
+    [[TextSecureKitEnv sharedEnv].notificationsManager notifyUserForErrorMessage:errorMessage
+                                                                          thread:contactThread
+                                                                     transaction:transaction];
 }
 
 - (void)enqueueSyncMessageForVerificationStateForRecipientId:(NSString *)recipientId

--- a/SignalServiceKit/src/Messages/OWSMessageUtils.h
+++ b/SignalServiceKit/src/Messages/OWSMessageUtils.h
@@ -15,7 +15,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSUInteger)unreadMessagesCount;
 - (NSUInteger)unreadMessagesCountExcept:(TSThread *)thread;
-- (NSUInteger)unreadMessagesInThread:(TSThread *)thread;
 
 - (void)updateApplicationBadgeCount;
 

--- a/SignalServiceKit/src/Messages/OWSMessageUtils.m
+++ b/SignalServiceKit/src/Messages/OWSMessageUtils.m
@@ -95,14 +95,6 @@ NS_ASSUME_NONNULL_BEGIN
     [CurrentAppContext() setMainAppBadgeNumber:numberOfItems];
 }
 
-- (NSUInteger)unreadMessagesInThread:(TSThread *)thread
-{
-    __block NSUInteger numberOfItems;
-    [self.dbConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
-        numberOfItems = [[transaction ext:TSUnreadDatabaseViewExtensionName] numberOfItemsInGroup:thread.uniqueId];
-    }];
-    return numberOfItems;
-}
 
 @end
 

--- a/SignalServiceKit/src/Messages/TSCall.h
+++ b/SignalServiceKit/src/Messages/TSCall.h
@@ -20,7 +20,7 @@ typedef enum {
     RPRecentCallTypeIncomingDeclined
 } RPRecentCallType;
 
-@interface TSCall : TSInteraction <OWSReadTracking>
+@interface TSCall : TSInteraction <OWSReadTracking, OWSPreviewText>
 
 @property (nonatomic, readonly) RPRecentCallType callType;
 

--- a/SignalServiceKit/src/Messages/TSCall.m
+++ b/SignalServiceKit/src/Messages/TSCall.m
@@ -69,11 +69,7 @@ NSUInteger TSCallCurrentSchemaVersion = 1;
 
 - (NSString *)previewTextWithTransaction:(YapDatabaseReadTransaction *)transaction
 {
-    return [self previewText];
-}
-
-- (NSString *)previewText
-{
+    // We don't actually use the `transaction` but other sibling classes do.
     switch (_callType) {
         case RPRecentCallTypeIncoming:
             return NSLocalizedString(@"INCOMING_CALL", @"");
@@ -91,12 +87,6 @@ NSUInteger TSCallCurrentSchemaVersion = 1;
             return NSLocalizedString(@"INCOMING_DECLINED_CALL",
                                      @"info message recorded in conversation history when local user declined a call");
     }
-}
-
-- (NSString *)description
-{
-    OWSFail(@"%@ in %s verify this isnt exposed in the UI", self.logTag, __PRETTY_FUNCTION__);
-    return [self previewText];
 }
 
 #pragma mark - OWSReadTracking

--- a/SignalServiceKit/src/Messages/TSCall.m
+++ b/SignalServiceKit/src/Messages/TSCall.m
@@ -67,7 +67,13 @@ NSUInteger TSCallCurrentSchemaVersion = 1;
     return OWSInteractionType_Call;
 }
 
-- (NSString *)description {
+- (NSString *)previewTextWithTransaction:(YapDatabaseReadTransaction *)transaction
+{
+    return [self previewText];
+}
+
+- (NSString *)previewText
+{
     switch (_callType) {
         case RPRecentCallTypeIncoming:
             return NSLocalizedString(@"INCOMING_CALL", @"");
@@ -83,8 +89,14 @@ NSUInteger TSCallCurrentSchemaVersion = 1;
             return NSLocalizedString(@"INFO_MESSAGE_MISSED_CALL_DUE_TO_CHANGED_IDENITY", @"info message text shown in conversation view");
         case RPRecentCallTypeIncomingDeclined:
             return NSLocalizedString(@"INCOMING_DECLINED_CALL",
-                @"info message recorded in conversation history when local user declined a call");
+                                     @"info message recorded in conversation history when local user declined a call");
     }
+}
+
+- (NSString *)description
+{
+    OWSFail(@"%@ in %s verify this isnt exposed in the UI", self.logTag, __PRETTY_FUNCTION__);
+    return [self previewText];
 }
 
 #pragma mark - OWSReadTracking

--- a/SignalServiceKit/src/Protocols/NotificationsProtocol.h
+++ b/SignalServiceKit/src/Protocols/NotificationsProtocol.h
@@ -1,11 +1,14 @@
 //
-//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//  Copyright (c) 2018 Open Whisper Systems. All rights reserved.
 //
+
+NS_ASSUME_NONNULL_BEGIN
 
 @class TSErrorMessage;
 @class TSIncomingMessage;
 @class TSThread;
 @class YapDatabaseReadTransaction;
+
 @protocol ContactsManagerProtocol;
 
 @protocol NotificationsProtocol <NSObject>
@@ -15,6 +18,10 @@
                      contactsManager:(id<ContactsManagerProtocol>)contactsManager
                          transaction:(YapDatabaseReadTransaction *)transaction;
 
-- (void)notifyUserForErrorMessage:(TSErrorMessage *)error inThread:(TSThread *)thread;
+- (void)notifyUserForErrorMessage:(TSErrorMessage *)error
+                           thread:(TSThread *)thread
+                      transaction:(YapDatabaseReadWriteTransaction *)transaction;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/SignalServiceKit/src/Storage/TSYapDatabaseObject.m
+++ b/SignalServiceKit/src/Storage/TSYapDatabaseObject.m
@@ -109,17 +109,20 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (YapDatabaseConnection *)dbReadConnection
 {
+    OWSAssert(![NSThread isMainThread]);
+    
     // We use TSYapDatabaseObject's dbReadWriteConnection (not OWSPrimaryStorage's
     // dbReadConnection) for consistency, since we tend to [TSYapDatabaseObject
     // save] and want to write to the same connection we read from.  To get true
     // consistency, we'd want to update entities by reading & writing from within
     // the same transaction, but that'll be a big refactor.
-
     return self.dbReadWriteConnection;
 }
 
 + (YapDatabaseConnection *)dbReadWriteConnection
 {
+    OWSAssert(![NSThread isMainThread]);
+
     // Use a dedicated connection for model reads & writes.
     static YapDatabaseConnection *dbReadWriteConnection = nil;
     static dispatch_once_t onceToken;

--- a/SignalServiceKit/src/Storage/TSYapDatabaseObject.m
+++ b/SignalServiceKit/src/Storage/TSYapDatabaseObject.m
@@ -109,8 +109,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (YapDatabaseConnection *)dbReadConnection
 {
-    OWSAssert(![NSThread isMainThread]);
-    
+    //    OWSAssert(![NSThread isMainThread]);
+
     // We use TSYapDatabaseObject's dbReadWriteConnection (not OWSPrimaryStorage's
     // dbReadConnection) for consistency, since we tend to [TSYapDatabaseObject
     // save] and want to write to the same connection we read from.  To get true
@@ -121,7 +121,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (YapDatabaseConnection *)dbReadWriteConnection
 {
-    OWSAssert(![NSThread isMainThread]);
+    //    OWSAssert(![NSThread isMainThread]);
 
     // Use a dedicated connection for model reads & writes.
     static YapDatabaseConnection *dbReadWriteConnection = nil;

--- a/SignalServiceKit/src/Storage/TSYapDatabaseObject.m
+++ b/SignalServiceKit/src/Storage/TSYapDatabaseObject.m
@@ -109,7 +109,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (YapDatabaseConnection *)dbReadConnection
 {
-    //    OWSAssert(![NSThread isMainThread]);
+    OWSJanksUI();
 
     // We use TSYapDatabaseObject's dbReadWriteConnection (not OWSPrimaryStorage's
     // dbReadConnection) for consistency, since we tend to [TSYapDatabaseObject
@@ -121,7 +121,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (YapDatabaseConnection *)dbReadWriteConnection
 {
-    //    OWSAssert(![NSThread isMainThread]);
+    OWSJanksUI();
 
     // Use a dedicated connection for model reads & writes.
     static YapDatabaseConnection *dbReadWriteConnection = nil;

--- a/SignalServiceKit/src/Util/OWSAsserts.h
+++ b/SignalServiceKit/src/Util/OWSAsserts.h
@@ -150,4 +150,26 @@ void SwiftAssertIsOnMainThread(NSString *functionName);
                                      userInfo:userInfoParam];                                                          \
     }
 
+
+// UI JANK
+//
+// In pursuit of smooth UI, we want to continue moving blocking operations off the main thread.
+// Add `OWSJanksUI` in code paths that shouldn't be called on the main thread.
+// Because we have pervasively broken this tenant, enabling it by default would be too disruptive
+// but it's helpful while unjanking and maybe someday we can have it enabled by default.
+//#define DEBUG_UI_JANK 1
+
+#ifdef DEBUG
+#ifdef DEBUG_UI_JANK
+#define OWSJanksUI()                                                                                                   \
+    do {                                                                                                               \
+        OWSAssert(![NSThread isMainThread])                                                                            \
+    } while (NO)
+#endif
+#endif
+
+#ifndef OWSJanksUI
+#define OWSJanksUI()
+#endif
+
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Some changes to make scrolling the home screen smoother.

Esentially:

1. Get all data needed for the homeview via explicit db transactions, so we can be sure we're getting it via the uiDBConnection (as opposed to the shared/sometimes-blocked db connections).

2. Move all those db calls onto a new "ThreadModel" view model. It has everything we need to render a HomeViewCell already loaded.

2. a simple cache scheme for these ThreadModel view models

PTAL @charlesmchen 