### PR TITLE
db view corruption

### DIFF
--- a/Signal.xcodeproj/project.pbxproj
+++ b/Signal.xcodeproj/project.pbxproj
@@ -302,6 +302,7 @@
 		45360B901F9527DA00FA666C /* SearcherTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45360B8F1F9527DA00FA666C /* SearcherTest.swift */; };
 		45360B911F952AA900FA666C /* MarqueeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E5A6981F61E6DD001E4A8A /* MarqueeLabel.swift */; };
 		4539B5861F79348F007141FF /* PushRegistrationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4539B5851F79348F007141FF /* PushRegistrationManager.swift */; };
+		4542DF54208D40AC007B4E76 /* LoadingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4542DF53208D40AC007B4E76 /* LoadingViewController.swift */; };
 		45464DBC1DFA041F001D3FD6 /* DataChannelMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45464DBB1DFA041F001D3FD6 /* DataChannelMessage.swift */; };
 		454A84042059C787008B8C75 /* MediaTileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 454A84032059C787008B8C75 /* MediaTileViewController.swift */; };
 		454A965A1FD6017E008D2A0E /* SignalAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34D913491F62D4A500722898 /* SignalAttachment.swift */; };
@@ -919,6 +920,7 @@
 		45360B8F1F9527DA00FA666C /* SearcherTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearcherTest.swift; sourceTree = "<group>"; };
 		4539B5851F79348F007141FF /* PushRegistrationManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PushRegistrationManager.swift; sourceTree = "<group>"; };
 		453CC0361D08E1A60040EBA3 /* sn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sn; path = translations/sn.lproj/Localizable.strings; sourceTree = "<group>"; };
+		4542DF53208D40AC007B4E76 /* LoadingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingViewController.swift; sourceTree = "<group>"; };
 		45464DBB1DFA041F001D3FD6 /* DataChannelMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataChannelMessage.swift; sourceTree = "<group>"; };
 		454A84032059C787008B8C75 /* MediaTileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaTileViewController.swift; sourceTree = "<group>"; };
 		454A965E1FD60EA2008D2A0E /* OWSFlatButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = OWSFlatButton.swift; path = SignalMessaging/Views/OWSFlatButton.swift; sourceTree = SOURCE_ROOT; };
@@ -1639,6 +1641,7 @@
 				34B3F86E1E8DF1700035BE1A /* SignalsNavigationController.m */,
 				340FC897204DAC8D007AEB0F /* ThreadSettings */,
 				34D1F0BE1F8EC1760066283D /* Utils */,
+				4542DF53208D40AC007B4E76 /* LoadingViewController.swift */,
 			);
 			path = ViewControllers;
 			sourceTree = "<group>";
@@ -3270,6 +3273,7 @@
 				452314A01F7E9E18003A428C /* DirectionalPanGestureRecognizer.swift in Sources */,
 				34330AA31E79686200DF2FB9 /* OWSProgressView.m in Sources */,
 				45D2AC02204885170033C692 /* OWS2FAReminderViewController.swift in Sources */,
+				4542DF54208D40AC007B4E76 /* LoadingViewController.swift in Sources */,
 				34D5CCA91EAE3D30005515DB /* AvatarViewHelper.m in Sources */,
 				34D1F0B71F87F8850066283D /* OWSGenericAttachmentView.m in Sources */,
 				34B3F8801E8DF1700035BE1A /* InviteFlow.swift in Sources */,

--- a/Signal/src/AppDelegate.m
+++ b/Signal/src/AppDelegate.m
@@ -61,6 +61,8 @@ static NSString *const kInitialViewControllerIdentifier = @"UserInitialViewContr
 static NSString *const kURLSchemeSGNLKey                = @"sgnl";
 static NSString *const kURLHostVerifyPrefix             = @"verify";
 
+static NSTimeInterval launchStartedAt;
+
 @interface AppDelegate ()
 
 @property (nonatomic) BOOL hasInitialRootViewController;
@@ -103,6 +105,8 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
 
     // This should be the first thing we do.
     SetCurrentAppContext([MainAppContext new]);
+
+    launchStartedAt = CACurrentMediaTime();
 
     BOOL isLoggingEnabled;
 #ifdef DEBUG
@@ -171,8 +175,8 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
     UIWindow *mainWindow = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
     self.window = mainWindow;
     CurrentAppContext().mainWindow = mainWindow;
-    // Show the launch screen until the async database view registrations are complete.
-    mainWindow.rootViewController = [self loadingRootViewController];
+    // Show LoadingViewController until the async database view registrations are complete.
+    mainWindow.rootViewController = [LoadingViewController new];
     [mainWindow makeKeyAndVisible];
 
     // performUpdateCheck must be invoked after Environment has been initialized because
@@ -310,11 +314,9 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
 
     self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
 
-    // Show the launch screen until the async database view registrations are complete.
-    //
-    // Note: we void using loadingRootViewController, since it will indirectly try to
-    // instantiate primary storage, which will fail.
-    self.window.rootViewController = [self loadingRootViewControllerWithShowUpgradeWarning:NO];
+    // Show the launch screen
+    self.window.rootViewController =
+        [[UIStoryboard storyboardWithName:@"Launch Screen" bundle:nil] instantiateInitialViewController];
 
     [self.window makeKeyAndVisible];
 
@@ -409,74 +411,6 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
     free(machine);
 
     DDLogInfo(@"iPhone Version: %@", platform);
-}
-
-- (UIViewController *)loadingRootViewController
-{
-    NSString *lastLaunchedAppVersion = AppVersion.instance.lastAppVersion;
-    NSString *lastCompletedLaunchAppVersion = AppVersion.instance.lastCompletedLaunchAppVersion;
-    // Every time we change or add a database view in such a way that
-    // might cause a delay on launch, we need to bump this constant.
-    //
-    // We added a database view in v2.23.0.
-    NSString *kLastVersionWithDatabaseViewChange = @"2.23.0";
-    BOOL mayNeedUpgrade = ([TSAccountManager isRegistered] && lastLaunchedAppVersion
-        && (!lastCompletedLaunchAppVersion ||
-               [VersionMigrations isVersion:lastCompletedLaunchAppVersion
-                                   lessThan:kLastVersionWithDatabaseViewChange]));
-    DDLogInfo(@"%@ mayNeedUpgrade: %d", self.logTag, mayNeedUpgrade);
-
-    return [self loadingRootViewControllerWithShowUpgradeWarning:mayNeedUpgrade];
-}
-
-- (UIViewController *)loadingRootViewControllerWithShowUpgradeWarning:(BOOL)showUpgradeWarning
-{
-    UIViewController *viewController =
-        [[UIStoryboard storyboardWithName:@"Launch Screen" bundle:nil] instantiateInitialViewController];
-
-    if (!showUpgradeWarning) {
-        return viewController;
-    }
-
-    UIView *rootView = viewController.view;
-    UIImageView *iconView = nil;
-    for (UIView *subview in viewController.view.subviews) {
-        if ([subview isKindOfClass:[UIImageView class]]) {
-            iconView = (UIImageView *)subview;
-            break;
-        }
-    }
-    if (!iconView) {
-        OWSFail(@"Database view registration overlay has unexpected contents.");
-        return viewController;
-    }
-
-    UILabel *bottomLabel = [UILabel new];
-    bottomLabel.text = NSLocalizedString(
-        @"DATABASE_VIEW_OVERLAY_SUBTITLE", @"Subtitle shown while the app is updating its database.");
-    bottomLabel.font = [UIFont ows_mediumFontWithSize:16.f];
-    bottomLabel.textColor = [UIColor whiteColor];
-    bottomLabel.numberOfLines = 0;
-    bottomLabel.lineBreakMode = NSLineBreakByWordWrapping;
-    bottomLabel.textAlignment = NSTextAlignmentCenter;
-    [rootView addSubview:bottomLabel];
-
-    UILabel *topLabel = [UILabel new];
-    topLabel.text
-        = NSLocalizedString(@"DATABASE_VIEW_OVERLAY_TITLE", @"Title shown while the app is updating its database.");
-    topLabel.font = [UIFont ows_mediumFontWithSize:20.f];
-    topLabel.textColor = [UIColor whiteColor];
-    topLabel.numberOfLines = 0;
-    topLabel.lineBreakMode = NSLineBreakByWordWrapping;
-    topLabel.textAlignment = NSTextAlignmentCenter;
-    [rootView addSubview:topLabel];
-
-    [bottomLabel autoPinWidthToSuperviewWithMargin:20.f];
-    [topLabel autoPinWidthToSuperviewWithMargin:20.f];
-    [bottomLabel autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:topLabel withOffset:10.f];
-    [iconView autoPinEdge:ALEdgeTop toEdge:ALEdgeBottom ofView:bottomLabel withOffset:40.f];
-
-    return viewController;
 }
 
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
@@ -1150,7 +1084,7 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
     [self enableBackgroundRefreshIfNecessary];
 
     if ([TSAccountManager isRegistered]) {
-        DDLogInfo(@"localNumber: %@", [TSAccountManager localNumber]);
+        DDLogInfo(@"%@ localNumber: %@", [TSAccountManager localNumber], self.logTag);
 
         [[OWSPrimaryStorage sharedManager].newDatabaseConnection
             readWriteWithBlock:^(YapDatabaseReadWriteTransaction *_Nonnull transaction) {
@@ -1182,7 +1116,8 @@ static NSString *const kURLHostVerifyPrefix             = @"verify";
     }
     self.hasInitialRootViewController = YES;
 
-    DDLogInfo(@"%@ Presenting initial root view controller", self.logTag);
+    NSTimeInterval startupDuration = CACurrentMediaTime() - launchStartedAt;
+    DDLogInfo(@"%@ Presenting app %.2f seconds after launch started.", self.logTag, startupDuration);
 
     if ([TSAccountManager isRegistered]) {
         HomeViewController *homeView = [HomeViewController new];

--- a/Signal/src/ViewControllers/AppSettings/AboutTableViewController.m
+++ b/Signal/src/ViewControllers/AppSettings/AboutTableViewController.m
@@ -79,21 +79,43 @@
         attachmentCount = [transaction numberOfKeysInCollection:[TSAttachment collection]];
     }];
 
+    NSByteCountFormatter *byteCountFormatter = [NSByteCountFormatter new];
+
+    // format counts with thousands separator
+    NSNumberFormatter *numberFormatter = [NSNumberFormatter new];
+    numberFormatter.formatterBehavior = NSNumberFormatterBehavior10_4;
+    numberFormatter.numberStyle = NSNumberFormatterDecimalStyle;
+
     OWSTableSection *debugSection = [OWSTableSection new];
+
     debugSection.headerTitle = @"Debug";
-    [debugSection addItem:[OWSTableItem labelItemWithText:[NSString stringWithFormat:@"Threads: %zd", threadCount]]];
-    [debugSection addItem:[OWSTableItem labelItemWithText:[NSString stringWithFormat:@"Messages: %zd", messageCount]]];
+
+    NSString *formattedThreadCount = [numberFormatter stringFromNumber:@(threadCount)];
     [debugSection
-        addItem:[OWSTableItem labelItemWithText:[NSString stringWithFormat:@"Attachments: %zd", attachmentCount]]];
+        addItem:[OWSTableItem labelItemWithText:[NSString stringWithFormat:@"Threads: %@", formattedThreadCount]]];
+
+    NSString *formattedMessageCount = [numberFormatter stringFromNumber:@(messageCount)];
     [debugSection
-        addItem:[OWSTableItem labelItemWithText:[NSString stringWithFormat:@"Database size: %llu",
-                                                          [OWSPrimaryStorage.sharedManager databaseFileSize]]]];
+        addItem:[OWSTableItem labelItemWithText:[NSString stringWithFormat:@"Messages: %@", formattedMessageCount]]];
+
+    NSString *formattedAttachmentCount = [numberFormatter stringFromNumber:@(attachmentCount)];
+    [debugSection addItem:[OWSTableItem labelItemWithText:[NSString stringWithFormat:@"Attachments: %@",
+                                                                    formattedAttachmentCount]]];
+
+    NSString *dbSize =
+        [byteCountFormatter stringFromByteCount:(long long)[OWSPrimaryStorage.sharedManager databaseFileSize]];
+    [debugSection addItem:[OWSTableItem labelItemWithText:[NSString stringWithFormat:@"Database size: %@", dbSize]]];
+
+    NSString *dbWALSize =
+        [byteCountFormatter stringFromByteCount:(long long)[OWSPrimaryStorage.sharedManager databaseWALFileSize]];
     [debugSection
-        addItem:[OWSTableItem labelItemWithText:[NSString stringWithFormat:@"Database WAL size: %llu",
-                                                          [OWSPrimaryStorage.sharedManager databaseWALFileSize]]]];
+        addItem:[OWSTableItem labelItemWithText:[NSString stringWithFormat:@"Database WAL size: %@", dbWALSize]]];
+
+    NSString *dbSHMSize =
+        [byteCountFormatter stringFromByteCount:(long long)[OWSPrimaryStorage.sharedManager databaseSHMFileSize]];
     [debugSection
-        addItem:[OWSTableItem labelItemWithText:[NSString stringWithFormat:@"Database SHM size: %llu",
-                                                          [OWSPrimaryStorage.sharedManager databaseSHMFileSize]]]];
+        addItem:[OWSTableItem labelItemWithText:[NSString stringWithFormat:@"Database SHM size: %@", dbSHMSize]]];
+
     [contents addSection:debugSection];
 
     OWSPreferences *preferences = [Environment preferences];

--- a/Signal/src/ViewControllers/LoadingViewController.swift
+++ b/Signal/src/ViewControllers/LoadingViewController.swift
@@ -1,0 +1,102 @@
+//
+//  Copyright (c) 2018 Open Whisper Systems. All rights reserved.
+//
+
+import Foundation
+import PromiseKit
+
+// The initial presentation is intended to be indistinguishable from the Launch Screen.
+// After a delay we present some "loading" UI so the user doesn't think the app is frozen.
+@objc
+public class LoadingViewController: UIViewController {
+
+    var logoView: UIImageView!
+    var topLabel: UILabel!
+    var bottomLabel: UILabel!
+
+    override public func loadView() {
+        self.view = UIView()
+        view.backgroundColor = UIColor.ows_materialBlue
+
+        self.logoView = UIImageView(image: #imageLiteral(resourceName: "logoSignal"))
+        view.addSubview(logoView)
+
+        logoView.autoCenterInSuperview()
+        logoView.autoPinToSquareAspectRatio()
+        logoView.autoMatch(.width, to: .width, of: view, withMultiplier: 1/3)
+
+        self.topLabel = buildLabel()
+        topLabel.alpha = 0
+        topLabel.font = UIFont.ows_dynamicTypeTitle2
+        topLabel.text = NSLocalizedString("DATABASE_VIEW_OVERLAY_TITLE", comment: "Title shown while the app is updating its database.")
+
+        self.bottomLabel = buildLabel()
+        bottomLabel.alpha = 0
+        bottomLabel.font = UIFont.ows_dynamicTypeBody
+        bottomLabel.text = NSLocalizedString("DATABASE_VIEW_OVERLAY_SUBTITLE", comment: "Subtitle shown while the app is updating its database.")
+
+        let labelStack = UIStackView(arrangedSubviews: [topLabel, bottomLabel])
+        labelStack.axis = .vertical
+        labelStack.alignment = .center
+        labelStack.spacing = 8
+        view.addSubview(labelStack)
+
+        labelStack.autoPinEdge(.top, to: .bottom, of: logoView, withOffset: 20)
+        labelStack.autoPinLeadingToSuperviewMargin()
+        labelStack.autoPinTrailingToSuperviewMargin()
+        labelStack.setCompressionResistanceHigh()
+        labelStack.setContentHuggingHigh()
+    }
+
+    var isShowingTopLabel = false
+    var isShowingBottomLabel = false
+    override public func viewDidAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        // We only show the "loading" UI if it's a slow launch. Otherwise this ViewController
+        // shoudl be indistinguishable from the launch screen.
+        let kTopLabelThreshold: TimeInterval = 5
+        DispatchQueue.main.asyncAfter(deadline: .now() + kTopLabelThreshold) { [weak self] in
+            guard let strongSelf = self else {
+                return
+            }
+
+            guard !strongSelf.isShowingTopLabel else {
+                return
+            }
+
+            strongSelf.isShowingTopLabel = true
+            UIView.animate(withDuration: 0.1) {
+                strongSelf.topLabel.alpha = 1
+            }
+            UIView.animate(withDuration: 0.9, delay: 2, options: [.autoreverse, .repeat, .curveEaseInOut], animations: {
+                strongSelf.topLabel.alpha = 0.2
+            }, completion: nil)
+        }
+
+        let kBottomLabelThreshold: TimeInterval = 15
+        DispatchQueue.main.asyncAfter(deadline: .now() + kBottomLabelThreshold) { [weak self] in
+            guard let strongSelf = self else {
+                return
+            }
+            guard !strongSelf.isShowingBottomLabel else {
+                return
+            }
+
+            strongSelf.isShowingBottomLabel = true
+            UIView.animate(withDuration: 0.1) {
+                strongSelf.bottomLabel.alpha = 1
+            }
+        }
+    }
+
+    private func buildLabel() -> UILabel {
+        let label = UILabel()
+
+        label.textColor = .white
+        label.numberOfLines = 0
+        label.lineBreakMode = .byWordWrapping
+
+        return label
+    }
+}

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -497,7 +497,7 @@
 "DATABASE_VIEW_OVERLAY_SUBTITLE" = "This can take a few minutes.";
 
 /* Title shown while the app is updating its database. */
-"DATABASE_VIEW_OVERLAY_TITLE" = "Updating Database";
+"DATABASE_VIEW_OVERLAY_TITLE" = "Optimizing Database";
 
 /* The current day. */
 "DATE_TODAY" = "Today";

--- a/SignalServiceKit/src/Storage/TSDatabaseView.m
+++ b/SignalServiceKit/src/Storage/TSDatabaseView.m
@@ -162,7 +162,7 @@ NSString *const TSLazyRestoreAttachmentsGroup = @"TSLazyRestoreAttachmentsGroup"
 
     [self registerMessageDatabaseViewWithName:TSMessageDatabaseViewExtensionName
                                  viewGrouping:viewGrouping
-                                      version:@"1"
+                                      version:@"2"
                                       storage:storage];
 }
 


### PR DESCRIPTION
PTAL @charlesmchen 

Rebuilding the messages view seems sufficient to recover the no-longer appearing message.

An iPhone5 with 100k messages takes 10mins to rebuild this view, so though it's faster than the SAE upgrade which rebuilt all views, it's still not cheap. It translates pretty linearly, so I'd expect most users one-time slow load to be a minute or less. 

e.g. an iPhone7 w/ 60k messages took 30s.

screenshot (not "Optimizing Database" is animated - flashing slowly)

<img width="559" alt="screen shot 2018-04-23 at 12 54 22 pm" src="https://user-images.githubusercontent.com/36971200/39141332-81edba0a-46f5-11e8-87b0-542a7e8d9e2e.png">
