### PR TITLE
Only clean up messages while active

### DIFF
--- a/SignalServiceKit/src/Messages/OWSDisappearingMessagesJob.m
+++ b/SignalServiceKit/src/Messages/OWSDisappearingMessagesJob.m
@@ -364,6 +364,10 @@ void AssertIsOnDisappearingMessagesQueue()
     }
 
     dispatch_async(OWSDisappearingMessagesJob.serialQueue, ^{
+        if (!CurrentAppContext().isMainAppAndActive) {
+            DDLogInfo(@"%@ Ignoring fallbacktimer for app which is not main and active.", self.logTag);
+            return;
+        }
         NSUInteger deletedCount = [self runLoop];
 
         // Normally deletions should happen via the disappearanceTimer, to make sure that they're prompt.


### PR DESCRIPTION
Most of the 10deadCC crashes reported in beta were (6/8) happened while the the DisappearingMessages#runLoop was called - all of them in response to `fallbackTimerDidFire`.

You can see from the stack traces that we're crashing within the readWrite transaction - meaning we already have a background task started, so I didn't bother adding another one here.

My theory is that sometimes this timer is firing just as we're moving from background -> suspended, otherwise, if this timer is fired before we're in the background, the time allocated by the readWrite transaction's background task should be sufficient.

The counter theory is that for some reason this task is just taking much longer than the background task allows (>~30s).