### PR TITLE
Ensure thread safety in phone parsing logic.

### DIFF
--- a/SignalServiceKit/src/Contacts/PhoneNumber.m
+++ b/SignalServiceKit/src/Contacts/PhoneNumber.m
@@ -40,7 +40,7 @@ static NSString *const RPDefaultsKeyPhoneNumberCanonical = @"RPDefaultsKeyPhoneN
     OWSAssert(text != nil);
     OWSAssert(regionCode != nil);
 
-    PhoneNumberUtil *phoneUtil = [PhoneNumberUtil sharedUtil];
+    PhoneNumberUtil *phoneUtil = [PhoneNumberUtil sharedThreadLocal];
 
     NSError *parseError   = nil;
     NBPhoneNumber *number = [phoneUtil parse:text defaultRegion:regionCode error:&parseError];
@@ -71,7 +71,7 @@ static NSString *const RPDefaultsKeyPhoneNumberCanonical = @"RPDefaultsKeyPhoneN
 
     NSString *_Nullable countryCode = nil;
 #if TARGET_OS_IPHONE
-    countryCode = [[PhoneNumberUtil sharedUtil].nbPhoneNumberUtil countryCodeByCarrier];
+    countryCode = [[PhoneNumberUtil sharedThreadLocal].nbPhoneNumberUtil countryCodeByCarrier];
 
     if ([countryCode isEqualToString:@"ZZ"]) {
         countryCode = [locale objectForKey:NSLocaleCountryCode];
@@ -164,7 +164,7 @@ static NSString *const RPDefaultsKeyPhoneNumberCanonical = @"RPDefaultsKeyPhoneN
 }
 
 + (NSString *)regionCodeFromCountryCodeString:(NSString *)countryCodeString {
-    NBPhoneNumberUtil *phoneUtil = [PhoneNumberUtil sharedUtil].nbPhoneNumberUtil;
+    NBPhoneNumberUtil *phoneUtil = [PhoneNumberUtil sharedThreadLocal].nbPhoneNumberUtil;
     NSString *regionCode =
         [phoneUtil getRegionCodeForCountryCode:@([[countryCodeString substringFromIndex:1] integerValue])];
     return regionCode;
@@ -381,11 +381,11 @@ static NSString *const RPDefaultsKeyPhoneNumberCanonical = @"RPDefaultsKeyPhoneN
 }
 
 - (BOOL)isValid {
-    return [[PhoneNumberUtil sharedUtil].nbPhoneNumberUtil isValidNumber:self.phoneNumber];
+    return [[PhoneNumberUtil sharedThreadLocal].nbPhoneNumberUtil isValidNumber:self.phoneNumber];
 }
 
 - (NSString *)localizedDescriptionForUser {
-    NBPhoneNumberUtil *phoneUtil = [PhoneNumberUtil sharedUtil].nbPhoneNumberUtil;
+    NBPhoneNumberUtil *phoneUtil = [PhoneNumberUtil sharedThreadLocal].nbPhoneNumberUtil;
 
     NSError *formatError = nil;
     NSString *pretty =

--- a/SignalServiceKit/src/Contacts/PhoneNumberUtil.h
+++ b/SignalServiceKit/src/Contacts/PhoneNumberUtil.h
@@ -1,13 +1,17 @@
 //
-//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//  Copyright (c) 2018 Open Whisper Systems. All rights reserved.
 //
 
-#import <libPhoneNumber_iOS/NBPhoneNumberUtil.h>
 #import "PhoneNumber.h"
+#import <libPhoneNumber_iOS/NBPhoneNumberUtil.h>
 
 @interface PhoneNumberUtil : NSObject
 
 @property (nonatomic, retain) NBPhoneNumberUtil *nbPhoneNumberUtil;
+
+- (instancetype)init NS_UNAVAILABLE;
+
++ (instancetype)sharedThreadLocal;
 
 + (BOOL)name:(NSString *)nameString matchesQuery:(NSString *)queryString;
 
@@ -27,8 +31,6 @@
                     stickingRightward:(bool)preferHigh;
 
 + (NSString *)examplePhoneNumberForCountryCode:(NSString *)countryCode;
-
-+ (instancetype)sharedUtil;
 
 - (NBPhoneNumber *)parse:(NSString *)numberToParse defaultRegion:(NSString *)defaultRegion error:(NSError **)error;
 - (NSString *)format:(NBPhoneNumber *)phoneNumber


### PR DESCRIPTION
The thread locals won't share a cache, but I don't think that'll be too expensive in terms of memory (it caches a set of short strings) or perf (each system contact fetch will take place on a single thread so cache will quickly warm).

PTAL @michaelkirk 