### PR TITLE
Add IDE template macro for consistent headers

### DIFF
--- a/Signal.xcworkspace/xcshareddata/IDETemplateMacros.plist
+++ b/Signal.xcworkspace/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+<key>FILEHEADER</key>
+<string>
+//  Copyright (c) 2018 Open Whisper Systems. All rights reserved.
+// </string>
+</dict>
+</plist>


### PR DESCRIPTION
Xcode has undesirable default header comments, and now you can customize them.
This adds an `IDETemplateMacros.plist` file to the `xcworkspace` so that new files created
in the workspace have the same, consistent default header comments automatically added:

```
//
//  Copyright (c) 2018 Open Whisper Systems. All rights reserved.
//
```

This will prevent contributors from either (1) committing Xcode's default, or
(2) having to manually copy-pasta the standard comment headers for every new file added.

[See here for more details](https://oleb.net/blog/2017/07/xcode-9-text-macros/)

