### PR TITLE
[Build] Update clone instructions

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,19 +1,31 @@
 # Building
 
-We typically develop against the latest stable version of XCode.
+We typically develop against the latest stable version of Xcode.
 
-As of this writing, that's XCode 9.4
+As of this writing, that's Xcode 9.4.
 
 ## 1. Clone
 
-Clone the repo to a working directory
+Clone the repo to a working directory:
 
 ```
-git clone https:github.com/signalapp/Signal-iOS
+git clone --recurse-submodules https:github.com/signalapp/Signal-iOS
 ```
 
 Since we make use of submodules, you must use `git clone`, rather than
 downloading a prepared zip file from Github.
+
+We recommend you fork the repo on GitHub, then clone your fork:
+
+```
+git clone --recurse-submodules https://github.com/<USERNAME>/Signal-iOS.git
+```
+
+You can then add the Signal repo to sync with upstream changes:
+
+```
+git remote add upstream https:github.com/signalapp/Signal-iOS
+```
 
 ## 2. Dependencies
 
@@ -73,7 +85,7 @@ A prebuilt version of WebRTC.framework resides in our Carthage submodule
 and should be installed by the above steps.  However, if you'd like to
 build it from source, see: https://github.com/signalapp/signal-webrtc-ios
 
-## 3. XCode
+## 3. Xcode
 
 Open the `Signal.xcworkspace` in Xcode.
 


### PR DESCRIPTION
### Description

Per discussion [here](https://community.signalusers.org/t/not-able-to-build-in-xcode-9-3-9-4/3498/12).

Using `--recurse-submodules` will init and update all submodules, so you can do everything at once. I find this a bit nicer.
(Also, it seems like it might be more reliable with GitHub forks?)

I realize `make dependencies` runs `git submodule update --init`. It will just be a no-op if you clone this way.

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks