### PR TITLE
Mkirk/no unread status for search results

### DIFF
--- a/Signal/src/ViewControllers/HomeView/HomeViewCell.m
+++ b/Signal/src/ViewControllers/HomeView/HomeViewCell.m
@@ -191,7 +191,7 @@ NS_ASSUME_NONNULL_BEGIN
     self.dateTimeLabel.text
         = (overrideDate ? [self stringForDate:overrideDate] : [self stringForDate:thread.lastMessageDate]);
 
-    if (hasUnreadMessages) {
+    if (hasUnreadMessages && overrideSnippet == nil) {
         self.dateTimeLabel.textColor = [UIColor ows_blackColor];
         self.dateTimeLabel.font = self.unreadFont.ows_mediumWeight;
     } else {
@@ -200,7 +200,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     NSUInteger unreadCount = thread.unreadCount;
-    if (unreadCount == 0) {
+    if (unreadCount == 0 || overrideSnippet != nil) {
         [self.viewConstraints addObject:[self.payloadView autoPinTrailingToSuperviewMargin]];
     } else {
         [self.contentView addSubview:self.unreadBadge];

--- a/SignalMessaging/Views/ContactTableViewCell.m
+++ b/SignalMessaging/Views/ContactTableViewCell.m
@@ -93,7 +93,6 @@ NS_ASSUME_NONNULL_BEGIN
 
     [self.cellView prepareForReuse];
 
-    self.accessoryView = nil;
     self.accessoryType = UITableViewCellAccessoryNone;
 }
 


### PR DESCRIPTION
Don't show the unread badge or bold text for FTS message results (we still show them for conversation results).

PTAL @charlesmchen 

## before 

![before_messages](https://user-images.githubusercontent.com/36971200/41796682-bb1ee804-7624-11e8-8d44-f60abf7e4963.png)

## after messages

![after_messgaes](https://user-images.githubusercontent.com/36971200/41796683-bb330ba4-7624-11e8-95ff-8d370f77a5d5.png)

## after conversations 

![after_conversation](https://user-images.githubusercontent.com/36971200/41796684-bb447f88-7624-11e8-83c5-252df72863b9.png)
