### PR TITLE
FIX: obscured searchbar upon returning

### DIFF
--- a/Signal/src/ViewControllers/HomeView/HomeViewController.m
+++ b/Signal/src/ViewControllers/HomeView/HomeViewController.m
@@ -529,18 +529,24 @@ NSString *const kArchivedConversationsReuseIdentifier = @"kArchivedConversations
 
     self.isViewVisible = YES;
 
-    // When returning to home view, try to ensure that the "last" thread is still
-    // visible.  The threads often change ordering while in conversation view due
-    // to incoming & outgoing messages.
-    if (self.lastThread) {
+    BOOL isShowingSearchResults = !self.searchResultsController.view.hidden;
+    if (isShowingSearchResults) {
+        OWSAssert(self.searchBar.text.ows_stripped.length > 0);
+        self.tableView.contentOffset = CGPointZero;
+    } else if (self.lastThread) {
+        OWSAssert(self.searchBar.text.ows_stripped.length == 0);
+        
+        // When returning to home view, try to ensure that the "last" thread is still
+        // visible.  The threads often change ordering while in conversation view due
+        // to incoming & outgoing messages.
         __block NSIndexPath *indexPathOfLastThread = nil;
         [self.uiDatabaseConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
             indexPathOfLastThread =
-                [[transaction extension:TSThreadDatabaseViewExtensionName] indexPathForKey:self.lastThread.uniqueId
-                                                                              inCollection:[TSThread collection]
-                                                                              withMappings:self.threadMappings];
+            [[transaction extension:TSThreadDatabaseViewExtensionName] indexPathForKey:self.lastThread.uniqueId
+                                                                          inCollection:[TSThread collection]
+                                                                          withMappings:self.threadMappings];
         }];
-
+        
         if (indexPathOfLastThread) {
             [self.tableView scrollToRowAtIndexPath:indexPathOfLastThread
                                   atScrollPosition:UITableViewScrollPositionNone


### PR DESCRIPTION
When navigating back from a conversation, we could be scrolled down a ways.
Since the search bar lives in the inbox table view, we need to make sure the
inbox table view is scrolled all the way up to keep the search bar visible.

PTAL @charlesmchen 