### PR TITLE
Fixed settings button margin in home view controller, also fixes land…

### DIFF
--- a/Signal/src/ViewControllers/HomeView/HomeViewController.m
+++ b/Signal/src/ViewControllers/HomeView/HomeViewController.m
@@ -329,40 +329,11 @@ NSString *const kArchivedConversationsReuseIdentifier = @"kArchivedConversations
     if (self.homeViewMode != HomeViewMode_Inbox) {
         return;
     }
-    const CGFloat kBarButtonSize = 44;
-    // We use UIButtons with [UIBarButtonItem initWithCustomView:...] instead of
-    // UIBarButtonItem in order to ensure that these buttons are spaced tightly.
-    // The contents of the navigation bar are cramped in this view.
-    UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];
-    UIImage *image = [UIImage imageNamed:@"button_settings_white"];
-    [button setImage:image forState:UIControlStateNormal];
-    UIEdgeInsets imageEdgeInsets = UIEdgeInsetsZero;
-    // We normally would want to use left and right insets that ensure the button
-    // is square and the icon is centered.  However UINavigationBar doesn't offer us
-    // control over the margins and spacing of its content, and the buttons end up
-    // too far apart and too far from the edge of the screen. So we use a smaller
-    // leading inset tighten up the layout.
-    CGFloat hInset = round((kBarButtonSize - image.size.width) * 0.5f);
-    if (self.view.isRTL) {
-        imageEdgeInsets.right = hInset;
-        imageEdgeInsets.left = round((kBarButtonSize - (image.size.width + hInset)) * 0.5f);
-    } else {
-        imageEdgeInsets.left = hInset;
-        imageEdgeInsets.right = round((kBarButtonSize - (image.size.width + hInset)) * 0.5f);
-    }
-    imageEdgeInsets.top = round((kBarButtonSize - image.size.height) * 0.5f);
-    imageEdgeInsets.bottom = round(kBarButtonSize - (image.size.height + imageEdgeInsets.top));
-    button.imageEdgeInsets = imageEdgeInsets;
-    button.accessibilityLabel = CommonStrings.openSettingsButton;
 
-    [button addTarget:self action:@selector(settingsButtonPressed:) forControlEvents:UIControlEventTouchUpInside];
-    button.frame = CGRectMake(0,
-        0,
-        round(image.size.width + imageEdgeInsets.left + imageEdgeInsets.right),
-        round(image.size.height + imageEdgeInsets.top + imageEdgeInsets.bottom));
-    UIBarButtonItem *settingsButton = [[UIBarButtonItem alloc] initWithCustomView:button];
-    settingsButton.accessibilityLabel
-        = NSLocalizedString(@"SETTINGS_BUTTON_ACCESSIBILITY", @"Accessibility hint for the settings button");
+    //  Settings button.
+    UIImage *image = [UIImage imageNamed:@"button_settings_white"];
+    UIBarButtonItem *settingsButton = [[UIBarButtonItem alloc] initWithImage:image style:UIBarButtonItemStylePlain target:self action:@selector(settingsButtonPressed:)];
+    settingsButton.accessibilityLabel = CommonStrings.openSettingsButton;
     self.navigationItem.leftBarButtonItem = settingsButton;
 
     self.navigationItem.rightBarButtonItem =

--- a/Signal/translations/bin/auto-genstrings
+++ b/Signal/translations/bin/auto-genstrings
@@ -27,7 +27,7 @@ fi
 
 done
 
-JSQ_STRINGS_PATH="../JSQMessagesViewController/JSQMessagesViewController/Assets/JSQMessagesAssets.bundle/Base.lproj/JSQMessages.strings"
+JSQ_STRINGS_PATH="${REPO_ROOT}/Pods/JSQMessagesViewController/JSQMessagesViewController/Assets/JSQMessagesAssets.bundle/Base.lproj/JSQMessages.strings"
 if [ ! -f $JSQ_STRINGS_PATH ]; then
   echo "[!] Error. Expected to find strings for JSQMessagesViewController at ${JSQ_STRINGS_PATH}"
   exit 1

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -1873,9 +1873,6 @@
 /* Label for the block list section of the settings view */
 "SETTINGS_BLOCK_LIST_TITLE" = "Blocked";
 
-/* Accessibility hint for the settings button */
-"SETTINGS_BUTTON_ACCESSIBILITY" = "Settings";
-
 /* Table cell label */
 "SETTINGS_CALLING_HIDES_IP_ADDRESS_PREFERENCE_TITLE" = "Always Relay Calls";
 


### PR DESCRIPTION
…tches.

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [X] My commits are rebased on the latest master branch
- [X] My commits are in nice logical chunks
- [X] My contribution is fully baked and is ready to be merged as is
- [X] I have tested my contribution on these devices:
 * iPad Pro in iPhone compatibility mode.
 * iPhone 5S simulator
 * iPhone 8+ (landscape glitch doesn't manifest but margin does correct itself).

- - - - - - - - - -

### Description
I've started running Signal in landscape mode to see what needs to get fixed to enable it for good and as an intermediate step to getting an iPad version up. The first thing I noticed is that several of the nav bar icons appear squished when moving to landscape.

Looking at the logic a few things became apparent:
1) The custom UIBarButtonItem seems to have the opposite effect from what the extensive comments around its creation say, as it moves it further in and leaves less space in the nav bar. It's also unclear when the contents of the nav bar are cramped as even in an iPad in compatibility mode (original iPhone screen size) there's more than enough space for "Signal" and two icons.
2) The accessibility labels in the button and its wrapping UIBarButtonItem are the same and redundant. Most of the patch is removing the extra label from all localizations.

I may be missing something, like a UI state where there's a number of extra things in the nav bar or different behaviors in older versions of iOS for nav bar buttons, so let me know if that's the case. I'll add that once seen that the button is farther to the right than usual it cannot be unseen 😝

For reference, this is how the home view looks currently:

![screen shot 2018-06-10 at 12 54 46](https://user-images.githubusercontent.com/38818781/41205958-bf384d4e-6cb1-11e8-9701-7c30a6964f71.png)

And here's how it looks with the changes:

![patched screen shot 2018-06-10 at 12 51 27](https://user-images.githubusercontent.com/38818781/41205960-d02caba4-6cb1-11e8-884b-9f8c5adf7be7.png)

And for further reference (not that we'll be enabling landscape mode for now...), here's how landscape (manually enabled) mode looks in current master:

![screen shot 2018-06-10 at 12 54 34](https://user-images.githubusercontent.com/38818781/41206006-3dc178a2-6cb2-11e8-9f98-53acc3e4405a.png)

And here's how it looks with the patch:

![patched screen shot 2018-06-10 at 12 51 36](https://user-images.githubusercontent.com/38818781/41206011-47d7334a-6cb2-11e8-8ee7-8ca81379ba15.png)


Let me know if any further tweaks are needed to this patch or if there's a reason I'm unaware of to keep things as they are.