### PR TITLE
Use dark blur for navbar

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/ConversationInputToolbar.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationInputToolbar.m
@@ -92,8 +92,7 @@ const CGFloat kMaxTextViewHeight = 98;
         CGFloat alpha = OWSNavigationBar.backgroundBlurMutingFactor;
         self.backgroundColor = [Theme.toolbarBackgroundColor colorWithAlphaComponent:alpha];
 
-        UIBlurEffect *blurEffect = [UIBlurEffect effectWithStyle:UIBlurEffectStyleLight];
-        UIVisualEffectView *blurEffectView = [[UIVisualEffectView alloc] initWithEffect:blurEffect];
+        UIVisualEffectView *blurEffectView = [[UIVisualEffectView alloc] initWithEffect:Theme.barBlurEffect];
         [self addSubview:blurEffectView];
         [blurEffectView autoPinEdgesToSuperviewEdges];
     }

--- a/SignalMessaging/categories/Theme.h
+++ b/SignalMessaging/categories/Theme.h
@@ -47,6 +47,7 @@ extern NSString *const ThemeDidChangeNotification;
 @property (class, readonly, nonatomic) UIBarStyle barStyle;
 @property (class, readonly, nonatomic) UISearchBarStyle searchBarStyle;
 @property (class, readonly, nonatomic) UIColor *searchBarBackgroundColor;
+@property (class, readonly, nonatomic) UIBlurEffect *barBlurEffect;
 
 @end
 

--- a/SignalMessaging/categories/Theme.m
+++ b/SignalMessaging/categories/Theme.m
@@ -123,6 +123,12 @@ NSString *const ThemeKeyThemeEnabled = @"ThemeKeyThemeEnabled";
     return (Theme.isDarkThemeEnabled ? [UIColor colorWithWhite:0.35f alpha:1.f] : UIColor.ows_light02Color);
 }
 
++ (UIBlurEffect *)barBlurEffect
+{
+    return Theme.isDarkThemeEnabled ? [UIBlurEffect effectWithStyle:UIBlurEffectStyleDark]
+                                    : [UIBlurEffect effectWithStyle:UIBlurEffectStyleLight];
+}
+
 #pragma mark -
 
 + (UIBarStyle)barStyle


### PR DESCRIPTION
PTAL @charlesmchen 

Before this change the navbar is always visible in dark theme, and the nav bar item icons become low contrast.
![navbar-light-blur](https://user-images.githubusercontent.com/36971200/43931245-d206c8f6-9bfa-11e8-8825-c2523516f72d.jpeg)

After this change the navbar is invisible if there's no content behind it - in line with recent light-theme changes. 

And when there is content behind it, the icons still have relatively high contrast.

![navbar-dark-blur](https://user-images.githubusercontent.com/36971200/43931244-d1ee204e-9bfa-11e8-9661-9afd654a71f6.png)


