### PR TITLE
Fix: iOS10 was not respecting margins with our homebrew pin method

### DIFF
--- a/SignalMessaging/Views/ContactCellView.m
+++ b/SignalMessaging/Views/ContactCellView.m
@@ -94,8 +94,9 @@ const CGFloat kContactCellAvatarTextMargin = 12;
     hStackView.distribution = UIStackViewDistributionFill;
     [self addSubview:hStackView];
     [hStackView autoVCenterInSuperview];
-    [hStackView autoPinLeadingToSuperviewMargin];
-    [hStackView autoPinTrailingToSuperviewMargin];
+    [hStackView autoPinEdgeToSuperviewMargin:ALEdgeLeading];
+    [hStackView autoPinEdgeToSuperviewMargin:ALEdgeTrailing];
+
     // Ensure that the cell's contents never overflow the cell bounds.
     [hStackView autoPinEdgeToSuperviewMargin:ALEdgeTop relation:NSLayoutRelationGreaterThanOrEqual];
     [hStackView autoPinEdgeToSuperviewMargin:ALEdgeBottom relation:NSLayoutRelationGreaterThanOrEqual];


### PR DESCRIPTION
PTAL @charlesmchen

## before

![ios10-before](https://user-images.githubusercontent.com/36971200/41788441-ce7c0c9a-7608-11e8-841f-0e27d3cbbbef.png)

## after

![ios10 after](https://user-images.githubusercontent.com/36971200/41788440-ce547a04-7608-11e8-9ec8-74fdbcd8cf7d.png)

I haven't dug in much to find out what's different with our homebrew margin pinning method, but since it's used all over the place, I'd be hesitant to make any changes to that method during stabilization anyway.

