### PR TITLE
cleanup contact syncing

### DIFF
--- a/SignalMessaging/contacts/OWSContactsSyncing.m
+++ b/SignalMessaging/contacts/OWSContactsSyncing.m
@@ -167,7 +167,7 @@ NSString *const kOWSPrimaryStorageOWSContactsSyncingLastMessageKey
         return;
     }
 
-    if ([TSAccountManager sharedInstance]) {
+    if ([TSAccountManager sharedInstance].isRegistered) {
         [self sendSyncContactsMessageIfNecessary];
     }
 }

--- a/SignalServiceKit/src/Account/TSAccountManager.h
+++ b/SignalServiceKit/src/Account/TSAccountManager.h
@@ -34,6 +34,7 @@ extern NSString *const kNSNotificationName_LocalNumberDidChange;
  *  @return registered or not
  */
 + (BOOL)isRegistered;
+- (BOOL)isRegistered;
 
 /**
  *  Returns current phone number for this device, which may not yet have been registered.


### PR DESCRIPTION
It's largely a redundant check anyway, but the previous typo was a
no-op.

PTAL @charlesmchen 