### PR TITLE
Mkirk/cleanup longview

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageBubbleView.h
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageBubbleView.h
@@ -21,6 +21,8 @@ typedef NS_ENUM(NSUInteger, OWSMessageGestureLocation) {
     OWSMessageGestureLocation_QuotedReply,
 };
 
+extern const UIDataDetectorTypes OWSAllowedDataDetectorTypes;
+
 @protocol OWSMessageBubbleViewDelegate
 
 - (void)didTapImageViewItem:(ConversationViewItem *)viewItem

--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageBubbleView.h
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageBubbleView.h
@@ -21,7 +21,7 @@ typedef NS_ENUM(NSUInteger, OWSMessageGestureLocation) {
     OWSMessageGestureLocation_QuotedReply,
 };
 
-extern const UIDataDetectorTypes OWSAllowedDataDetectorTypes;
+extern const UIDataDetectorTypes kOWSAllowedDataDetectorTypes;
 
 @protocol OWSMessageBubbleViewDelegate
 

--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageBubbleView.m
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageBubbleView.m
@@ -21,7 +21,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-const UIDataDetectorTypes OWSAllowedDataDetectorTypes
+const UIDataDetectorTypes kOWSAllowedDataDetectorTypes
     = UIDataDetectorTypeLink | UIDataDetectorTypeAddress | UIDataDetectorTypeCalendarEvent;
 
 @interface OWSMessageBubbleView () <OWSQuotedMessageViewDelegate, OWSContactShareButtonsViewDelegate>
@@ -97,7 +97,7 @@ const UIDataDetectorTypes OWSAllowedDataDetectorTypes
 
     self.bodyTextView = [self newTextView];
     // Setting dataDetectorTypes is expensive.  Do it just once.
-    self.bodyTextView.dataDetectorTypes = OWSAllowedDataDetectorTypes;
+    self.bodyTextView.dataDetectorTypes = kOWSAllowedDataDetectorTypes;
     self.bodyTextView.hidden = YES;
 
     self.footerView = [OWSMessageFooterView new];

--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageBubbleView.m
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageBubbleView.m
@@ -21,6 +21,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+const UIDataDetectorTypes OWSAllowedDataDetectorTypes
+    = UIDataDetectorTypeLink | UIDataDetectorTypeAddress | UIDataDetectorTypeCalendarEvent;
+
 @interface OWSMessageBubbleView () <OWSQuotedMessageViewDelegate, OWSContactShareButtonsViewDelegate>
 
 @property (nonatomic) OWSBubbleView *bubbleView;
@@ -94,8 +97,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     self.bodyTextView = [self newTextView];
     // Setting dataDetectorTypes is expensive.  Do it just once.
-    self.bodyTextView.dataDetectorTypes
-        = (UIDataDetectorTypeLink | UIDataDetectorTypeAddress | UIDataDetectorTypeCalendarEvent);
+    self.bodyTextView.dataDetectorTypes = OWSAllowedDataDetectorTypes;
     self.bodyTextView.hidden = YES;
 
     self.footerView = [OWSMessageFooterView new];

--- a/Signal/src/ViewControllers/LongTextViewController.swift
+++ b/Signal/src/ViewControllers/LongTextViewController.swift
@@ -77,6 +77,17 @@ public class LongTextViewController: OWSViewController {
         messageTextView.dataDetectorTypes = OWSAllowedDataDetectorTypes
         messageTextView.text = messageBody
 
+        // RADAR #18669
+        // https://github.com/lionheart/openradar-mirror/issues/18669
+        //
+        // UITextView’s linkTextAttributes property has type [String : Any]! but should be [NSAttributedStringKey : Any]! in Swift 4.
+        let linkTextAttributes: [String: Any] = [
+            NSAttributedStringKey.foregroundColor.rawValue: Theme.primaryColor,
+            NSAttributedStringKey.underlineColor.rawValue: Theme.primaryColor,
+            NSAttributedStringKey.underlineStyle.rawValue: NSUnderlineStyle.styleSingle.rawValue
+        ]
+        messageTextView.linkTextAttributes = linkTextAttributes
+
         view.addSubview(messageTextView)
         messageTextView.autoPinEdge(toSuperviewEdge: .top)
         messageTextView.autoPinEdge(toSuperviewMargin: .leading)

--- a/Signal/src/ViewControllers/LongTextViewController.swift
+++ b/Signal/src/ViewControllers/LongTextViewController.swift
@@ -74,7 +74,7 @@ public class LongTextViewController: OWSViewController {
         messageTextView.showsVerticalScrollIndicator = true
         messageTextView.isUserInteractionEnabled = true
         messageTextView.textColor = Theme.primaryColor
-        messageTextView.dataDetectorTypes = OWSAllowedDataDetectorTypes
+        messageTextView.dataDetectorTypes = kOWSAllowedDataDetectorTypes
         messageTextView.text = messageBody
 
         // RADAR #18669

--- a/Signal/src/ViewControllers/LongTextViewController.swift
+++ b/Signal/src/ViewControllers/LongTextViewController.swift
@@ -15,7 +15,7 @@ public class LongTextViewController: OWSViewController {
 
     let messageBody: String
 
-    var messageTextView: UITextView?
+    var messageTextView: UITextView!
 
     // MARK: Initializers
 
@@ -53,6 +53,8 @@ public class LongTextViewController: OWSViewController {
                                                       comment: "Title for the 'long text message' view.")
 
         createViews()
+
+        self.messageTextView.contentOffset = CGPoint(x: 0, y: self.messageTextView.contentInset.top)
     }
 
     // MARK: - Create Views
@@ -72,17 +74,17 @@ public class LongTextViewController: OWSViewController {
         messageTextView.showsVerticalScrollIndicator = true
         messageTextView.isUserInteractionEnabled = true
         messageTextView.textColor = Theme.primaryColor
+        messageTextView.dataDetectorTypes = OWSAllowedDataDetectorTypes
         messageTextView.text = messageBody
 
         view.addSubview(messageTextView)
-        messageTextView.autoPinEdge(toSuperviewEdge: .leading)
-        messageTextView.autoPinEdge(toSuperviewEdge: .trailing)
-        messageTextView.textContainerInset = UIEdgeInsets(top: 0, left: view.layoutMargins.left, bottom: 0, right: view.layoutMargins.right)
-        messageTextView.autoPin(toTopLayoutGuideOf: self, withInset: 0)
+        messageTextView.autoPinEdge(toSuperviewEdge: .top)
+        messageTextView.autoPinEdge(toSuperviewMargin: .leading)
+        messageTextView.autoPinEdge(toSuperviewMargin: .trailing)
 
         let footer = UIToolbar()
         view.addSubview(footer)
-        footer.autoPinWidthToSuperview(withMargin: 0)
+        footer.autoPinWidthToSuperview()
         footer.autoPinEdge(.top, to: .bottom, of: messageTextView)
         footer.autoPin(toBottomLayoutGuideOf: self, withInset: 0)
 


### PR DESCRIPTION
For 2.29

PTAL @charlesmchen 

Several tweaks:

1. don't obscure content behind navbar
2. respect default margins
3. style links


Before: (not content scrolled behind navbar)

![lt_before](https://user-images.githubusercontent.com/36971200/44495030-6e5a0d00-a62b-11e8-91d7-9d8af3ede9fc.png)


After:

![lt_after](https://user-images.githubusercontent.com/36971200/44495026-6c904980-a62b-11e8-8cad-c868d66df8a0.png)
