### PR TITLE
FIX: compose search group cell

### DIFF
--- a/Signal/src/views/GroupTableViewCell.swift
+++ b/Signal/src/views/GroupTableViewCell.swift
@@ -16,35 +16,27 @@ import SignalServiceKit
     init() {
         super.init(style: .default, reuseIdentifier: TAG)
 
-        self.contentView.addSubview(avatarView)
-
-        let textContainer = UIView.container()
-        textContainer.addSubview(nameLabel)
-        textContainer.addSubview(subtitleLabel)
-        self.contentView.addSubview(textContainer)
-
         // Font config
         nameLabel.font = .ows_dynamicTypeBody
         subtitleLabel.font = UIFont.ows_regularFont(withSize: 11.0)
         subtitleLabel.textColor = UIColor.ows_darkGray
 
-        // Listen to notifications...
-        // TODO avatar, group name change, group membership change, group member name change
-
         // Layout
 
-        nameLabel.autoPinEdgesToSuperviewEdges(with: UIEdgeInsets.zero, excludingEdge: .bottom)
-        subtitleLabel.autoPinEdgesToSuperviewEdges(with: UIEdgeInsets.zero, excludingEdge: .top)
-        subtitleLabel.autoPinEdge(.top, to: .bottom, of: nameLabel)
-
-        avatarView.autoPinLeadingToSuperviewMargin()
-        avatarView.autoVCenterInSuperview()
         avatarView.autoSetDimension(.width, toSize: CGFloat(kContactCellAvatarSize))
         avatarView.autoPinToSquareAspectRatio()
 
-        textContainer.autoPinEdge(.leading, to: .trailing, of: avatarView, withOffset: kContactCellAvatarTextMargin)
-        textContainer.autoPinTrailingToSuperviewMargin()
-        textContainer.autoVCenterInSuperview()
+        let textRows = UIStackView(arrangedSubviews: [nameLabel, subtitleLabel])
+        textRows.axis = .vertical
+        textRows.alignment = .leading
+
+        let columns = UIStackView(arrangedSubviews: [avatarView, textRows])
+        columns.axis = .horizontal
+        columns.alignment = .center
+        columns.spacing = kContactCellAvatarTextMargin
+
+        self.contentView.addSubview(columns)
+        columns.autoPinEdgesToSuperviewMargins()
     }
 
     required init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
We switched sizing to automatic, but group cell wasn't autolayout ready.

**before**

![before_group_cell](https://user-images.githubusercontent.com/36971200/41927226-d42d6da4-792e-11e8-8ee6-28cddc8cdf4c.png)

**after**

![after_group_cell](https://user-images.githubusercontent.com/36971200/41927225-d41533d8-792e-11e8-986e-74de57bcd1db.png)

