### PR TITLE
Fix: input toolbar disappears when tapping media while edit menu is presented

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
@@ -2059,6 +2059,12 @@ typedef enum : NSUInteger {
 
     [self dismissKeyBoard];
 
+    // In case we were presenting edit menu, we need to become first responder before presenting another VC
+    // else UIKit won't restore first responder status to us when the presented VC is dismissed.
+    if (!self.isFirstResponder) {
+        [self becomeFirstResponder];
+    }
+
     if (![viewItem.interaction isKindOfClass:[TSMessage class]]) {
         OWSFail(@"Unexpected viewItem.interaction");
         return;
@@ -2082,6 +2088,11 @@ typedef enum : NSUInteger {
     OWSAssert(attachmentStream);
 
     [self dismissKeyBoard];
+    // In case we were presenting edit menu, we need to become first responder before presenting another VC
+    // else UIKit won't restore first responder status to us when the presented VC is dismissed.
+    if (!self.isFirstResponder) {
+        [self becomeFirstResponder];
+    }
 
     if (![viewItem.interaction isKindOfClass:[TSMessage class]]) {
         OWSFail(@"Unexpected viewItem.interaction");


### PR DESCRIPTION
Longer term I'd like to replace the UIMenuController with a custom look-a-like that avoids the first responder pattern.

PTAL @charlesmchen 