### PR TITLE
Use case-insensitive comparison when sorting contacts.

### DIFF
--- a/SignalMessaging/contacts/OWSContactsManager.m
+++ b/SignalMessaging/contacts/OWSContactsManager.m
@@ -763,7 +763,7 @@ NSString *const OWSContactsManagerSignalAccountsDidChangeNotification
         NSString *leftName = [self comparableNameForSignalAccount:left];
         NSString *rightName = [self comparableNameForSignalAccount:right];
 
-        NSComparisonResult nameComparison = [leftName compare:rightName];
+        NSComparisonResult nameComparison = [leftName caseInsensitiveCompare:rightName];
         if (nameComparison == NSOrderedSame) {
             return [left.recipientId compare:right.recipientId];
         }


### PR DESCRIPTION
We manipulate case when rendering contact names but not when sorting them, which leads to surprising results.

PTAL @michaelkirk 