### PR TITLE
fix contact cell

### DIFF
--- a/Signal/src/ViewControllers/AppSettings/OWSQRCodeScanningViewController.m
+++ b/Signal/src/ViewControllers/AppSettings/OWSQRCodeScanningViewController.m
@@ -75,7 +75,7 @@ NS_ASSUME_NONNULL_BEGIN
         layer.opacity = 0.5f;
     }];
     [self.view addSubview:maskingView];
-    [maskingView autoPinToSuperviewEdges];
+    [maskingView ows_autoPinToSuperviewEdges];
 }
 
 - (void)viewWillAppear:(BOOL)animated

--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSContactShareButtonsView.m
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSContactShareButtonsView.m
@@ -132,7 +132,7 @@ NS_ASSUME_NONNULL_BEGIN
     label.textColor = UIColor.ows_materialBlueColor;
     label.textAlignment = NSTextAlignmentCenter;
     [self addSubview:label];
-    [label autoPinToSuperviewEdges];
+    [label ows_autoPinToSuperviewEdges];
     [label autoSetDimension:ALDimensionHeight toSize:OWSContactShareButtonsView.buttonHeight];
 
     self.userInteractionEnabled = YES;

--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSContactShareView.m
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSContactShareView.m
@@ -157,7 +157,7 @@ NS_ASSUME_NONNULL_BEGIN
     [hStackView addArrangedSubview:labelsView];
     [hStackView addArrangedSubview:disclosureImageView];
     [self addSubview:hStackView];
-    [hStackView autoPinToSuperviewEdges];
+    [hStackView ows_autoPinToSuperviewEdges];
 }
 
 @end

--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageBubbleView.m
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageBubbleView.m
@@ -363,7 +363,7 @@ NS_ASSUME_NONNULL_BEGIN
                 [self.viewConstraints addObjectsFromArray:[clipView autoPinToEdgesOfView:proxyView]];
 
                 [clipView addSubview:bodyMediaView];
-                [self.viewConstraints addObjectsFromArray:[bodyMediaView autoPinToSuperviewEdges]];
+                [self.viewConstraints addObjectsFromArray:[bodyMediaView ows_autoPinToSuperviewEdges]];
 
                 [self.bubbleView addPartnerView:shadowView1];
                 [self.bubbleView addPartnerView:shadowView2];
@@ -447,7 +447,7 @@ NS_ASSUME_NONNULL_BEGIN
                                  }];
         [gradientView.layer addSublayer:gradientLayer];
         [bodyMediaView addSubview:gradientView];
-        [self.viewConstraints addObjectsFromArray:[gradientView autoPinToSuperviewEdges]];
+        [self.viewConstraints addObjectsFromArray:[gradientView ows_autoPinToSuperviewEdges]];
 
         [self.footerView configureWithConversationViewItem:self.viewItem
                                          isOverlayingMedia:YES
@@ -528,7 +528,7 @@ NS_ASSUME_NONNULL_BEGIN
     [self.viewConstraints addObjectsFromArray:[clipView autoPinToEdgesOfView:proxyView]];
 
     [clipView addSubview:buttonsView];
-    [self.viewConstraints addObjectsFromArray:[buttonsView autoPinToSuperviewEdges]];
+    [self.viewConstraints addObjectsFromArray:[buttonsView ows_autoPinToSuperviewEdges]];
 
     [self.bubbleView addPartnerView:shadowView];
     [self.bubbleView addPartnerView:clipView];
@@ -1091,7 +1091,7 @@ NS_ASSUME_NONNULL_BEGIN
                 [[AttachmentUploadView alloc] initWithAttachment:self.attachmentStream
                                          attachmentStateCallback:attachmentStateCallback];
             [self.bubbleView addSubview:attachmentUploadView];
-            [attachmentUploadView autoPinToSuperviewEdges];
+            [attachmentUploadView ows_autoPinToSuperviewEdges];
         }
     }
 }

--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageTimerView.m
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageTimerView.m
@@ -56,7 +56,7 @@ const CGFloat kDisappearingMessageIconSize = 12.f;
 {
     self.imageView = [UIImageView new];
     [self addSubview:self.imageView];
-    [self.imageView autoPinToSuperviewEdges];
+    [self.imageView ows_autoPinToSuperviewEdges];
     [self.imageView autoSetDimension:ALDimensionWidth toSize:kDisappearingMessageIconSize];
     [self.imageView autoSetDimension:ALDimensionHeight toSize:kDisappearingMessageIconSize];
 }

--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSQuotedMessageView.m
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSQuotedMessageView.m
@@ -190,7 +190,7 @@ NS_ASSUME_NONNULL_BEGIN
     hStackView.axis = UILayoutConstraintAxisHorizontal;
     hStackView.spacing = self.hSpacing;
     [innerBubbleView addSubview:hStackView];
-    [hStackView autoPinToSuperviewEdges];
+    [hStackView ows_autoPinToSuperviewEdges];
 
     UIView *stripeView = [UIView new];
     stripeView.backgroundColor = [self.conversationStyle quotedReplyStripeColorWithIsIncoming:!self.isOutgoing];

--- a/Signal/src/ViewControllers/ConversationView/ConversationInputToolbar.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationInputToolbar.m
@@ -248,7 +248,7 @@ const CGFloat kMaxTextViewHeight = 98;
     UIView *wrapper = [UIView containerView];
     wrapper.layoutMargins = UIEdgeInsetsMake(self.quotedMessageTopMargin, 0, 0, 0);
     [wrapper addSubview:quotedMessagePreview];
-    [quotedMessagePreview autoPinToSuperviewMargins];
+    [quotedMessagePreview ows_autoPinToSuperviewMargins];
 
     [self.contentRows insertArrangedSubview:wrapper atIndex:0];
 
@@ -386,7 +386,7 @@ const CGFloat kMaxTextViewHeight = 98;
 
     self.voiceMemoContentView = [UIView new];
     [self.voiceMemoUI addSubview:self.voiceMemoContentView];
-    [self.voiceMemoContentView autoPinToSuperviewEdges];
+    [self.voiceMemoContentView ows_autoPinToSuperviewEdges];
 
     self.recordingLabel = [UILabel new];
     self.recordingLabel.textColor = [UIColor ows_destructiveRedColor];

--- a/Signal/src/ViewControllers/GifPicker/GifPickerCell.swift
+++ b/Signal/src/ViewControllers/GifPicker/GifPickerCell.swift
@@ -206,7 +206,7 @@ class GifPickerCell: UICollectionViewCell {
             let imageView = YYAnimatedImageView()
             self.imageView = imageView
             self.contentView.addSubview(imageView)
-            imageView.autoPinToSuperviewEdges()
+            imageView.ows_autoPinToSuperviewEdges()
         }
         guard let imageView = imageView else {
             owsFail("\(TAG) missing imageview.")

--- a/Signal/src/ViewControllers/MediaDetailViewController.m
+++ b/Signal/src/ViewControllers/MediaDetailViewController.m
@@ -180,7 +180,7 @@ NS_ASSUME_NONNULL_BEGIN
         self.automaticallyAdjustsScrollViewInsets = NO;
     }
 
-    [scrollView autoPinToSuperviewEdges];
+    [scrollView ows_autoPinToSuperviewEdges];
 
     if (self.isAnimated) {
         if (self.attachmentStream.isValidImage) {

--- a/Signal/src/ViewControllers/MenuActionsViewController.swift
+++ b/Signal/src/ViewControllers/MenuActionsViewController.swift
@@ -293,7 +293,7 @@ class MenuActionSheetView: UIView, MenuActionViewDelegate {
 
         backgroundColor = UIColor.ows_light10
         addSubview(actionStackView)
-        actionStackView.autoPinToSuperviewEdges()
+        actionStackView.ows_autoPinToSuperviewEdges()
 
         self.clipsToBounds = true
 
@@ -378,7 +378,7 @@ class MenuActionView: UIButton {
         contentRow.isUserInteractionEnabled = false
 
         self.addSubview(contentRow)
-        contentRow.autoPinToSuperviewMargins()
+        contentRow.ows_autoPinToSuperviewMargins()
         contentRow.autoSetDimension(.height, toSize: 56, relation: .greaterThanOrEqual)
 
         self.addTarget(self, action: #selector(didPress(sender:)), for: .touchUpInside)

--- a/Signal/src/ViewControllers/MessageDetailViewController.swift
+++ b/Signal/src/ViewControllers/MessageDetailViewController.swift
@@ -261,7 +261,7 @@ class MessageDetailViewController: OWSViewController, MediaGalleryDataSourceDele
                     let wrapper = UIView()
                     wrapper.layoutMargins = UIEdgeInsets(top: 8, left: 20, bottom: 8, right: 20)
                     wrapper.addSubview(cellView)
-                    cellView.autoPinToSuperviewMargins()
+                    cellView.autoPinEdgesToSuperviewMargins()
                     groupRows.append(wrapper)
                 }
 

--- a/Signal/src/ViewControllers/ThreadSettings/FingerprintViewController.m
+++ b/Signal/src/ViewControllers/ThreadSettings/FingerprintViewController.m
@@ -289,7 +289,7 @@ typedef void (^CustomLayoutBlock)(void);
         layer.path = [UIBezierPath bezierPathWithOvalInRect:circle].CGPath;
     }];
     [fingerprintView addSubview:fingerprintCircle];
-    [fingerprintCircle autoPinToSuperviewEdges];
+    [fingerprintCircle ows_autoPinToSuperviewEdges];
 
     UIImageView *fingerprintImageView = [UIImageView new];
     fingerprintImageView.image = self.fingerprint.image;

--- a/Signal/src/views/ReminderView.swift
+++ b/Signal/src/views/ReminderView.swift
@@ -80,7 +80,7 @@ class ReminderView: UIView {
 
         self.addSubview(container)
         container.layoutMargins = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
-        container.autoPinToSuperviewEdges()
+        container.ows_autoPinToSuperviewEdges()
 
         // Label
         label.font = UIFont.ows_dynamicTypeSubheadline

--- a/SignalMessaging/Views/OWSFlatButton.swift
+++ b/SignalMessaging/Views/OWSFlatButton.swift
@@ -41,7 +41,7 @@ public class OWSFlatButton: UIView {
     private func createContent() {
         self.addSubview(button)
         button.addTarget(self, action: #selector(buttonPressed), for: .touchUpInside)
-        button.autoPinToSuperviewEdges()
+        button.ows_autoPinToSuperviewEdges()
     }
 
     @objc

--- a/SignalMessaging/attachments/VideoPlayerView.swift
+++ b/SignalMessaging/attachments/VideoPlayerView.swift
@@ -109,7 +109,7 @@ public class PlayerProgressBar: UIView {
         backgroundColor = UIColor.lightGray.withAlphaComponent(0.5)
         if !UIAccessibilityIsReduceTransparencyEnabled() {
             addSubview(blurEffectView)
-            blurEffectView.autoPinToSuperviewEdges()
+            blurEffectView.ows_autoPinToSuperviewEdges()
         }
 
         // Configure controls

--- a/SignalMessaging/categories/UIView+OWS.h
+++ b/SignalMessaging/categories/UIView+OWS.h
@@ -27,8 +27,8 @@ CGFloat ScaleFromIPhone5(CGFloat iPhone5Value);
 - (NSArray<NSLayoutConstraint *> *)autoPinHeightToSuperviewWithMargin:(CGFloat)margin;
 - (NSArray<NSLayoutConstraint *> *)autoPinHeightToSuperview;
 
-- (NSArray<NSLayoutConstraint *> *)autoPinToSuperviewEdges;
-- (NSArray<NSLayoutConstraint *> *)autoPinToSuperviewMargins;
+- (NSArray<NSLayoutConstraint *> *)ows_autoPinToSuperviewEdges;
+- (NSArray<NSLayoutConstraint *> *)ows_autoPinToSuperviewMargins;
 
 - (NSLayoutConstraint *)autoHCenterInSuperview;
 - (NSLayoutConstraint *)autoVCenterInSuperview;

--- a/SignalMessaging/categories/UIView+OWS.m
+++ b/SignalMessaging/categories/UIView+OWS.m
@@ -79,7 +79,7 @@ CGFloat ScaleFromIPhone5(CGFloat iPhone5Value)
     return result;
 }
 
-- (NSArray<NSLayoutConstraint *> *)autoPinToSuperviewEdges
+- (NSArray<NSLayoutConstraint *> *)ows_autoPinToSuperviewEdges
 {
     NSArray<NSLayoutConstraint *> *result = @[
         [self autoPinEdgeToSuperviewEdge:ALEdgeLeft],
@@ -90,7 +90,7 @@ CGFloat ScaleFromIPhone5(CGFloat iPhone5Value)
     return result;
 }
 
-- (NSArray<NSLayoutConstraint *> *)autoPinToSuperviewMargins
+- (NSArray<NSLayoutConstraint *> *)ows_autoPinToSuperviewMargins
 {
     NSArray<NSLayoutConstraint *> *result = @[
         [self autoPinTopToSuperviewMargin],


### PR DESCRIPTION
On iOS9/10 the ContactCell is not respecting it's wrapper's margin.

We have some methods that are named very similarly to PureLayout methods.

`PureLayout#autoPinEdgesToSuperviewEdges` pins to leading/trailing/top/left
`OWS#autoPinToSuperviewEdges` now renamed to `ows_autoPinToSuperviewEdges` pinned to left/right/top/left.

I think it's probably rare that we want to use this one, but didn't want to make a broad sweeping change during stabilization.

`PureLayout#autoPinEdgesToSuperviewMargin` vs
`OWS#autoPinToSuperviewMargins` uses our own constraint adding logic,
and behaves differently in some cases. In the case of this PR, using PureLayout's flavor results in the margins being respected on iOS9 and 10 (both work with iOS11).

I haven't dug into exactly why this method is behaving differently, and again, was loathe to make a broad change during stabilization, so I've simply renamed our home-brew version to be more obvious when we're using one vs the other.

PTAL @charlesmchen 