### PR TITLE
Fixup parser: Robust to servers various "empty" types

### DIFF
--- a/Signal/src/Jobs/MessageFetcherJob.swift
+++ b/Signal/src/Jobs/MessageFetcherJob.swift
@@ -131,7 +131,7 @@ public class MessageFetcherJob: NSObject {
             let timestamp: UInt64 = try params.required(key: "timestamp")
             let source: String = try params.required(key: "source")
             let sourceDevice: UInt32 = try params.required(key: "sourceDevice")
-            let legacyMessage = try params.optionalBase64EncodedData(key: "message")
+            let legacyMessage: Data? = try params.optionalBase64EncodedData(key: "message")
             let content: Data? = try params.optionalBase64EncodedData(key: "content")
 
             return SSKEnvelope(timestamp: UInt64(timestamp), source: source, sourceDevice: sourceDevice, type: type, content: content, legacyMessage: legacyMessage)

--- a/Signal/test/SSKTests/ParamParserTest.swift
+++ b/Signal/test/SSKTests/ParamParserTest.swift
@@ -71,7 +71,9 @@ class ParamParserTest: XCTestCase {
         }())
     }
 
-    func testBase64Data() {
+    // MARK: Base64EncodedData
+
+    func testBase64Data_Valid() {
         let originalString = "asdf"
         let utf8Data: Data = originalString.data(using: .utf8)!
         let base64EncodedString = utf8Data.base64EncodedString()
@@ -85,5 +87,32 @@ class ParamParserTest: XCTestCase {
         let data: Data = try! parser.requiredBase64EncodedData(key: "some_data")
         let roundTripString = String(data: data, encoding: .utf8)
         XCTAssertEqual(originalString, roundTripString)
+    }
+
+    func testBase64Data_EmptyString() {
+        let dict: [String: Any] = ["some_data": ""]
+        let parser = ParamParser(dictionary: dict)
+
+        XCTAssertThrowsError(try parser.requiredBase64EncodedData(key: "some_data"))
+        XCTAssertEqual(nil, try parser.optionalBase64EncodedData(key: "some_data"))
+    }
+
+    func testBase64Data_NSNull() {
+        let dict: [String: Any] = ["some_data": NSNull()]
+        let parser = ParamParser(dictionary: dict)
+
+        XCTAssertThrowsError(try parser.requiredBase64EncodedData(key: "some_data"))
+        XCTAssertEqual(nil, try parser.optionalBase64EncodedData(key: "some_data"))
+    }
+
+    func testBase64Data_Invalid() {
+        // invalid base64 data
+        let base64EncodedString = "YXNkZg"
+
+        let dict: [String: Any] = ["some_data": base64EncodedString]
+        let parser = ParamParser(dictionary: dict)
+
+        XCTAssertThrowsError(try parser.requiredBase64EncodedData(key: "some_data"))
+        XCTAssertThrowsError(try parser.optionalBase64EncodedData(key: "some_data"))
     }
 }

--- a/SignalServiceKit/src/Contacts/ContactsUpdater.m
+++ b/SignalServiceKit/src/Contacts/ContactsUpdater.m
@@ -82,8 +82,8 @@ NS_ASSUME_NONNULL_BEGIN
                            failure:(void (^)(NSError *error))failure
 {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        OWSContactDiscoveryOperation *operation =
-            [[OWSContactDiscoveryOperation alloc] initWithRecipientIdsToLookup:recipientIdsToLookup.allObjects];
+        OWSLegacyContactDiscoveryOperation *operation =
+            [[OWSLegacyContactDiscoveryOperation alloc] initWithRecipientIdsToLookup:recipientIdsToLookup.allObjects];
 
         NSArray<NSOperation *> *operationAndDependencies = [operation.dependencies arrayByAddingObject:operation];
         [self.contactIntersectionQueue addOperations:operationAndDependencies waitUntilFinished:YES];

--- a/SignalServiceKit/src/Util/ParamParser.swift
+++ b/SignalServiceKit/src/Util/ParamParser.swift
@@ -64,6 +64,10 @@ public class ParamParser {
             return nil
         }
 
+        guard !(someValue is NSNull) else {
+            return nil
+        }
+
         guard let typedValue = someValue as? T else {
             throw invalid(key: key)
         }
@@ -85,7 +89,7 @@ public class ParamParser {
     }
 
     public func optional<T>(key: Key) throws -> T? where T: FixedWidthInteger {
-        guard let someValue = dictionary[key] else {
+        guard let someValue: Any = try optional(key: key) else {
             return nil
         }
 
@@ -119,6 +123,10 @@ public class ParamParser {
 
         guard let data = Data(base64Encoded: encodedData) else {
             throw ParseError.invalidFormat(key)
+        }
+
+        guard data.count > 0 else {
+            return nil
         }
 
         return data


### PR DESCRIPTION
For empty base64Encoded data, sometimes the server sends "null" (which is represented as NSNull) and sometimes the server sends an empty string. 🤷‍♂️ 

In both cases we represent this as nil - which will fail if it's a required field.

PTAL @charlesmchen
