### PR TITLE
Avoid incremental theme-redraws

### DIFF
--- a/SignalMessaging/categories/Theme.m
+++ b/SignalMessaging/categories/Theme.m
@@ -46,7 +46,9 @@ NSString *const ThemeKeyThemeEnabled = @"ThemeKeyThemeEnabled";
 
     [UIUtil setupSignalAppearence];
 
-    [[NSNotificationCenter defaultCenter] postNotificationNameAsync:ThemeDidChangeNotification object:nil userInfo:nil];
+    [UIView performWithoutAnimation:^{
+        [[NSNotificationCenter defaultCenter] postNotificationName:ThemeDidChangeNotification object:nil userInfo:nil];
+    }];
 }
 
 + (UIColor *)backgroundColor


### PR DESCRIPTION
Before this change, the settings table redraws several times during the theme switch, which feels clunky - this feels cleaner.

PTAL @charlesmchen 