### PR TITLE
Don't use dynamic type in registration view... yet.

### DIFF
--- a/Signal/src/ViewControllers/Registration/RegistrationViewController.m
+++ b/Signal/src/ViewControllers/Registration/RegistrationViewController.m
@@ -94,7 +94,7 @@ NSString *const kKeychainKey_LastRegisteredPhoneNumber = @"kKeychainKey_LastRegi
 
     UILabel *legalTopMatterLabel = [UILabel new];
     legalTopMatterLabel.textColor = UIColor.whiteColor;
-    legalTopMatterLabel.font = UIFont.ows_dynamicTypeFootnoteFont;
+    legalTopMatterLabel.font = [UIFont ows_regularFontWithSize:ScaleFromIPhone5To7Plus(13.f, 15.f)];
     legalTopMatterLabel.numberOfLines = 0;
     legalTopMatterLabel.textAlignment = NSTextAlignmentCenter;
     legalTopMatterLabel.attributedText = attributedLegalTopMatter;
@@ -247,7 +247,7 @@ NSString *const kKeychainKey_LastRegisteredPhoneNumber = @"kKeychainKey_LastRegi
     NSString *bottomTermsLinkText = NSLocalizedString(@"REGISTRATION_LEGAL_TERMS_LINK",
         @"one line label below submit button on registration screen, which links to an external webpage.");
     UIButton *bottomLegalLinkButton = [UIButton new];
-    bottomLegalLinkButton.titleLabel.font = UIFont.ows_dynamicTypeFootnoteFont;
+    bottomLegalLinkButton.titleLabel.font = [UIFont ows_regularFontWithSize:ScaleFromIPhone5To7Plus(13.f, 15.f)];
     [bottomLegalLinkButton setTitleColor:UIColor.ows_materialBlueColor forState:UIControlStateNormal];
     [bottomLegalLinkButton setTitle:bottomTermsLinkText forState:UIControlStateNormal];
     [contentView addSubview:bottomLegalLinkButton];


### PR DESCRIPTION
Eventually we should convert this view to use dynamic type everywhere, but that would involve a bunch of work that we don't have time for before this release.

PTAL @michaelkirk 

### Before

![simulator screen shot - iphone se - 2018-06-01 at 12 31 22](https://user-images.githubusercontent.com/36971147/40852245-d073aa34-6597-11e8-9725-626185d9da97.png)

### After

![simulator screen shot - iphone se - 2018-06-01 at 12 30 24](https://user-images.githubusercontent.com/36971147/40852246-d08344da-6597-11e8-87e6-e1245271927c.png)
