### PR TITLE
Avoid spurious "Disabled Disappearing Messages"

### DIFF
--- a/Signal/src/ViewControllers/DebugUI/DebugUIMisc.m
+++ b/Signal/src/ViewControllers/DebugUI/DebugUIMisc.m
@@ -69,6 +69,18 @@ NS_ASSUME_NONNULL_BEGIN
                                          [DebugUIMisc clearHasDismissedOffers];
                                      }]];
 
+    [items addObject:[OWSTableItem itemWithTitle:@"Delete disappearing messages config"
+                                     actionBlock:^{
+                                         [[OWSPrimaryStorage sharedManager].newDatabaseConnection readWriteWithBlock:^(
+                                             YapDatabaseReadWriteTransaction *_Nonnull transaction) {
+                                             OWSDisappearingMessagesConfiguration *config =
+                                                 [OWSDisappearingMessagesConfiguration
+                                                     fetchOrCreateDefaultWithThreadId:thread.uniqueId
+                                                                          transaction:transaction];
+                                             [config removeWithTransaction:transaction];
+                                         }];
+                                     }]];
+
     [items addObject:[OWSTableItem
                          itemWithTitle:@"Re-register"
                            actionBlock:^{

--- a/SignalServiceKit/src/Contacts/OWSDisappearingMessagesConfiguration.m
+++ b/SignalServiceKit/src/Contacts/OWSDisappearingMessagesConfiguration.m
@@ -44,8 +44,8 @@ NS_ASSUME_NONNULL_BEGIN
 
     _enabled = isEnabled;
     _durationSeconds = seconds;
-    _originalDictionaryValue = [NSDictionary new];
     _newRecord = YES;
+    _originalDictionaryValue = self.dictionaryValue;
 
     return self;
 }


### PR DESCRIPTION
`dictionaryDidChange` was always true for new records.

I missed a case in https://github.com/signalapp/Signal-iOS/pull/3387 - for conversations which had never before used disappearing messages.

