### PR TITLE
Disable compact text layout.

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageBubbleView.m
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageBubbleView.m
@@ -958,8 +958,8 @@ NS_ASSUME_NONNULL_BEGIN
     const int maxTextWidth = (int)floor(self.conversationStyle.maxMessageWidth - hMargins);
 
     [self configureBodyTextView];
-    const int kMaxIterations = 5;
-    CGSize result = [self.bodyTextView compactSizeThatFitsMaxWidth:maxTextWidth maxIterations:kMaxIterations];
+
+    CGSize result = CGSizeCeil([self.bodyTextView sizeThatFits:CGSizeMake(maxTextWidth, CGFLOAT_MAX)]);
 
     return [NSValue valueWithCGSize:CGSizeCeil(result)];
 }

--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageTextView.h
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageTextView.h
@@ -8,8 +8,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic) BOOL shouldIgnoreEvents;
 
-- (CGSize)compactSizeThatFitsMaxWidth:(CGFloat)maxWidth maxIterations:(NSUInteger)maxIterations;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageTextView.m
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageTextView.m
@@ -61,47 +61,6 @@ NS_ASSUME_NONNULL_BEGIN
     return result;
 }
 
-// TODO: Add unit test.
-- (CGSize)compactSizeThatFitsMaxWidth:(CGFloat)maxWidth maxIterations:(NSUInteger)maxIterations
-{
-    OWSAssert(maxWidth > 0);
-
-    CGSize textSize = CGSizeCeil([self sizeThatFits:CGSizeMake(maxWidth, CGFLOAT_MAX)]);
-
-    // "Compact" layout to reduce "widows",
-    // e.g. last lines with only a single word.
-    //
-    // After measuring the size of the text, we try to find smaller widths
-    // in which the text will fit without adding any height, by wrapping
-    // more text onto the last line. We use a binary search.
-    if (textSize.width > 0 && textSize.height > 0) {
-        NSUInteger upperBound = (NSUInteger)textSize.width;
-        NSUInteger lowerBound = 1;
-        // The more iterations we perform in our binary search,
-        // the more accurate the result, but the more expensive
-        // layout becomes.
-        for (NSUInteger i = 0; i < maxIterations; i++) {
-            NSUInteger resizeWidth = (upperBound + lowerBound) / 2;
-            if (resizeWidth >= upperBound || resizeWidth <= lowerBound) {
-                break;
-            }
-            CGSize resizeSize = CGSizeCeil([self sizeThatFits:CGSizeMake(resizeWidth, CGFLOAT_MAX)]);
-            BOOL success
-                = (resizeSize.width > 0 && resizeSize.width <= resizeWidth && resizeSize.height <= textSize.height);
-            if (success) {
-                // Success.
-                textSize = resizeSize;
-                upperBound = (NSUInteger)textSize.width;
-            } else {
-                // Failure.
-                lowerBound = resizeWidth;
-            }
-        }
-    }
-    textSize.width = MIN(textSize.width, maxWidth);
-    return CGSizeCeil(textSize);
-}
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SignalMessaging/categories/UIView+OWS.h
+++ b/SignalMessaging/categories/UIView+OWS.h
@@ -163,4 +163,9 @@ CG_INLINE CGSize CGSizeRound(CGSize size)
     return CGSizeMake((CGFloat)round(size.width), (CGFloat)round(size.height));
 }
 
+CG_INLINE CGSize CGSizeMax(CGSize size1, CGSize size2)
+{
+    return CGSizeMake(MAX(size1.width, size2.width), MAX(size1.height, size2.height));
+}
+
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
It turns out this technique works for `UILabel` but not `UITextArea`.  I tried to fix it using `UITextArea` container and layout properties, but couldn't.

PTAL @michaelkirk 