### PR TITLE
Charlesmchen/defer message resizing

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageFooterView.m
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageFooterView.m
@@ -228,29 +228,6 @@ NS_ASSUME_NONNULL_BEGIN
     // Measure the actual current width, to be safe.
     CGFloat timestampLabelWidth = [self.timestampLabel sizeThatFits:CGSizeZero].width;
 
-    // Measuring the timestamp label's width is non-trivial since its
-    // contents can be relative the current time.  We avoid having
-    // message bubbles' "visually vibrate" as their timestamp labels
-    // vary in width.  So we try to leave enough space for all possible
-    // contents of this label _for the first hour of its lifetime_, when
-    // the timestamp is particularly volatile.
-    if ([DateUtil isTimestampFromLastHour:viewItem.interaction.timestamp]) {
-        // Measure the "now" case.
-        self.timestampLabel.text = [DateUtil exemplaryNowTimeFormat];
-        timestampLabelWidth = MAX(timestampLabelWidth, [self.timestampLabel sizeThatFits:CGSizeZero].width);
-        // Measure the "relative time" case.
-        // Since this case varies with time, we multiply to leave
-        // space for the worst case (whose exact value, due to localization,
-        // is unpredictable).
-        self.timestampLabel.text = [DateUtil exemplaryMinutesTimeFormat];
-        timestampLabelWidth = MAX(timestampLabelWidth,
-            [self.timestampLabel sizeThatFits:CGSizeZero].width + self.timestampLabel.font.lineHeight * 0.5f);
-
-        // Re-configure the labels with the current appropriate value in case
-        // we are configuring this view for display.
-        [self configureLabelsWithConversationViewItem:viewItem];
-    }
-
     result.width = timestampLabelWidth;
     if (viewItem.interaction.interactionType == OWSInteractionType_OutgoingMessage) {
         if (![self isFailedOutgoingMessage:viewItem]) {

--- a/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
@@ -235,6 +235,7 @@ typedef enum : NSUInteger {
 @property (nonatomic) ContactShareViewHelper *contactShareViewHelper;
 @property (nonatomic) NSTimer *reloadTimer;
 @property (nonatomic, nullable) NSDate *lastReloadDate;
+@property (nonatomic, nullable) NSDate *collapseCutoffDate;
 
 @end
 
@@ -447,6 +448,7 @@ typedef enum : NSUInteger {
     // Cache the cell media for ~24 cells.
     self.cellMediaCache.countLimit = 24;
     _conversationStyle = [[ConversationStyle alloc] initWithThread:thread];
+    self.collapseCutoffDate = [NSDate new];
 
     // We need to update the "unread indicator" _before_ we determine the initial range
     // size, since it depends on where the unread indicator is placed.
@@ -818,9 +820,11 @@ typedef enum : NSUInteger {
 - (void)resetContentAndLayout
 {
     // Avoid layout corrupt issues and out-of-date message subtitles.
+    self.lastReloadDate = [NSDate new];
+    self.collapseCutoffDate = [NSDate new];
+    [self reloadViewItems];
     [self.collectionView.collectionViewLayout invalidateLayout];
     [self.collectionView reloadData];
-    self.lastReloadDate = [NSDate new];
 }
 
 - (void)setUserHasScrolled:(BOOL)userHasScrolled
@@ -3384,9 +3388,10 @@ typedef enum : NSUInteger {
         // These errors seems to be very rare; they can only be reproduced
         // using the more extreme actions in the debug UI.
         OWSProdLogAndFail(@"%@ hasMalformedRowChange", self.logTag);
+        self.lastReloadDate = [NSDate new];
+        self.collapseCutoffDate = [NSDate new];
         [self reloadViewItems];
         [self.collectionView reloadData];
-        self.lastReloadDate = [NSDate new];
         [self updateLastVisibleTimestamp];
         return;
     }
@@ -4349,9 +4354,11 @@ typedef enum : NSUInteger {
 - (void)conversationColorWasUpdated
 {
     [self.conversationStyle updateProperties];
+    self.collapseCutoffDate = [NSDate new];
+    self.lastReloadDate = [NSDate new];
+    [self reloadViewItems];
     [self.headerView updateAvatar];
     [self.collectionView reloadData];
-    self.lastReloadDate = [NSDate new];
 }
 
 - (void)groupWasUpdated:(TSGroupModel *)groupModel
@@ -4862,6 +4869,8 @@ typedef enum : NSUInteger {
     BOOL shouldShowDateOnNextViewItem = YES;
     uint64_t previousViewItemTimestamp = 0;
     OWSUnreadIndicator *_Nullable unreadIndicator = self.dynamicInteractions.unreadIndicator;
+    uint64_t collapseCutoffTimestamp = [NSDate ows_millisecondsSince1970ForDate:self.collapseCutoffDate];
+
     BOOL hasPlacedUnreadIndicator = NO;
     for (ConversationViewItem *viewItem in viewItems) {
         BOOL canShowDate = NO;
@@ -5069,6 +5078,10 @@ typedef enum : NSUInteger {
                         || nextViewItem.hasCellHeader);
                 }
             }
+        }
+
+        if (viewItem.interaction.timestampForSorting > collapseCutoffTimestamp) {
+            shouldHideFooter = NO;
         }
 
         viewItem.isFirstInCluster = isFirstInCluster;


### PR DESCRIPTION
PTAL @michaelkirk 

A proposal for how to reduce the "animation churn" around footer collapse/resizing.

Essentially, we reload all cells every minute in order to update footer timestamps.  We only change footer sizing & collapse in those updates, once per minute.  This will group and reduce these animations.