### PR TITLE
faster conversation presentation after contact picking

### DIFF
--- a/Signal/src/ViewControllers/ContactShareViewHelper.swift
+++ b/Signal/src/ViewControllers/ContactShareViewHelper.swift
@@ -62,12 +62,12 @@ public class ContactShareViewHelper: NSObject, CNContactViewControllerDelegate {
         }
         guard phoneNumbers.count > 1 else {
             let recipientId = phoneNumbers.first!
-            SignalApp.shared().presentConversation(forRecipientId: recipientId, action: action)
+            SignalApp.shared().presentConversation(forRecipientId: recipientId, action: action, animated: true)
             return
         }
 
         showPhoneNumberPicker(phoneNumbers: phoneNumbers, fromViewController: fromViewController, completion: { (recipientId) in
-            SignalApp.shared().presentConversation(forRecipientId: recipientId, action: action)
+            SignalApp.shared().presentConversation(forRecipientId: recipientId, action: action, animated: true)
         })
     }
 

--- a/Signal/src/ViewControllers/ContactViewController.swift
+++ b/Signal/src/ViewControllers/ContactViewController.swift
@@ -544,17 +544,17 @@ class ContactViewController: OWSViewController, ContactShareViewHelperDelegate {
                 actionSheet.addAction(UIAlertAction(title: NSLocalizedString("ACTION_SEND_MESSAGE",
                                                                              comment: "Label for 'send message' button in contact view."),
                                                     style: .default) { _ in
-                                                        SignalApp.shared().presentConversation(forRecipientId: e164, action: .compose)
+                                                        SignalApp.shared().presentConversation(forRecipientId: e164, action: .compose, animated: true)
                 })
                 actionSheet.addAction(UIAlertAction(title: NSLocalizedString("ACTION_AUDIO_CALL",
                                                                              comment: "Label for 'audio call' button in contact view."),
                                                     style: .default) { _ in
-                                                        SignalApp.shared().presentConversation(forRecipientId: e164, action: .audioCall)
+                                                        SignalApp.shared().presentConversation(forRecipientId: e164, action: .audioCall, animated: true)
                 })
                 actionSheet.addAction(UIAlertAction(title: NSLocalizedString("ACTION_VIDEO_CALL",
                                                                              comment: "Label for 'video call' button in contact view."),
                                                     style: .default) { _ in
-                                                        SignalApp.shared().presentConversation(forRecipientId: e164, action: .videoCall)
+                                                        SignalApp.shared().presentConversation(forRecipientId: e164, action: .videoCall, animated: true)
                 })
             } else {
                 // TODO: We could offer callPhoneNumberWithSystemCall.

--- a/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
@@ -1133,22 +1133,6 @@ typedef enum : NSUInteger {
     [self updateBackButtonUnreadCount];
     [self autoLoadMoreIfNecessary];
 
-    switch (self.actionOnOpen) {
-        case ConversationViewActionNone:
-            break;
-        case ConversationViewActionCompose:
-            [self popKeyBoard];
-            break;
-        case ConversationViewActionAudioCall:
-            [self startAudioCall];
-            break;
-        case ConversationViewActionVideoCall:
-            [self startVideoCall];
-            break;
-    }
-
-    // Clear the "on open" state after the view has been presented.
-    self.actionOnOpen = ConversationViewActionNone;
     self.focusMessageIdOnOpen = nil;
 
     self.isViewCompletelyAppeared = YES;
@@ -1173,6 +1157,23 @@ typedef enum : NSUInteger {
             [self becomeFirstResponder];
         }
     }
+
+    switch (self.actionOnOpen) {
+        case ConversationViewActionNone:
+            break;
+        case ConversationViewActionCompose:
+            [self popKeyBoard];
+            break;
+        case ConversationViewActionAudioCall:
+            [self startAudioCall];
+            break;
+        case ConversationViewActionVideoCall:
+            [self startVideoCall];
+            break;
+    }
+
+    // Clear the "on open" state after the view has been presented.
+    self.actionOnOpen = ConversationViewActionNone;
 }
 
 // `viewWillDisappear` is called whenever the view *starts* to disappear,

--- a/Signal/src/ViewControllers/DebugUI/DebugUIContacts.m
+++ b/Signal/src/ViewControllers/DebugUI/DebugUIContacts.m
@@ -1338,7 +1338,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     NSString *recipientId = [self unregisteredRecipientId];
     TSContactThread *thread = [TSContactThread getOrCreateThreadWithContactId:recipientId];
-    [SignalApp.sharedApp presentConversationForThread:thread];
+    [SignalApp.sharedApp presentConversationForThread:thread animated:YES];
 }
 
 + (void)createUnregisteredGroupThread
@@ -1356,7 +1356,8 @@ NS_ASSUME_NONNULL_BEGIN
     TSGroupModel *model =
         [[TSGroupModel alloc] initWithTitle:groupName memberIds:recipientIds image:nil groupId:groupId];
     TSGroupThread *thread = [TSGroupThread getOrCreateThreadWithGroupModel:model];
-    [SignalApp.sharedApp presentConversationForThread:thread];
+
+    [SignalApp.sharedApp presentConversationForThread:thread animated:YES];
 }
 
 @end

--- a/Signal/src/ViewControllers/DebugUI/DebugUIStress.m
+++ b/Signal/src/ViewControllers/DebugUI/DebugUIStress.m
@@ -512,7 +512,7 @@ NS_ASSUME_NONNULL_BEGIN
         }];
     OWSAssert(thread);
 
-    [SignalApp.sharedApp presentConversationForThread:thread];
+    [SignalApp.sharedApp presentConversationForThread:thread animated:YES];
 }
 
 @end

--- a/Signal/src/ViewControllers/HomeView/ConversationSearchViewController.swift
+++ b/Signal/src/ViewControllers/HomeView/ConversationSearchViewController.swift
@@ -137,7 +137,7 @@ class ConversationSearchViewController: UITableViewController {
             }
 
             let thread = searchResult.thread
-            SignalApp.shared().presentConversation(for: thread.threadRecord, action: .compose)
+            SignalApp.shared().presentConversation(for: thread.threadRecord, action: .compose, animated: true)
 
         case .contacts:
             let sectionResults = searchResultSet.contacts
@@ -146,7 +146,7 @@ class ConversationSearchViewController: UITableViewController {
                 return
             }
 
-            SignalApp.shared().presentConversation(forRecipientId: searchResult.recipientId, action: .compose)
+            SignalApp.shared().presentConversation(forRecipientId: searchResult.recipientId, action: .compose, animated: true)
 
         case .messages:
             let sectionResults = searchResultSet.messages
@@ -157,8 +157,9 @@ class ConversationSearchViewController: UITableViewController {
 
             let thread = searchResult.thread
             SignalApp.shared().presentConversation(for: thread.threadRecord,
-                                                   action: .compose,
-                                                   focusMessageId: searchResult.messageId)
+                                                   action: .none,
+                                                   focusMessageId: searchResult.messageId,
+                                                   animated: true)
         }
     }
 

--- a/Signal/src/ViewControllers/HomeView/HomeViewController.h
+++ b/Signal/src/ViewControllers/HomeView/HomeViewController.h
@@ -12,19 +12,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface HomeViewController : OWSViewController
 
-- (void)presentThread:(TSThread *)thread action:(ConversationViewAction)action;
+- (void)presentThread:(TSThread *)thread action:(ConversationViewAction)action animated:(BOOL)isAnimated;
+
 - (void)presentThread:(TSThread *)thread
                action:(ConversationViewAction)action
-       focusMessageId:(nullable NSString *)focusMessageId;
+       focusMessageId:(nullable NSString *)focusMessageId
+             animated:(BOOL)isAnimated;
 
+// Used by force-touch Springboard icon shortcut
 - (void)showNewConversationView;
-
-- (void)presentTopLevelModalViewController:(UIViewController *)viewController
-                          animateDismissal:(BOOL)animateDismissal
-                       animatePresentation:(BOOL)animatePresentation;
-- (void)pushTopLevelViewController:(UIViewController *)viewController
-                  animateDismissal:(BOOL)animateDismissal
-               animatePresentation:(BOOL)animatePresentation;
 
 @end
 

--- a/Signal/src/ViewControllers/NewContactThreadViewController.m
+++ b/Signal/src/ViewControllers/NewContactThreadViewController.m
@@ -823,11 +823,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)newConversationWithThread:(TSThread *)thread
 {
     OWSAssert(thread != nil);
-    [self dismissViewControllerAnimated:YES
-                             completion:^() {
-                                 [SignalApp.sharedApp presentConversationForThread:thread
-                                                                            action:ConversationViewActionCompose];
-                             }];
+    [SignalApp.sharedApp presentConversationForThread:thread action:ConversationViewActionCompose animated:NO];
+    [self.presentingViewController dismissViewControllerAnimated:YES completion:nil];
 }
 
 - (void)showNewGroupView:(id)sender

--- a/Signal/src/ViewControllers/NewGroupViewController.m
+++ b/Signal/src/ViewControllers/NewGroupViewController.m
@@ -452,30 +452,24 @@ const NSUInteger kNewGroupViewControllerAvatarWidth = 68;
         DDLogError(@"Group creation successful.");
 
         dispatch_async(dispatch_get_main_queue(), ^{
-            [self dismissViewControllerAnimated:YES
-                                     completion:^{
-                                         // Pop to new group thread.
-                                         [SignalApp.sharedApp presentConversationForThread:thread];
-                                     }];
-
+            [SignalApp.sharedApp presentConversationForThread:thread action:ConversationViewActionCompose animated:NO];
+            [self.presentingViewController dismissViewControllerAnimated:YES completion:nil];
         });
     };
 
     void (^failureHandler)(NSError *error) = ^(NSError *error) {
         DDLogError(@"Group creation failed: %@", error);
 
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [self dismissViewControllerAnimated:YES
-                                     completion:^{
-                                         // Add an error message to the new group indicating
-                                         // that group creation didn't succeed.
-                                         [[[TSErrorMessage alloc] initWithTimestamp:[NSDate ows_millisecondTimeStamp]
-                                                                           inThread:thread
-                                                                  failedMessageType:TSErrorMessageGroupCreationFailed]
-                                             save];
+        // Add an error message to the new group indicating
+        // that group creation didn't succeed.
+        TSErrorMessage *errorMessage = [[TSErrorMessage alloc] initWithTimestamp:[NSDate ows_millisecondTimeStamp]
+                                                                        inThread:thread
+                                                               failedMessageType:TSErrorMessageGroupCreationFailed];
+        [errorMessage save];
 
-                                         [SignalApp.sharedApp presentConversationForThread:thread];
-                                     }];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [SignalApp.sharedApp presentConversationForThread:thread action:ConversationViewActionCompose animated:NO];
+            [self.presentingViewController dismissViewControllerAnimated:YES completion:nil];
         });
     };
 

--- a/Signal/src/ViewControllers/ProfileViewController.h
+++ b/Signal/src/ViewControllers/ProfileViewController.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (void)presentForAppSettings:(UINavigationController *)navigationController;
 + (void)presentForRegistration:(UINavigationController *)navigationController;
-+ (void)presentForUpgradeOrNag:(HomeViewController *)presentingController NS_SWIFT_NAME(presentForUpgradeOrNag(from:));
++ (void)presentForUpgradeOrNag:(HomeViewController *)fromViewController NS_SWIFT_NAME(presentForUpgradeOrNag(from:));
 
 @end
 

--- a/Signal/src/ViewControllers/ProfileViewController.m
+++ b/Signal/src/ViewControllers/ProfileViewController.m
@@ -558,15 +558,13 @@ NSString *const kProfileView_LastPresentedDate = @"kProfileView_LastPresentedDat
     [navigationController pushViewController:vc animated:YES];
 }
 
-+ (void)presentForUpgradeOrNag:(HomeViewController *)presentingController
++ (void)presentForUpgradeOrNag:(HomeViewController *)fromViewController
 {
-    OWSAssert(presentingController);
+    OWSAssert(fromViewController);
 
     ProfileViewController *vc = [[ProfileViewController alloc] initWithMode:ProfileViewMode_UpgradeOrNag];
     OWSNavigationController *navigationController = [[OWSNavigationController alloc] initWithRootViewController:vc];
-    [presentingController presentTopLevelModalViewController:navigationController
-                                            animateDismissal:YES
-                                         animatePresentation:YES];
+    [fromViewController presentViewController:navigationController animated:YES completion:nil];
 }
 
 #pragma mark - AvatarViewHelperDelegate

--- a/Signal/src/ViewControllers/ThreadSettings/ShowGroupMembersViewController.m
+++ b/Signal/src/ViewControllers/ThreadSettings/ShowGroupMembersViewController.m
@@ -403,12 +403,16 @@ NS_ASSUME_NONNULL_BEGIN
 {
     OWSAssert(recipientId.length > 0);
 
-    [SignalApp.sharedApp presentConversationForRecipientId:recipientId action:ConversationViewActionCompose];
+    [SignalApp.sharedApp presentConversationForRecipientId:recipientId
+                                                    action:ConversationViewActionCompose
+                                                  animated:YES];
 }
 
 - (void)callMember:(NSString *)recipientId
 {
-    [SignalApp.sharedApp presentConversationForRecipientId:recipientId action:ConversationViewActionAudioCall];
+    [SignalApp.sharedApp presentConversationForRecipientId:recipientId
+                                                    action:ConversationViewActionAudioCall
+                                                  animated:YES];
 }
 
 - (void)showSafetyNumberView:(NSString *)recipientId

--- a/Signal/src/environment/SignalApp.h
+++ b/Signal/src/environment/SignalApp.h
@@ -35,16 +35,24 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (instancetype)sharedApp;
 
-#pragma mark - View Convenience Methods
+#pragma mark - Conversation Presentation
 
-- (void)presentConversationForRecipientId:(NSString *)recipientId;
-- (void)presentConversationForRecipientId:(NSString *)recipientId action:(ConversationViewAction)action;
-- (void)presentConversationForThreadId:(NSString *)threadId;
-- (void)presentConversationForThread:(TSThread *)thread;
-- (void)presentConversationForThread:(TSThread *)thread action:(ConversationViewAction)action;
+- (void)presentConversationForRecipientId:(NSString *)recipientId animated:(BOOL)isAnimated;
+
+- (void)presentConversationForRecipientId:(NSString *)recipientId
+                                   action:(ConversationViewAction)action
+                                 animated:(BOOL)isAnimated;
+
+- (void)presentConversationForThreadId:(NSString *)threadId animated:(BOOL)isAnimated;
+
+- (void)presentConversationForThread:(TSThread *)thread animated:(BOOL)isAnimated;
+
+- (void)presentConversationForThread:(TSThread *)thread action:(ConversationViewAction)action animated:(BOOL)isAnimated;
+
 - (void)presentConversationForThread:(TSThread *)thread
                               action:(ConversationViewAction)action
-                      focusMessageId:(nullable NSString *)focusMessageId;
+                      focusMessageId:(nullable NSString *)focusMessageId
+                            animated:(BOOL)isAnimated;
 
 #pragma mark - Methods
 

--- a/Signal/src/environment/SignalApp.m
+++ b/Signal/src/environment/SignalApp.m
@@ -152,24 +152,24 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - View Convenience Methods
 
+- (void)presentConversationForRecipientId:(NSString *)recipientId animated:(BOOL)isAnimated
+{
+    [self presentConversationForRecipientId:recipientId action:ConversationViewActionNone animated:(BOOL)isAnimated];
+}
+
 - (void)presentConversationForRecipientId:(NSString *)recipientId
+                                   action:(ConversationViewAction)action
+                                 animated:(BOOL)isAnimated
 {
-    [self presentConversationForRecipientId:recipientId action:ConversationViewActionNone];
+    __block TSThread *thread = nil;
+    [OWSPrimaryStorage.dbReadWriteConnection
+        readWriteWithBlock:^(YapDatabaseReadWriteTransaction *_Nonnull transaction) {
+            thread = [TSContactThread getOrCreateThreadWithContactId:recipientId transaction:transaction];
+        }];
+    [self presentConversationForThread:thread action:action animated:(BOOL)isAnimated];
 }
 
-- (void)presentConversationForRecipientId:(NSString *)recipientId action:(ConversationViewAction)action
-{
-    DispatchMainThreadSafe(^{
-        __block TSThread *thread = nil;
-        [OWSPrimaryStorage.dbReadWriteConnection
-            readWriteWithBlock:^(YapDatabaseReadWriteTransaction *_Nonnull transaction) {
-                thread = [TSContactThread getOrCreateThreadWithContactId:recipientId transaction:transaction];
-            }];
-        [self presentConversationForThread:thread action:action];
-    });
-}
-
-- (void)presentConversationForThreadId:(NSString *)threadId
+- (void)presentConversationForThreadId:(NSString *)threadId animated:(BOOL)isAnimated
 {
     OWSAssert(threadId.length > 0);
 
@@ -179,22 +179,23 @@ NS_ASSUME_NONNULL_BEGIN
         return;
     }
 
-    [self presentConversationForThread:thread];
+    [self presentConversationForThread:thread animated:isAnimated];
 }
 
-- (void)presentConversationForThread:(TSThread *)thread
+- (void)presentConversationForThread:(TSThread *)thread animated:(BOOL)isAnimated
 {
-    [self presentConversationForThread:thread action:ConversationViewActionNone];
+    [self presentConversationForThread:thread action:ConversationViewActionNone animated:isAnimated];
 }
 
-- (void)presentConversationForThread:(TSThread *)thread action:(ConversationViewAction)action
+- (void)presentConversationForThread:(TSThread *)thread action:(ConversationViewAction)action animated:(BOOL)isAnimated
 {
-    [self presentConversationForThread:thread action:action focusMessageId:nil];
+    [self presentConversationForThread:thread action:action focusMessageId:nil animated:isAnimated];
 }
 
 - (void)presentConversationForThread:(TSThread *)thread
                               action:(ConversationViewAction)action
                       focusMessageId:(nullable NSString *)focusMessageId
+                            animated:(BOOL)isAnimated
 {
     OWSAssertIsOnMainThread();
 
@@ -216,7 +217,7 @@ NS_ASSUME_NONNULL_BEGIN
             }
         }
 
-        [self.homeViewController presentThread:thread action:action focusMessageId:focusMessageId];
+        [self.homeViewController presentThread:thread action:action focusMessageId:focusMessageId animated:isAnimated];
     });
 }
 

--- a/Signal/src/network/PushManager.m
+++ b/Signal/src/network/PushManager.m
@@ -154,7 +154,11 @@ NSString *const Signal_Message_MarkAsRead_Identifier = @"Signal_Message_MarkAsRe
     }
 
     self.hasPresentedConversationSinceLastDeactivation = YES;
-    [SignalApp.sharedApp presentConversationForThreadId:threadId];
+
+    // This will happen before the app is visible. By making this animated:NO, the conversation screen
+    // will be visible to the user immediately upon opening the app, rather than having to watch it animate
+    // in from the homescreen.
+    [SignalApp.sharedApp presentConversationForThreadId:threadId animated:NO];
 }
 
 - (void)application:(UIApplication *)application didReceiveLocalNotification:(UILocalNotification *)notification


### PR DESCRIPTION
Current after picking a conversation we first dismiss the keyboard, the current view (contact picker) then animate pushing the conversation view.

This PR pushes (without animation) the conversation view *before* dismissing the contact picker, allowing us to skip:

1. the keyboard dismiss animation
2. the conversation push animation

PTAL @charlesmchen 

You might want to build and run this and compare it to prod to get a feel for the difference.