### PR TITLE
Darken message actions overlay in dark theme

### DIFF
--- a/Signal/src/ViewControllers/MenuActionsViewController.swift
+++ b/Signal/src/ViewControllers/MenuActionsViewController.swift
@@ -135,7 +135,8 @@ class MenuActionsViewController: UIViewController, MenuActionSheetDelegate {
 
         let backgroundDuration: TimeInterval = 0.1
         UIView.animate(withDuration: backgroundDuration) {
-            self.view.backgroundColor = UIColor.black.withAlphaComponent(0.4)
+            let alpha: CGFloat = Theme.isDarkThemeEnabled ? 0.7 : 0.4
+            self.view.backgroundColor = UIColor.black.withAlphaComponent(alpha)
         }
 
         self.actionSheetView.superview?.layoutIfNeeded()


### PR DESCRIPTION
For 2.29

PTAL @charlesmchen 

Tweak message actions transparency in dark theme.

**before**
<img width="559" alt="screen shot 2018-08-22 at 12 45 59 pm" src="https://user-images.githubusercontent.com/36971200/44483851-6a1cf800-a609-11e8-8503-4a58686282b7.png">

**after**
<img width="559" alt="screen shot 2018-08-22 at 12 45 28 pm" src="https://user-images.githubusercontent.com/36971200/44483852-6a1cf800-a609-11e8-9bab-2b5b1e23a990.png">

