### PR TITLE
contact flow vs. navbar style issues

### DIFF
--- a/Signal/src/ViewControllers/ContactShareViewHelper.swift
+++ b/Signal/src/ViewControllers/ContactShareViewHelper.swift
@@ -158,23 +158,18 @@ public class ContactShareViewHelper: NSObject, CNContactViewControllerDelegate {
         contactViewController.delegate = self
         contactViewController.allowsActions = false
         contactViewController.allowsEditing = true
-        contactViewController.navigationItem.leftBarButtonItem = UIBarButtonItem(title: CommonStrings.cancelButton, style: .plain, target: self, action: #selector(didFinishEditingContact))
         contactViewController.navigationItem.leftBarButtonItem = UIBarButtonItem(title: CommonStrings.cancelButton,
                                                                                  style: .plain,
                                                                                  target: self,
                                                                                  action: #selector(didFinishEditingContact))
 
-        guard let navigationController = fromViewController.navigationController else {
-            owsFail("\(logTag) missing navigationController")
-            return
-        }
-
-        navigationController.pushViewController(contactViewController, animated: true)
-
         // HACK otherwise CNContactViewController Navbar is shown as black.
         // RADAR rdar://28433898 http://www.openradar.me/28433898
         // CNContactViewController incompatible with opaque navigation bar
         UIUtil.applyDefaultSystemAppearence()
+
+        let modal = UINavigationController(rootViewController: contactViewController)
+        fromViewController.present(modal, animated: true)
     }
 
     private func presentSelectAddToExistingContactView(contactShare: ContactShareViewModel, fromViewController: UIViewController) {
@@ -208,6 +203,7 @@ public class ContactShareViewHelper: NSObject, CNContactViewControllerDelegate {
             return
         }
 
+        UIUtil.applySignalAppearence()
         delegate.didCreateOrEditContact()
     }
 
@@ -219,6 +215,7 @@ public class ContactShareViewHelper: NSObject, CNContactViewControllerDelegate {
             return
         }
 
+        UIUtil.applySignalAppearence()
         delegate.didCreateOrEditContact()
     }
 }

--- a/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
@@ -5058,8 +5058,7 @@ interactionControllerForAnimationController:(id<UIViewControllerAnimatedTransiti
 - (void)didCreateOrEditContact
 {
     DDLogInfo(@"%@ in %s", self.logTag, __PRETTY_FUNCTION__);
-
-    [self.navigationController popToViewController:self animated:true];
+    [self dismissViewControllerAnimated:YES completion:nil];
 }
 
 @end

--- a/Signal/src/ViewControllers/MessageDetailViewController.swift
+++ b/Signal/src/ViewControllers/MessageDetailViewController.swift
@@ -720,12 +720,7 @@ class MessageDetailViewController: OWSViewController, MediaGalleryDataSourceDele
     // MARK: - ContactShareViewHelperDelegate
 
     public func didCreateOrEditContact() {
-        guard let navigationController = self.navigationController else {
-            owsFail("\(logTag) in \(#function) navigationController was unexpectedly nil")
-            return
-        }
-        navigationController.popToViewController(self, animated: true)
-
         updateContent()
+        self.dismiss(animated: true)
     }
 }


### PR DESCRIPTION
PTAL @charlesmchen 

Two issues:

1. Make sure we always return the navbar to the correct style. There were certain ways to leave the contact flow yet see navbar labels rendered black.

The issue occurs when mutating NavBar appearance when a navbar is hidden. i.e. if we weren't hiding the navbars in the OWS ContactViewController, this wouldn't occur (obviously for the design we want to hide these navbars, but it explains why we haven't seen this before.)

2. Present the "add a contact" modally. Since the "Add a contact" view needs to use the navbar (for the "done" and "cancel" buttons), animating the navbar back in for this view controller looks janky. 

Tested on iOS 9.4, 10.3, and 11.3