### PR TITLE
Charlesmchen/input toolbar fix

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
@@ -117,6 +117,68 @@ typedef enum : NSUInteger {
 
 #pragma mark -
 
+@interface OWSImagePickerController : UIImagePickerController
+
+@end
+
+#pragma mark -
+
+@implementation OWSImagePickerController
+
+- (void)viewWillAppear:(BOOL)animated
+{
+    [super viewWillAppear:animated];
+
+    [self becomeFirstResponder];
+}
+
+- (void)viewDidAppear:(BOOL)animated
+{
+    [super viewDidAppear:animated];
+
+    [self becomeFirstResponder];
+}
+
+- (BOOL)canBecomeFirstResponder
+{
+    return YES;
+}
+
+@end
+
+#pragma mark -
+
+@interface OWSDocumentMenuViewController : UIDocumentMenuViewController
+
+@end
+
+#pragma mark -
+
+@implementation OWSDocumentMenuViewController
+
+- (void)viewWillAppear:(BOOL)animated
+{
+    [super viewWillAppear:animated];
+
+    [self becomeFirstResponder];
+}
+
+- (void)viewDidAppear:(BOOL)animated
+{
+    [super viewDidAppear:animated];
+
+    [self becomeFirstResponder];
+}
+
+- (BOOL)canBecomeFirstResponder
+{
+    return YES;
+}
+
+@end
+
+#pragma mark -
+
 @interface ConversationViewController () <AttachmentApprovalViewControllerDelegate,
     AVAudioPlayerDelegate,
     ContactsViewHelperDelegate,
@@ -2547,7 +2609,7 @@ typedef enum : NSUInteger {
     // TODO: UIDocumentMenuViewController is deprecated; we should use UIDocumentPickerViewController
     //       instead.
     UIDocumentMenuViewController *menuController =
-        [[UIDocumentMenuViewController alloc] initWithDocumentTypes:documentTypes inMode:pickerMode];
+        [[OWSDocumentMenuViewController alloc] initWithDocumentTypes:documentTypes inMode:pickerMode];
     menuController.delegate = self;
 
     UIImage *takeMediaImage = [UIImage imageNamed:@"actionsheet_camera_black"];
@@ -2718,7 +2780,7 @@ typedef enum : NSUInteger {
             return;
         }
 
-        UIImagePickerController *picker = [UIImagePickerController new];
+        UIImagePickerController *picker = [OWSImagePickerController new];
         picker.sourceType = UIImagePickerControllerSourceTypeCamera;
         picker.mediaTypes = @[ (__bridge NSString *)kUTTypeImage, (__bridge NSString *)kUTTypeMovie ];
         picker.allowsEditing = NO;
@@ -2755,7 +2817,7 @@ typedef enum : NSUInteger {
             return;
         }
 
-        UIImagePickerController *picker = [UIImagePickerController new];
+        UIImagePickerController *picker = [OWSImagePickerController new];
         picker.sourceType = UIImagePickerControllerSourceTypePhotoLibrary;
         picker.delegate = self;
         picker.mediaTypes = @[ (__bridge NSString *)kUTTypeImage, (__bridge NSString *)kUTTypeMovie ];

--- a/Signal/src/ViewControllers/GifPicker/GifPickerViewController.swift
+++ b/Signal/src/ViewControllers/GifPicker/GifPickerViewController.swift
@@ -53,6 +53,10 @@ class GifPickerViewController: OWSViewController, UISearchBarDelegate, UICollect
 
     var progressiveSearchTimer: Timer?
 
+    override public var canBecomeFirstResponder: Bool {
+        return true
+    }
+
     // MARK: Initializers
 
     @available(*, unavailable, message:"use other constructor instead.")
@@ -129,6 +133,12 @@ class GifPickerViewController: OWSViewController, UISearchBarDelegate, UICollect
                                                selector: #selector(didBecomeActive),
                                                name: NSNotification.Name.OWSApplicationDidBecomeActive,
                                                object: nil)
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        self.becomeFirstResponder()
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/Signal/src/ViewControllers/MediaGalleryViewController.swift
+++ b/Signal/src/ViewControllers/MediaGalleryViewController.swift
@@ -199,6 +199,10 @@ class MediaGalleryViewController: UINavigationController, MediaGalleryDataSource
     // we start with a small range size for quick loading.
     private let fetchRangeSize: UInt = 10
 
+    override public var canBecomeFirstResponder: Bool {
+        return true
+    }
+
     deinit {
         Logger.debug("\(logTag) deinit")
     }
@@ -244,6 +248,18 @@ class MediaGalleryViewController: UINavigationController, MediaGalleryDataSource
         presentationView.layer.minificationFilter = kCAFilterTrilinear
         presentationView.layer.magnificationFilter = kCAFilterTrilinear
         presentationView.contentMode = .scaleAspectFit
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        self.becomeFirstResponder()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        self.becomeFirstResponder()
     }
 
     // MARK: Present/Dismiss


### PR DESCRIPTION
PTAL @michaelkirk 

This fixes a few more scenarios where it's really easy to get the input toolbar to reappear (present view X from conversation view, send app to background, return to app), but I can't help but feel that instead of trying to mop up N leaks we should fix some root cause elsewhere.  

Also, some manifestations of this problem can't be fixed. i.e. `UIAlertController` can't be subclassed.