### PR TITLE
Don't block "register" button on iPad registration

### DIFF
--- a/Signal.xcodeproj/project.pbxproj
+++ b/Signal.xcodeproj/project.pbxproj
@@ -412,6 +412,7 @@
 		4AC4EA13C8A444455DAB351F /* Pods_SignalMessaging.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 264242150E87D10A357DB07B /* Pods_SignalMessaging.framework */; };
 		4C20B2B720CA0034001BAC90 /* ThreadViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4542DF51208B82E9007B4E76 /* ThreadViewModel.swift */; };
 		4C20B2B920CA10DE001BAC90 /* ConversationSearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C20B2B820CA10DE001BAC90 /* ConversationSearchViewController.swift */; };
+		4C4AEC4520EC343B0020E72B /* DismissableTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C4AEC4420EC343B0020E72B /* DismissableTextField.swift */; };
 		70377AAB1918450100CAF501 /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 70377AAA1918450100CAF501 /* MobileCoreServices.framework */; };
 		768A1A2B17FC9CD300E00ED8 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 768A1A2A17FC9CD300E00ED8 /* libz.dylib */; };
 		76C87F19181EFCE600C4ACAB /* MediaPlayer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 76C87F18181EFCE600C4ACAB /* MediaPlayer.framework */; };
@@ -1066,6 +1067,7 @@
 		45FBC5D01DF8592E00E9B410 /* SignalCall.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignalCall.swift; sourceTree = "<group>"; };
 		45FDA43420A4D22700396358 /* OWSNavigationBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OWSNavigationBar.swift; sourceTree = "<group>"; };
 		4C20B2B820CA10DE001BAC90 /* ConversationSearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationSearchViewController.swift; sourceTree = "<group>"; };
+		4C4AEC4420EC343B0020E72B /* DismissableTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DismissableTextField.swift; sourceTree = "<group>"; };
 		69349DE607F5BA6036C9AC60 /* Pods-SignalShareExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SignalShareExtension.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SignalShareExtension/Pods-SignalShareExtension.debug.xcconfig"; sourceTree = "<group>"; };
 		70377AAA1918450100CAF501 /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
 		748A5CAEDD7C919FC64C6807 /* Pods_SignalTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SignalTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2151,6 +2153,7 @@
 				45A6DAD51EBBF85500893231 /* ReminderView.swift */,
 				450D19111F85236600970622 /* RemoteVideoView.h */,
 				450D19121F85236600970622 /* RemoteVideoView.m */,
+				4C4AEC4420EC343B0020E72B /* DismissableTextField.swift */,
 			);
 			name = Views;
 			path = views;
@@ -3238,6 +3241,7 @@
 				34E3EF101EFC2684007F6822 /* DebugUIPage.m in Sources */,
 				340FC8CD20518C77007AEB0F /* OWSBackupJob.m in Sources */,
 				34D1F0AE1F867BFC0066283D /* OWSMessageCell.m in Sources */,
+				4C4AEC4520EC343B0020E72B /* DismissableTextField.swift in Sources */,
 				451686AB1F520CDA00AC3D4B /* MultiDeviceProfileKeyUpdateJob.swift in Sources */,
 				45D231771DC7E8F10034FA89 /* SessionResetJob.swift in Sources */,
 				340FC8A9204DAC8D007AEB0F /* NotificationSettingsOptionsViewController.m in Sources */,

--- a/Signal/src/ViewControllers/Registration/RegistrationViewController.m
+++ b/Signal/src/ViewControllers/Registration/RegistrationViewController.m
@@ -189,7 +189,13 @@ NSString *const kKeychainKey_LastRegisteredPhoneNumber = @"kKeychainKey_LastRegi
     [phoneNumberLabel autoVCenterInSuperview];
     [phoneNumberLabel autoPinLeadingToSuperviewMargin];
 
-    UITextField *phoneNumberTextField = [UITextField new];
+    UITextField *phoneNumberTextField;
+    if (UIDevice.currentDevice.isShorterThanIPhone5) {
+        phoneNumberTextField = [DismissableTextField new];
+    } else {
+        phoneNumberTextField = [UITextField new];
+    }
+
     phoneNumberTextField.textAlignment = NSTextAlignmentRight;
     phoneNumberTextField.delegate = self;
     phoneNumberTextField.keyboardType = UIKeyboardTypeNumberPad;

--- a/Signal/src/views/DismissableTextField.swift
+++ b/Signal/src/views/DismissableTextField.swift
@@ -1,0 +1,66 @@
+//
+//  Copyright (c) 2018 Open Whisper Systems. All rights reserved.
+//
+
+import Foundation
+
+protocol DismissInputBarDelegate: class {
+    func dismissInputBarDidTapDismiss(_ dismissInputBar: DismissInputBar)
+}
+
+class DismissInputBar: UIToolbar {
+
+    weak var dismissDelegate: DismissInputBarDelegate?
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        let spacer = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+        let dismissButton = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(didTapDone))
+        dismissButton.imageInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 40)
+        dismissButton.tintColor = UIColor.ows_systemPrimaryButton
+
+        self.items = [spacer, dismissButton]
+        self.isTranslucent = false
+        self.isOpaque = true
+        self.barTintColor = UIColor.ows_toolbarBackground
+
+        self.autoresizingMask = .flexibleHeight
+        self.translatesAutoresizingMaskIntoConstraints = false
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    @objc
+    public func didTapDone() {
+        self.dismissDelegate?.dismissInputBarDidTapDismiss(self)
+    }
+}
+
+@objc
+public class DismissableTextField: UITextField, DismissInputBarDelegate {
+
+    private let dismissBar: DismissInputBar
+
+    override init(frame: CGRect) {
+        self.dismissBar = DismissInputBar()
+
+        super.init(frame: frame)
+
+        self.inputAccessoryView = dismissBar
+
+        dismissBar.dismissDelegate = self
+    }
+
+    required public init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: DismissInputBarDelegate
+
+    func dismissInputBarDidTapDismiss(_ dismissInputBar: DismissInputBar) {
+        self.resignFirstResponder()
+    }
+}

--- a/SignalMessaging/categories/UIDevice+featureSupport.swift
+++ b/SignalMessaging/categories/UIDevice+featureSupport.swift
@@ -35,6 +35,11 @@ public extension UIDevice {
     }
 
     @objc
+    public var isShorterThanIPhone5: Bool {
+        return UIScreen.main.nativeBounds.height < 1136
+    }
+
+    @objc
     public var isIPad: Bool {
         let isNativeIPad = UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiom.pad
         let isCompatabilityModeIPad = UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiom.phone && self.model.hasPrefix("iPad")


### PR DESCRIPTION
On short devices, add a toolbar with a "dismiss" button to the number pad.

<img width="840" alt="screen shot 2018-07-03 at 5 58 02 pm" src="https://user-images.githubusercontent.com/36971200/42249849-b734d7f2-7eea-11e8-9888-37357f80cd8b.png">

<img width="840" alt="screen shot 2018-07-03 at 5 08 19 pm" src="https://user-images.githubusercontent.com/36971200/42249311-d5263e8e-7ee7-11e8-810e-3082631352b9.png">

PTAL @charlesmchen 

