### PR TITLE
Fix crash converting images in SAE.

### DIFF
--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -136,6 +136,9 @@
 /* Attachment error message for image attachments in which metadata could not be removed */
 "ATTACHMENT_ERROR_COULD_NOT_REMOVE_METADATA" = "Unable to remove metadata from image.";
 
+/* Attachment error message for image attachments which could not be resized */
+"ATTACHMENT_ERROR_COULD_NOT_RESIZE_IMAGE" = "Could not resize image.";
+
 /* Attachment error message for attachments whose data exceed file size limits */
 "ATTACHMENT_ERROR_FILE_SIZE_TOO_LARGE" = "Attachment is too large.";
 


### PR DESCRIPTION
We need to this thoroughly since we don't know exactly why using UIGraphicsBeginImageContext() crashes in share extension after using auth UI, but under some light testing this approach seems to resolve the issue.

PTAL @michaelkirk 