### PR TITLE
Cache system message text.

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/Cells/ConversationViewCell.h
+++ b/Signal/src/ViewControllers/ConversationView/Cells/ConversationViewCell.h
@@ -18,7 +18,6 @@ NS_ASSUME_NONNULL_BEGIN
 @class TSMessage;
 @class TSOutgoingMessage;
 @class TSQuotedMessage;
-@class YapDatabaseReadTransaction;
 
 @protocol ConversationViewCellDelegate <NSObject>
 
@@ -85,9 +84,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, nullable) ConversationStyle *conversationStyle;
 
-- (void)loadForDisplayWithTransaction:(YapDatabaseReadTransaction *)transaction;
+- (void)loadForDisplay;
 
-- (CGSize)cellSizeWithTransaction:(YapDatabaseReadTransaction *)transaction;
+- (CGSize)cellSize;
 
 @end
 

--- a/Signal/src/ViewControllers/ConversationView/Cells/ConversationViewCell.m
+++ b/Signal/src/ViewControllers/ConversationView/Cells/ConversationViewCell.m
@@ -19,12 +19,12 @@ NS_ASSUME_NONNULL_BEGIN
     self.conversationStyle = nil;
 }
 
-- (void)loadForDisplayWithTransaction:(YapDatabaseReadTransaction *)transaction
+- (void)loadForDisplay
 {
     OWS_ABSTRACT_METHOD();
 }
 
-- (CGSize)cellSizeWithTransaction:(YapDatabaseReadTransaction *)transaction
+- (CGSize)cellSize
 {
     OWS_ABSTRACT_METHOD();
 

--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSContactOffersCell.m
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSContactOffersCell.m
@@ -108,7 +108,7 @@ NS_ASSUME_NONNULL_BEGIN
     return NSStringFromClass([self class]);
 }
 
-- (void)loadForDisplayWithTransaction:(YapDatabaseReadTransaction *)transaction
+- (void)loadForDisplay
 {
     OWSAssert(self.conversationStyle);
     OWSAssert(self.conversationStyle.viewWidth > 0);
@@ -173,7 +173,7 @@ NS_ASSUME_NONNULL_BEGIN
     return (24.f + self.addToContactsButton.titleLabel.font.lineHeight);
 }
 
-- (CGSize)cellSizeWithTransaction:(YapDatabaseReadTransaction *)transaction
+- (CGSize)cellSize
 {
     OWSAssert(self.conversationStyle);
     OWSAssert(self.conversationStyle.viewWidth > 0);

--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageCell.m
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageCell.m
@@ -124,7 +124,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Load
 
-- (void)loadForDisplayWithTransaction:(YapDatabaseReadTransaction *)transaction
+- (void)loadForDisplay
 {
     OWSAssert(self.conversationStyle);
     OWSAssert(self.viewItem);
@@ -320,7 +320,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Measurement
 
-- (CGSize)cellSizeWithTransaction:(YapDatabaseReadTransaction *)transaction
+- (CGSize)cellSize
 {
     OWSAssert(self.conversationStyle);
     OWSAssert(self.conversationStyle.viewWidth > 0);

--- a/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
@@ -569,8 +569,7 @@ typedef enum : NSUInteger {
 {
     OWSAssert(self.conversationStyle);
 
-    _layout = [[ConversationViewLayout alloc] initWithConversationStyle:self.conversationStyle
-                                                   uiDatabaseConnection:self.uiDatabaseConnection];
+    _layout = [[ConversationViewLayout alloc] initWithConversationStyle:self.conversationStyle];
     self.conversationStyle.viewWidth = self.view.width;
 
     self.layout.delegate = self;
@@ -5167,9 +5166,7 @@ typedef enum : NSUInteger {
     }
     cell.conversationStyle = self.conversationStyle;
 
-    [self.uiDatabaseConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
-        [cell loadForDisplayWithTransaction:transaction];
-    }];
+    [cell loadForDisplay];
 
     return cell;
 }

--- a/Signal/src/ViewControllers/ConversationView/ConversationViewItem.h
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewItem.h
@@ -109,6 +109,8 @@ NSString *NSStringForOWSMessageCellType(OWSMessageCellType cellType);
 
 @property (nonatomic, readonly, nullable) ContactShareViewModel *contactShare;
 
+@property (nonatomic, nullable) NSString *systemMessageText;
+
 #pragma mark - MessageActions
 
 @property (nonatomic, readonly) BOOL hasBodyTextActionContent;

--- a/Signal/src/ViewControllers/ConversationView/ConversationViewLayout.h
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewLayout.h
@@ -5,12 +5,10 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class ConversationStyle;
-@class YapDatabaseConnection;
-@class YapDatabaseReadTransaction;
 
 @protocol ConversationViewLayoutItem <NSObject>
 
-- (CGSize)cellSizeWithTransaction:(YapDatabaseReadTransaction *)transaction;
+- (CGSize)cellSize;
 
 - (CGFloat)vSpacingWithPreviousLayoutItem:(id<ConversationViewLayoutItem>)previousLayoutItem;
 
@@ -39,8 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 
-- (instancetype)initWithConversationStyle:(ConversationStyle *)conversationStyle
-                     uiDatabaseConnection:(YapDatabaseConnection *)uiDatabaseConnection;
+- (instancetype)initWithConversationStyle:(ConversationStyle *)conversationStyle;
 
 @end
 

--- a/Signal/src/ViewControllers/ConversationView/ConversationViewLayout.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewLayout.m
@@ -10,8 +10,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ConversationViewLayout ()
 
-@property (nonatomic, readonly) YapDatabaseConnection *uiDatabaseConnection;
-
 @property (nonatomic) CGSize contentSize;
 
 @property (nonatomic, readonly) NSMutableDictionary<NSNumber *, UICollectionViewLayoutAttributes *> *itemAttributesMap;
@@ -31,12 +29,10 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation ConversationViewLayout
 
 - (instancetype)initWithConversationStyle:(ConversationStyle *)conversationStyle
-                     uiDatabaseConnection:(YapDatabaseConnection *)uiDatabaseConnection
 {
     if (self = [super init]) {
         _itemAttributesMap = [NSMutableDictionary new];
         _conversationStyle = conversationStyle;
-        _uiDatabaseConnection = uiDatabaseConnection;
     }
 
     return self;
@@ -98,15 +94,11 @@ NS_ASSUME_NONNULL_BEGIN
     // TODO: Remove this log statement after we've reduced the invalidation churn.
     DDLogVerbose(@"%@ prepareLayout", self.logTag);
 
-    [self.uiDatabaseConnection readWithBlock:^(YapDatabaseReadTransaction *transaction) {
-        [self prepareLayoutWithTransaction:transaction];
-    }];
+    [self prepareLayoutOfItems];
 }
 
-- (void)prepareLayoutWithTransaction:(YapDatabaseReadTransaction *)transaction
+- (void)prepareLayoutOfItems
 {
-    OWSAssert(transaction);
-
     const CGFloat viewWidth = self.conversationStyle.viewWidth;
 
     NSArray<id<ConversationViewLayoutItem>> *layoutItems = self.delegate.layoutItems;
@@ -121,7 +113,7 @@ NS_ASSUME_NONNULL_BEGIN
             y += [layoutItem vSpacingWithPreviousLayoutItem:previousLayoutItem];
         }
 
-        CGSize layoutSize = CGSizeCeil([layoutItem cellSizeWithTransaction:transaction]);
+        CGSize layoutSize = CGSizeCeil([layoutItem cellSize]);
 
         // Ensure cell fits within view.
         OWSAssert(layoutSize.width <= viewWidth);


### PR DESCRIPTION
Something that we've talked about for a while.  By caching system message text, we can skip opening a ton of read transactions in the conversation view.

PTAL @michaelkirk 