### PR TITLE
Charlesmchen/reworking logging

### DIFF
--- a/Signal/src/Jobs/ConversationConfigurationSyncOperation.swift
+++ b/Signal/src/Jobs/ConversationConfigurationSyncOperation.swift
@@ -67,7 +67,7 @@ class ConversationConfigurationSyncOperation: OWSOperation {
         var dataSource: DataSource?
         self.dbConnection.readWrite { transaction in
             guard let messageData: Data = syncMessage.buildPlainTextAttachmentData(with: transaction) else {
-                owsFail("\(self.logTag) could not serialize sync contacts data")
+                owsFail("could not serialize sync contacts data")
                 return
             }
             dataSource = DataSourceValue.dataSource(withSyncMessageData: messageData)
@@ -91,7 +91,7 @@ class ConversationConfigurationSyncOperation: OWSOperation {
         var dataSource: DataSource?
         self.dbConnection.read { transaction in
             guard let messageData: Data = syncMessage.buildPlainTextAttachmentData(with: transaction) else {
-                owsFail("\(self.logTag) could not serialize sync groups data")
+                owsFail("could not serialize sync groups data")
                 return
             }
             dataSource = DataSourceValue.dataSource(withSyncMessageData: messageData)

--- a/Signal/src/Jobs/MultiDeviceProfileKeyUpdateJob.swift
+++ b/Signal/src/Jobs/MultiDeviceProfileKeyUpdateJob.swift
@@ -36,7 +36,7 @@ import SignalMessaging
 
     func run(retryDelay: TimeInterval = 1) {
         guard let localNumber = TSAccountManager.localNumber() else {
-            owsFail("\(self.logTag) localNumber was unexpectedly nil")
+            owsFail("localNumber was unexpectedly nil")
             return
         }
 
@@ -49,14 +49,14 @@ import SignalMessaging
         var dataSource: DataSource?
         self.editingDatabaseConnection.readWrite { transaction in
             guard let messageData: Data = syncContactsMessage.buildPlainTextAttachmentData(with: transaction) else {
-                owsFail("\(self.logTag) could not serialize sync contacts data")
+                owsFail("could not serialize sync contacts data")
                 return
             }
             dataSource = DataSourceValue.dataSource(withSyncMessageData: messageData)
         }
 
         guard let attachmentDataSource = dataSource else {
-            owsFail("\(self.logTag) in \(#function) dataSource was unexpectedly nil")
+            owsFail("dataSource was unexpectedly nil")
             return
         }
 
@@ -64,10 +64,10 @@ import SignalMessaging
             contentType: OWSMimeTypeApplicationOctetStream,
             in: syncContactsMessage,
             success: {
-                Logger.info("\(self.logTag) Successfully synced profile key")
+                Logger.info("Successfully synced profile key")
             },
             failure: { error in
-                Logger.error("\(self.logTag) in \(#function) failed with error: \(error) retrying in \(retryDelay)s.")
+                Logger.error("failed with error: \(error) retrying in \(retryDelay)s.")
                 after(interval: retryDelay).then {
                     self.run(retryDelay: retryDelay * 2)
                 }.retainUntilComplete()

--- a/Signal/src/Jobs/SessionResetJob.swift
+++ b/Signal/src/Jobs/SessionResetJob.swift
@@ -22,11 +22,11 @@ public class SessionResetJob: NSObject {
     }
 
     func run() {
-        Logger.info("\(logTag) Local user reset session.")
+        Logger.info("Local user reset session.")
 
         let dbConnection = OWSPrimaryStorage.shared().newDatabaseConnection()
         dbConnection.asyncReadWrite { (transaction) in
-            Logger.info("\(self.logTag) deleting sessions for recipient: \(self.recipientId)")
+            Logger.info("deleting sessions for recipient: \(self.recipientId)")
             self.primaryStorage.deleteAllSessions(forContact: self.recipientId, protocolContext: transaction)
 
             DispatchQueue.main.async {
@@ -39,7 +39,7 @@ public class SessionResetJob: NSObject {
                         // Otherwise if we send another message before them, they wont have the session to decrypt it.
                         self.primaryStorage.archiveAllSessions(forContact: self.recipientId, protocolContext: transaction)
                     }
-                    Logger.info("\(self.logTag) successfully sent EndSessionMessage.")
+                    Logger.info("successfully sent EndSessionMessage.")
                     let message = TSInfoMessage(timestamp: NSDate.ows_millisecondTimeStamp(),
                                                 in: self.thread,
                                                 messageType: TSInfoMessageType.typeSessionDidEnd)
@@ -56,7 +56,7 @@ public class SessionResetJob: NSObject {
                         // Otherwise if we send another message before them, they wont have the session to decrypt it.
                         self.primaryStorage.archiveAllSessions(forContact: self.recipientId, protocolContext: transaction)
                     }
-                    Logger.error("\(self.logTag) failed to send EndSessionMessage with error: \(error.localizedDescription)")
+                    Logger.error("failed to send EndSessionMessage with error: \(error.localizedDescription)")
                 })
             }
             }

--- a/Signal/src/Jobs/SyncPushTokensJob.swift
+++ b/Signal/src/Jobs/SyncPushTokensJob.swift
@@ -31,7 +31,7 @@ class SyncPushTokensJob: NSObject {
     }
 
     func run() -> Promise<Void> {
-        Logger.info("\(logTag) Starting.")
+        Logger.info("Starting.")
 
         let runPromise: Promise<Void> = DispatchQueue.main.promise {
             // HACK: no-op dispatch to work around a bug in PromiseKit/Swift which won't compile
@@ -41,36 +41,36 @@ class SyncPushTokensJob: NSObject {
         }.then {
             return self.pushRegistrationManager.requestPushTokens()
         }.then { (pushToken: String, voipToken: String) in
-            Logger.info("\(self.logTag) finished: requesting push tokens")
+            Logger.info("finished: requesting push tokens")
             var shouldUploadTokens = false
 
             if self.preferences.getPushToken() != pushToken || self.preferences.getVoipToken() != voipToken {
-                Logger.debug("\(self.logTag) Push tokens changed.")
+                Logger.debug("Push tokens changed.")
                 shouldUploadTokens = true
             } else if !self.uploadOnlyIfStale {
-                Logger.debug("\(self.logTag) Forced uploading, even though tokens didn't change.")
+                Logger.debug("Forced uploading, even though tokens didn't change.")
                 shouldUploadTokens = true
             }
 
             if AppVersion.sharedInstance().lastAppVersion != AppVersion.sharedInstance().currentAppVersion {
-                Logger.info("\(self.logTag) Uploading due to fresh install or app upgrade.")
+                Logger.info("Uploading due to fresh install or app upgrade.")
                 shouldUploadTokens = true
             }
 
             guard shouldUploadTokens else {
-                Logger.info("\(self.logTag) No reason to upload pushToken: \(pushToken), voipToken: \(voipToken)")
+                Logger.info("No reason to upload pushToken: \(pushToken), voipToken: \(voipToken)")
                 return Promise(value: ())
             }
 
-            Logger.warn("\(self.logTag) uploading tokens to account servers. pushToken: \(pushToken), voipToken: \(voipToken)")
+            Logger.warn("uploading tokens to account servers. pushToken: \(pushToken), voipToken: \(voipToken)")
             return self.accountManager.updatePushTokens(pushToken: pushToken, voipToken: voipToken).then {
-                Logger.info("\(self.logTag) successfully updated push tokens on server")
+                Logger.info("successfully updated push tokens on server")
                 return self.recordPushTokensLocally(pushToken: pushToken, voipToken: voipToken)
             }
         }.then {
-            Logger.info("\(self.logTag) completed successfully.")
+            Logger.info("completed successfully.")
         }.catch { error in
-            Logger.error("\(self.logTag) in \(#function): Failed with error: \(error).")
+            Logger.error("Failed with error: \(error).")
         }
 
         runPromise.retainUntilComplete()
@@ -91,18 +91,18 @@ class SyncPushTokensJob: NSObject {
     }
 
     private func recordPushTokensLocally(pushToken: String, voipToken: String) -> Promise<Void> {
-        Logger.warn("\(logTag) Recording push tokens locally. pushToken: \(pushToken), voipToken: \(voipToken)")
+        Logger.warn("Recording push tokens locally. pushToken: \(pushToken), voipToken: \(voipToken)")
 
         var didTokensChange = false
 
         if (pushToken != self.preferences.getPushToken()) {
-            Logger.info("\(logTag) Recording new plain push token")
+            Logger.info("Recording new plain push token")
             self.preferences.setPushToken(pushToken)
             didTokensChange = true
         }
 
         if (voipToken != self.preferences.getVoipToken()) {
-            Logger.info("\(logTag) Recording new voip token")
+            Logger.info("Recording new voip token")
             self.preferences.setVoipToken(voipToken)
             didTokensChange = true
         }

--- a/Signal/src/Models/AccountManager.swift
+++ b/Signal/src/Models/AccountManager.swift
@@ -49,7 +49,7 @@ public class AccountManager: NSObject {
             return Promise(error: error)
         }
 
-        Logger.debug("\(self.logTag) registering with signal server")
+        Logger.debug("registering with signal server")
         let registrationPromise: Promise<Void> = firstly {
             return self.registerForTextSecure(verificationCode: verificationCode, pin: pin)
         }.then {
@@ -60,7 +60,7 @@ public class AccountManager: NSObject {
                 // This can happen with:
                 // - simulators, none of which support receiving push notifications
                 // - on iOS11 devices which have disabled "Allow Notifications" and disabled "Enable Background Refresh" in the system settings.
-                Logger.info("\(self.logTag) Recovered push registration error. Registering for manual message fetcher because push not supported: \(description)")
+                Logger.info("Recovered push registration error. Registering for manual message fetcher because push not supported: \(description)")
                 return self.registerForManualMessageFetching()
             default:
                 throw error
@@ -85,14 +85,14 @@ public class AccountManager: NSObject {
     }
 
     private func syncPushTokens() -> Promise<Void> {
-        Logger.info("\(self.logTag) in \(#function)")
+        Logger.info("")
         let job = SyncPushTokensJob(accountManager: self, preferences: self.preferences)
         job.uploadOnlyIfStale = false
         return job.run()
     }
 
     private func completeRegistration() {
-        Logger.info("\(self.logTag) in \(#function)")
+        Logger.info("")
         self.textSecureAccountManager.didRegister()
     }
 
@@ -127,7 +127,7 @@ public class AccountManager: NSObject {
                                                     if let turnServerInfo = TurnServerInfo(attributes: responseDictionary) {
                                                         return fulfill(turnServerInfo)
                                                     }
-                                                    Logger.error("\(self.logTag) unexpected server response:\(responseDictionary)")
+                                                    Logger.error("unexpected server response:\(responseDictionary)")
                                                 }
                                                 return reject(OWSErrorMakeUnableToProcessServerResponseError())
             },

--- a/Signal/src/Models/CompareSafetyNumbersActivity.swift
+++ b/Signal/src/Models/CompareSafetyNumbersActivity.swift
@@ -61,7 +61,7 @@ class CompareSafetyNumbersActivity: UIActivity {
 
         let pasteboardString = numericOnly(string: UIPasteboard.general.string)
         guard (pasteboardString != nil && pasteboardString!.count == 60) else {
-            Logger.warn("\(logTag) no valid safety numbers found in pasteboard: \(String(describing: pasteboardString))")
+            Logger.warn("no valid safety numbers found in pasteboard: \(String(describing: pasteboardString))")
             let error = OWSErrorWithCodeDescription(OWSErrorCode.userError,
                                                     NSLocalizedString("PRIVACY_VERIFICATION_FAILED_NO_SAFETY_NUMBERS_IN_CLIPBOARD", comment: "Alert body for user error"))
 
@@ -72,10 +72,10 @@ class CompareSafetyNumbersActivity: UIActivity {
         let pasteboardSafetyNumbers = pasteboardString!
 
         if pasteboardSafetyNumbers == mySafetyNumbers {
-            Logger.info("\(logTag) successfully matched safety numbers. local numbers: \(String(describing: mySafetyNumbers)) pasteboard:\(pasteboardSafetyNumbers)")
+            Logger.info("successfully matched safety numbers. local numbers: \(String(describing: mySafetyNumbers)) pasteboard:\(pasteboardSafetyNumbers)")
             delegate.compareSafetyNumbersActivitySucceeded(activity: self)
         } else {
-            Logger.warn("\(logTag) local numbers: \(String(describing: mySafetyNumbers)) didn't match pasteboard:\(pasteboardSafetyNumbers)")
+            Logger.warn("local numbers: \(String(describing: mySafetyNumbers)) didn't match pasteboard:\(pasteboardSafetyNumbers)")
             let error = OWSErrorWithCodeDescription(OWSErrorCode.privacyVerificationFailure,
                                                     NSLocalizedString("PRIVACY_VERIFICATION_FAILED_MISMATCHED_SAFETY_NUMBERS_IN_CLIPBOARD", comment: "Alert body"))
             delegate.compareSafetyNumbersActivity(self, failedWithError: error)

--- a/Signal/src/Models/CompareSafetyNumbersActivity.swift
+++ b/Signal/src/Models/CompareSafetyNumbersActivity.swift
@@ -72,10 +72,10 @@ class CompareSafetyNumbersActivity: UIActivity {
         let pasteboardSafetyNumbers = pasteboardString!
 
         if pasteboardSafetyNumbers == mySafetyNumbers {
-            Logger.info("successfully matched safety numbers. local numbers: \(String(describing: self.mySafetyNumbers)) pasteboard:\(pasteboardSafetyNumbers)")
+            Logger.info("successfully matched safety numbers. local numbers: \(String(describing: mySafetyNumbers)) pasteboard:\(pasteboardSafetyNumbers)")
             delegate.compareSafetyNumbersActivitySucceeded(activity: self)
         } else {
-            Logger.warn("local numbers: \(String(describing: self.mySafetyNumbers)) didn't match pasteboard:\(pasteboardSafetyNumbers)")
+            Logger.warn("local numbers: \(String(describing: mySafetyNumbers)) didn't match pasteboard:\(pasteboardSafetyNumbers)")
             let error = OWSErrorWithCodeDescription(OWSErrorCode.privacyVerificationFailure,
                                                     NSLocalizedString("PRIVACY_VERIFICATION_FAILED_MISMATCHED_SAFETY_NUMBERS_IN_CLIPBOARD", comment: "Alert body"))
             delegate.compareSafetyNumbersActivity(self, failedWithError: error)

--- a/Signal/src/Models/CompareSafetyNumbersActivity.swift
+++ b/Signal/src/Models/CompareSafetyNumbersActivity.swift
@@ -72,10 +72,10 @@ class CompareSafetyNumbersActivity: UIActivity {
         let pasteboardSafetyNumbers = pasteboardString!
 
         if pasteboardSafetyNumbers == mySafetyNumbers {
-            Logger.info("successfully matched safety numbers. local numbers: \(String(describing: mySafetyNumbers)) pasteboard:\(pasteboardSafetyNumbers)")
+            Logger.info("successfully matched safety numbers. local numbers: \(String(describing: self.mySafetyNumbers)) pasteboard:\(pasteboardSafetyNumbers)")
             delegate.compareSafetyNumbersActivitySucceeded(activity: self)
         } else {
-            Logger.warn("local numbers: \(String(describing: mySafetyNumbers)) didn't match pasteboard:\(pasteboardSafetyNumbers)")
+            Logger.warn("local numbers: \(String(describing: self.mySafetyNumbers)) didn't match pasteboard:\(pasteboardSafetyNumbers)")
             let error = OWSErrorWithCodeDescription(OWSErrorCode.privacyVerificationFailure,
                                                     NSLocalizedString("PRIVACY_VERIFICATION_FAILED_MISMATCHED_SAFETY_NUMBERS_IN_CLIPBOARD", comment: "Alert body"))
             delegate.compareSafetyNumbersActivity(self, failedWithError: error)

--- a/Signal/src/UIApplication+OWS.swift
+++ b/Signal/src/UIApplication+OWS.swift
@@ -20,7 +20,7 @@ import Foundation
         }
         Logger.error("findFrontmostViewController: \(window)")
         guard let viewController = window.rootViewController else {
-            owsFail("\(self.logTag) in \(#function) Missing root view controller.")
+            owsFail("Missing root view controller.")
             return nil
         }
         return viewController.findFrontmostViewController(ignoringAlerts)

--- a/Signal/src/UserInterface/Notifications/CallNotificationsAdapter.swift
+++ b/Signal/src/UserInterface/Notifications/CallNotificationsAdapter.swift
@@ -30,12 +30,12 @@ public class CallNotificationsAdapter: NSObject {
     }
 
     func presentIncomingCall(_ call: SignalCall, callerName: String) {
-        Logger.debug("\(logTag) in \(#function)")
+        Logger.debug("")
         adaptee.presentIncomingCall(call, callerName: callerName)
     }
 
     func presentMissedCall(_ call: SignalCall, callerName: String) {
-        Logger.debug("\(logTag) in \(#function)")
+        Logger.debug("")
         adaptee.presentMissedCall(call, callerName: callerName)
     }
 

--- a/Signal/src/UserInterface/Notifications/UserNotificationsAdaptee.swift
+++ b/Signal/src/UserInterface/Notifications/UserNotificationsAdaptee.swift
@@ -88,11 +88,11 @@ class UserNotificationsAdaptee: NSObject, OWSCallNotificationsAdaptee, UNUserNot
     func requestAuthorization() {
         center.requestAuthorization(options: [.badge, .sound, .alert]) { (granted, error) in
             if granted {
-                Logger.debug("\(self.logTag) \(#function) succeeded.")
+                Logger.debug("succeeded.")
             } else if error != nil {
-                Logger.error("\(self.logTag) \(#function) failed with error: \(error!)")
+                Logger.error("failed with error: \(error!)")
             } else {
-                Logger.error("\(self.logTag) \(#function) failed without error.")
+                Logger.error("failed without error.")
             }
         }
     }
@@ -100,13 +100,13 @@ class UserNotificationsAdaptee: NSObject, OWSCallNotificationsAdaptee, UNUserNot
     // MARK: - OWSCallNotificationsAdaptee
 
     public func presentIncomingCall(_ call: SignalCall, callerName: String) {
-        Logger.debug("\(logTag) \(#function) is no-op, because it's handled with callkit.")
+        Logger.debug("is no-op, because it's handled with callkit.")
         // TODO since CallKit doesn't currently work on the simulator,
         // we could implement UNNotifications for simulator testing, or if people have opted out of callkit.
     }
 
     public func presentMissedCall(_ call: SignalCall, callerName: String) {
-        Logger.debug("\(logTag) \(#function)")
+        Logger.debug("")
 
         let content = UNMutableNotificationContent()
         // TODO group by thread identifier
@@ -132,7 +132,7 @@ class UserNotificationsAdaptee: NSObject, OWSCallNotificationsAdaptee, UNUserNot
     }
 
     public func presentMissedCallBecauseOfNoLongerVerifiedIdentity(call: SignalCall, callerName: String) {
-        Logger.debug("\(logTag) \(#function)")
+        Logger.debug("")
 
         let content = UNMutableNotificationContent()
         // TODO group by thread identifier
@@ -158,7 +158,7 @@ class UserNotificationsAdaptee: NSObject, OWSCallNotificationsAdaptee, UNUserNot
     }
 
     public func presentMissedCallBecauseOfNewIdentity(call: SignalCall, callerName: String) {
-        Logger.debug("\(logTag) \(#function)")
+        Logger.debug("")
 
         let content = UNMutableNotificationContent()
         // TODO group by thread identifier

--- a/Signal/src/ViewControllers/AddContactShareToExistingContactViewController.swift
+++ b/Signal/src/ViewControllers/AddContactShareToExistingContactViewController.swift
@@ -35,10 +35,10 @@ class AddContactShareToExistingContactViewController: ContactsPicker, ContactsPi
     // MARK: - ContactsPickerDelegate
 
     func contactsPicker(_: ContactsPicker, contactFetchDidFail error: NSError) {
-        owsFail("\(logTag) in \(#function) with error: \(error)")
+        owsFail("with error: \(error)")
 
         guard let navigationController = self.navigationController else {
-            owsFail("\(logTag) in \(#function) navigationController was unexpectedly nil")
+            owsFail("navigationController was unexpectedly nil")
             return
         }
 
@@ -46,9 +46,9 @@ class AddContactShareToExistingContactViewController: ContactsPicker, ContactsPi
     }
 
     func contactsPickerDidCancel(_: ContactsPicker) {
-        Logger.debug("\(self.logTag) in \(#function)")
+        Logger.debug("")
         guard let navigationController = self.navigationController else {
-            owsFail("\(logTag) in \(#function) navigationController was unexpectedly nil")
+            owsFail("navigationController was unexpectedly nil")
             return
         }
 
@@ -56,22 +56,22 @@ class AddContactShareToExistingContactViewController: ContactsPicker, ContactsPi
     }
 
     func contactsPicker(_: ContactsPicker, didSelectContact oldContact: Contact) {
-        Logger.debug("\(self.logTag) in \(#function)")
+        Logger.debug("")
 
         let contactsManager = Environment.current().contactsManager
         guard let oldCNContact = contactsManager?.cnContact(withId: oldContact.cnContactId) else {
-            owsFail("\(logTag) could not load old CNContact.")
+            owsFail("could not load old CNContact.")
             return
         }
         guard let newCNContact = OWSContacts.systemContact(for: self.contactShare.dbRecord, imageData: self.contactShare.avatarImageData) else {
-            owsFail("\(logTag) could not load new CNContact.")
+            owsFail("could not load new CNContact.")
             return
         }
         merge(oldCNContact: oldCNContact, newCNContact: newCNContact)
     }
 
     func merge(oldCNContact: CNContact, newCNContact: CNContact) {
-        Logger.debug("\(self.logTag) in \(#function)")
+        Logger.debug("")
 
         let mergedCNContact: CNContact = Contact.merge(cnContact: oldCNContact, newCNContact: newCNContact)
 
@@ -91,11 +91,11 @@ class AddContactShareToExistingContactViewController: ContactsPicker, ContactsPi
     }
 
     func contactsPicker(_: ContactsPicker, didSelectMultipleContacts contacts: [Contact]) {
-        Logger.debug("\(self.logTag) in \(#function)")
-        owsFail("\(logTag) only supports single contact select")
+        Logger.debug("")
+        owsFail("only supports single contact select")
 
         guard let navigationController = self.navigationController else {
-            owsFail("\(logTag) in \(#function) navigationController was unexpectedly nil")
+            owsFail("navigationController was unexpectedly nil")
             return
         }
 
@@ -109,10 +109,10 @@ class AddContactShareToExistingContactViewController: ContactsPicker, ContactsPi
     // MARK: - CNContactViewControllerDelegate
 
     public func contactViewController(_ viewController: CNContactViewController, didCompleteWith contact: CNContact?) {
-        Logger.debug("\(self.logTag) in \(#function)")
+        Logger.debug("")
 
         guard let navigationController = self.navigationController else {
-            owsFail("\(logTag) in \(#function) navigationController was unexpectedly nil")
+            owsFail("navigationController was unexpectedly nil")
             return
         }
 
@@ -129,7 +129,7 @@ class AddContactShareToExistingContactViewController: ContactsPicker, ContactsPi
         // Note this happens for *cancel* and for *done*. Unfortunately, I don't know of a way to detect the difference
         // between the two, since both just call this method.
         guard let myIndex = navigationController.viewControllers.index(of: self) else {
-            owsFail("\(logTag) in \(#function) myIndex was unexpectedly nil")
+            owsFail("myIndex was unexpectedly nil")
             navigationController.popViewController(animated: true)
             navigationController.popViewController(animated: true)
             return

--- a/Signal/src/ViewControllers/CallViewController.swift
+++ b/Signal/src/ViewControllers/CallViewController.swift
@@ -102,7 +102,7 @@ class CallViewController: OWSViewController, CallObserver, CallServiceObserver, 
     // MARK: - Audio Source
 
     var hasAlternateAudioSources: Bool {
-        Logger.info("available audio sources: \(allAudioSources)")
+        Logger.info("available audio sources: \(self.allAudioSources)")
         // internal mic and speakerphone will be the first two, any more than one indicates e.g. an attached bluetooth device.
 
         // TODO is this sufficient? Are their devices w/ bluetooth but no external speaker? e.g. ipod?

--- a/Signal/src/ViewControllers/CallViewController.swift
+++ b/Signal/src/ViewControllers/CallViewController.swift
@@ -102,7 +102,7 @@ class CallViewController: OWSViewController, CallObserver, CallServiceObserver, 
     // MARK: - Audio Source
 
     var hasAlternateAudioSources: Bool {
-        Logger.info("available audio sources: \(self.allAudioSources)")
+        Logger.info("available audio sources: \(allAudioSources)")
         // internal mic and speakerphone will be the first two, any more than one indicates e.g. an attached bluetooth device.
 
         // TODO is this sufficient? Are their devices w/ bluetooth but no external speaker? e.g. ipod?

--- a/Signal/src/ViewControllers/CallViewController.swift
+++ b/Signal/src/ViewControllers/CallViewController.swift
@@ -102,7 +102,7 @@ class CallViewController: OWSViewController, CallObserver, CallServiceObserver, 
     // MARK: - Audio Source
 
     var hasAlternateAudioSources: Bool {
-        Logger.info("\(logTag) available audio sources: \(allAudioSources)")
+        Logger.info("available audio sources: \(allAudioSources)")
         // internal mic and speakerphone will be the first two, any more than one indicates e.g. an attached bluetooth device.
 
         // TODO is this sufficient? Are their devices w/ bluetooth but no external speaker? e.g. ipod?
@@ -201,7 +201,7 @@ class CallViewController: OWSViewController, CallObserver, CallServiceObserver, 
         updateAvatarImage()
         NotificationCenter.default.addObserver(forName: .OWSContactsManagerSignalAccountsDidChange, object: nil, queue: nil) { [weak self] _ in
             guard let strongSelf = self else { return }
-            Logger.info("\(strongSelf.logTag) updating avatar image")
+            Logger.info("updating avatar image")
             strongSelf.updateAvatarImage()
         }
 
@@ -597,7 +597,7 @@ class CallViewController: OWSViewController, CallObserver, CallServiceObserver, 
 
     func showCallFailed(error: Error) {
         // TODO Show something in UI.
-        Logger.error("\(logTag) call failed with error: \(error)")
+        Logger.error("call failed with error: \(error)")
     }
 
     // MARK: - View State
@@ -779,10 +779,10 @@ class CallViewController: OWSViewController, CallObserver, CallServiceObserver, 
         // Dismiss Handling
         switch callState {
         case .remoteHangup, .remoteBusy, .localFailure:
-            Logger.debug("\(logTag) dismissing after delay because new state is \(callState)")
+            Logger.debug("dismissing after delay because new state is \(callState)")
             dismissIfPossible(shouldDelay: true)
         case .localHangup:
-            Logger.debug("\(logTag) dismissing immediately from local hangup")
+            Logger.debug("dismissing immediately from local hangup")
             dismissIfPossible(shouldDelay: false)
         default: break
         }
@@ -836,7 +836,7 @@ class CallViewController: OWSViewController, CallObserver, CallServiceObserver, 
      * Ends a connected call. Do not confuse with `didPressDeclineCall`.
      */
     @objc func didPressHangup(sender: UIButton) {
-        Logger.info("\(logTag) called \(#function)")
+        Logger.info("")
 
         callUIAdapter.localHangupCall(call)
 
@@ -844,14 +844,14 @@ class CallViewController: OWSViewController, CallObserver, CallServiceObserver, 
     }
 
     @objc func didPressMute(sender muteButton: UIButton) {
-        Logger.info("\(logTag) called \(#function)")
+        Logger.info("")
         muteButton.isSelected = !muteButton.isSelected
 
         callUIAdapter.setIsMuted(call: call, isMuted: muteButton.isSelected)
     }
 
     @objc func didPressAudioSource(sender button: UIButton) {
-        Logger.info("\(logTag) called \(#function)")
+        Logger.info("")
 
         if self.hasAlternateAudioSources {
             presentAudioSourcePicker()
@@ -861,26 +861,26 @@ class CallViewController: OWSViewController, CallObserver, CallServiceObserver, 
     }
 
     func didPressSpeakerphone(sender button: UIButton) {
-        Logger.info("\(logTag) called \(#function)")
+        Logger.info("")
 
         button.isSelected = !button.isSelected
         callUIAdapter.audioService.requestSpeakerphone(isEnabled: button.isSelected)
     }
 
     func didPressTextMessage(sender button: UIButton) {
-        Logger.info("\(logTag) called \(#function)")
+        Logger.info("")
 
         dismissIfPossible(shouldDelay: false)
     }
 
     @objc func didPressAnswerCall(sender: UIButton) {
-        Logger.info("\(logTag) called \(#function)")
+        Logger.info("")
 
         callUIAdapter.answerCall(call)
     }
 
     @objc func didPressVideo(sender: UIButton) {
-        Logger.info("\(logTag) called \(#function)")
+        Logger.info("")
         let hasLocalVideo = !sender.isSelected
 
         callUIAdapter.setHasLocalVideo(call: call, hasLocalVideo: hasLocalVideo)
@@ -890,7 +890,7 @@ class CallViewController: OWSViewController, CallObserver, CallServiceObserver, 
         sender.isSelected = !sender.isSelected
 
         let isUsingFrontCamera = !sender.isSelected
-        Logger.info("\(logTag) in \(#function) with isUsingFrontCamera: \(isUsingFrontCamera)")
+        Logger.info("with isUsingFrontCamera: \(isUsingFrontCamera)")
 
         callUIAdapter.setCameraSource(call: call, isUsingFrontCamera: isUsingFrontCamera)
     }
@@ -899,7 +899,7 @@ class CallViewController: OWSViewController, CallObserver, CallServiceObserver, 
      * Denies an incoming not-yet-connected call, Do not confuse with `didPressHangup`.
      */
     @objc func didPressDeclineCall(sender: UIButton) {
-        Logger.info("\(logTag) called \(#function)")
+        Logger.info("")
 
         callUIAdapter.declineCall(call)
 
@@ -907,7 +907,7 @@ class CallViewController: OWSViewController, CallObserver, CallServiceObserver, 
     }
 
     @objc func didPressShowCallSettings(sender: UIButton) {
-        Logger.info("\(logTag) called \(#function)")
+        Logger.info("")
 
         markSettingsNagAsComplete()
 
@@ -926,7 +926,7 @@ class CallViewController: OWSViewController, CallObserver, CallServiceObserver, 
     }
 
     @objc func didPressDismissNag(sender: UIButton) {
-        Logger.info("\(logTag) called \(#function)")
+        Logger.info("")
 
         markSettingsNagAsComplete()
 
@@ -940,7 +940,7 @@ class CallViewController: OWSViewController, CallObserver, CallServiceObserver, 
     // settings to their default values to indicate that the user has reviewed
     // them.
     private func markSettingsNagAsComplete() {
-        Logger.info("\(logTag) called \(#function)")
+        Logger.info("")
 
         let preferences = Environment.current().preferences!
 
@@ -956,7 +956,8 @@ class CallViewController: OWSViewController, CallObserver, CallServiceObserver, 
 
     internal func stateDidChange(call: SignalCall, state: CallState) {
         AssertIsOnMainThread()
-        Logger.info("\(self.logTag) new call status: \(state)")
+        Logger.info("new call status: \(state)")
+
         self.updateCallUI(callState: state)
     }
 
@@ -1012,7 +1013,7 @@ class CallViewController: OWSViewController, CallObserver, CallServiceObserver, 
         localVideoView.captureSession = captureSession
         let isHidden = captureSession == nil
 
-        Logger.info("\(logTag) \(#function) isHidden: \(isHidden)")
+        Logger.info("isHidden: \(isHidden)")
         localVideoView.isHidden = isHidden
 
         updateLocalVideoLayout()

--- a/Signal/src/ViewControllers/ColorPickerViewController.swift
+++ b/Signal/src/ViewControllers/ColorPickerViewController.swift
@@ -108,7 +108,7 @@ class ColorPickerViewController: UIViewController, UIPickerViewDelegate, UIPicke
 
     public func pickerView(_ pickerView: UIPickerView, viewForRow row: Int, forComponent component: Int, reusing view: UIView?) -> UIView {
         guard let color = colors[safe: row] else {
-            owsFail("\(logTag) in \(#function) color was unexpectedly nil")
+            owsFail("color was unexpectedly nil")
             return ColorView(color: .white)
         }
 
@@ -120,7 +120,7 @@ class ColorPickerViewController: UIViewController, UIPickerViewDelegate, UIPicke
     var currentColor: UIColor {
         let index = pickerView.selectedRow(inComponent: 0)
         guard let color = self.colors[safe: index] else {
-            owsFail("\(self.logTag) in \(#function) index was unexpectedly nil")
+            owsFail("index was unexpectedly nil")
             return UIColor.white
         }
 
@@ -130,7 +130,7 @@ class ColorPickerViewController: UIViewController, UIPickerViewDelegate, UIPicke
     @objc
     public func didTapSave() {
         guard let colorName = UIColor.ows_conversationColorName(color: self.currentColor) else {
-            owsFail("\(self.logTag) in \(#function) colorName was unexpectedly nil")
+            owsFail("colorName was unexpectedly nil")
             self.delegate?.colorPickerDidCancel(self)
             return
         }

--- a/Signal/src/ViewControllers/ContactShareViewHelper.swift
+++ b/Signal/src/ViewControllers/ContactShareViewHelper.swift
@@ -33,21 +33,21 @@ public class ContactShareViewHelper: NSObject, CNContactViewControllerDelegate {
 
     @objc
     public func sendMessage(contactShare: ContactShareViewModel, fromViewController: UIViewController) {
-        Logger.info("\(logTag) \(#function)")
+        Logger.info("")
 
         presentThreadAndPeform(action: .compose, contactShare: contactShare, fromViewController: fromViewController)
     }
 
     @objc
     public func audioCall(contactShare: ContactShareViewModel, fromViewController: UIViewController) {
-        Logger.info("\(logTag) \(#function)")
+        Logger.info("")
 
         presentThreadAndPeform(action: .audioCall, contactShare: contactShare, fromViewController: fromViewController)
     }
 
     @objc
     public func videoCall(contactShare: ContactShareViewModel, fromViewController: UIViewController) {
-        Logger.info("\(logTag) \(#function)")
+        Logger.info("")
 
         presentThreadAndPeform(action: .videoCall, contactShare: contactShare, fromViewController: fromViewController)
     }
@@ -57,7 +57,7 @@ public class ContactShareViewHelper: NSObject, CNContactViewControllerDelegate {
         // want to let the user select if there's more than one.
         let phoneNumbers = contactShare.systemContactsWithSignalAccountPhoneNumbers(contactsManager)
         guard phoneNumbers.count > 0 else {
-            owsFail("\(logTag) missing Signal recipient id.")
+            owsFail("missing Signal recipient id.")
             return
         }
         guard phoneNumbers.count > 1 else {
@@ -73,16 +73,16 @@ public class ContactShareViewHelper: NSObject, CNContactViewControllerDelegate {
 
     @objc
     public func showInviteContact(contactShare: ContactShareViewModel, fromViewController: UIViewController) {
-        Logger.info("\(logTag) \(#function)")
+        Logger.info("")
 
         guard MFMessageComposeViewController.canSendText() else {
-            Logger.info("\(logTag) Device cannot send text")
+            Logger.info("Device cannot send text")
             OWSAlerts.showErrorAlert(message: NSLocalizedString("UNSUPPORTED_FEATURE_ERROR", comment: ""))
             return
         }
         let phoneNumbers = contactShare.e164PhoneNumbers()
         guard phoneNumbers.count > 0 else {
-            owsFail("\(logTag) no phone numbers.")
+            owsFail("no phone numbers.")
             return
         }
 
@@ -93,7 +93,7 @@ public class ContactShareViewHelper: NSObject, CNContactViewControllerDelegate {
 
     @objc
     func showAddToContacts(contactShare: ContactShareViewModel, fromViewController: UIViewController) {
-        Logger.info("\(logTag) \(#function)")
+        Logger.info("")
 
         let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
 
@@ -128,13 +128,13 @@ public class ContactShareViewHelper: NSObject, CNContactViewControllerDelegate {
     }
 
     func didPressCreateNewContact(contactShare: ContactShareViewModel, fromViewController: UIViewController) {
-        Logger.info("\(logTag) \(#function)")
+        Logger.info("")
 
         presentNewContactView(contactShare: contactShare, fromViewController: fromViewController)
     }
 
     func didPressAddToExistingContact(contactShare: ContactShareViewModel, fromViewController: UIViewController) {
-        Logger.info("\(logTag) \(#function)")
+        Logger.info("")
 
         presentSelectAddToExistingContactView(contactShare: contactShare, fromViewController: fromViewController)
     }
@@ -143,12 +143,12 @@ public class ContactShareViewHelper: NSObject, CNContactViewControllerDelegate {
 
     private func presentNewContactView(contactShare: ContactShareViewModel, fromViewController: UIViewController) {
         guard contactsManager.supportsContactEditing else {
-            owsFail("\(logTag) Contact editing not supported")
+            owsFail("Contact editing not supported")
             return
         }
 
         guard let systemContact = OWSContacts.systemContact(for: contactShare.dbRecord, imageData: contactShare.avatarImageData) else {
-            owsFail("\(logTag) Could not derive system contact.")
+            owsFail("Could not derive system contact.")
             return
         }
 
@@ -172,7 +172,7 @@ public class ContactShareViewHelper: NSObject, CNContactViewControllerDelegate {
 
     private func presentSelectAddToExistingContactView(contactShare: ContactShareViewModel, fromViewController: UIViewController) {
         guard contactsManager.supportsContactEditing else {
-            owsFail("\(logTag) Contact editing not supported")
+            owsFail("Contact editing not supported")
             return
         }
 
@@ -182,7 +182,7 @@ public class ContactShareViewHelper: NSObject, CNContactViewControllerDelegate {
         }
 
         guard let navigationController = fromViewController.navigationController else {
-            owsFail("\(logTag) missing navigationController")
+            owsFail("missing navigationController")
             return
         }
 
@@ -193,10 +193,10 @@ public class ContactShareViewHelper: NSObject, CNContactViewControllerDelegate {
     // MARK: - CNContactViewControllerDelegate
 
     @objc public func contactViewController(_ viewController: CNContactViewController, didCompleteWith contact: CNContact?) {
-        Logger.info("\(logTag) \(#function)")
+        Logger.info("")
 
         guard let delegate = delegate else {
-            owsFail("\(logTag) missing delegate")
+            owsFail("missing delegate")
             return
         }
 
@@ -204,10 +204,10 @@ public class ContactShareViewHelper: NSObject, CNContactViewControllerDelegate {
     }
 
     @objc public func didFinishEditingContact() {
-        Logger.info("\(logTag) \(#function)")
+        Logger.info("")
 
         guard let delegate = delegate else {
-            owsFail("\(logTag) missing delegate")
+            owsFail("missing delegate")
             return
         }
 

--- a/Signal/src/ViewControllers/ContactViewController.swift
+++ b/Signal/src/ViewControllers/ContactViewController.swift
@@ -79,7 +79,7 @@ class ContactViewController: OWSViewController, ContactShareViewHelperDelegate {
         super.viewWillAppear(animated)
 
         guard let navigationController = self.navigationController else {
-            owsFail("\(logTag) in \(#function) navigationController was unexpectedly nil")
+            owsFail("navigationController was unexpectedly nil")
             return
         }
 
@@ -103,7 +103,7 @@ class ContactViewController: OWSViewController, ContactShareViewHelperDelegate {
             // animation glitch where the navigation bar for this view controller starts to appear while
             // the whole nav stack is about to be obscured by the modal we are presenting.
             guard let postDismissNavigationController = self.postDismissNavigationController else {
-                owsFail("\(logTag) in \(#function) postDismissNavigationController was unexpectedly nil")
+                owsFail("postDismissNavigationController was unexpectedly nil")
                 return
             }
 
@@ -157,7 +157,7 @@ class ContactViewController: OWSViewController, ContactShareViewHelperDelegate {
         AssertIsOnMainThread()
 
         guard let rootView = self.view else {
-            owsFail("\(logTag) missing root view.")
+            owsFail("missing root view.")
             return
         }
 
@@ -223,7 +223,7 @@ class ContactViewController: OWSViewController, ContactShareViewHelperDelegate {
 
         let backIconName = (CurrentAppContext().isRTL ? "system_disclosure_indicator" : "system_disclosure_indicator_rtl")
         guard let backIconImage = UIImage(named: backIconName) else {
-            owsFail("\(logTag) missing icon.")
+            owsFail("missing icon.")
             return topView
         }
         let backIconView = UIImageView(image: backIconImage.withRenderingMode(.alwaysTemplate))
@@ -438,7 +438,7 @@ class ContactViewController: OWSViewController, ContactShareViewHelperDelegate {
         circleView.autoHCenterInSuperview()
 
         guard let image = UIImage(named: imageName) else {
-            owsFail("\(logTag) missing image.")
+            owsFail("missing image.")
             return button
         }
         let imageView = UIImageView(image: image.withRenderingMode(.alwaysTemplate))
@@ -485,7 +485,7 @@ class ContactViewController: OWSViewController, ContactShareViewHelperDelegate {
     }
 
     func didPressShareContact(sender: UIGestureRecognizer) {
-        Logger.info("\(logTag) \(#function)")
+        Logger.info("")
 
         guard sender.state == .recognized else {
             return
@@ -494,40 +494,40 @@ class ContactViewController: OWSViewController, ContactShareViewHelperDelegate {
     }
 
     func didPressSendMessage() {
-        Logger.info("\(logTag) \(#function)")
+        Logger.info("")
 
         self.contactShareViewHelper.sendMessage(contactShare: self.contactShare, fromViewController: self)
     }
 
     func didPressAudioCall() {
-        Logger.info("\(logTag) \(#function)")
+        Logger.info("")
 
         self.contactShareViewHelper.audioCall(contactShare: self.contactShare, fromViewController: self)
     }
 
     func didPressVideoCall() {
-        Logger.info("\(logTag) \(#function)")
+        Logger.info("")
 
         self.contactShareViewHelper.videoCall(contactShare: self.contactShare, fromViewController: self)
     }
 
     func didPressInvite() {
-        Logger.info("\(logTag) \(#function)")
+        Logger.info("")
 
         self.contactShareViewHelper.showInviteContact(contactShare: self.contactShare, fromViewController: self)
     }
 
     func didPressAddToContacts() {
-        Logger.info("\(logTag) \(#function)")
+        Logger.info("")
 
         self.contactShareViewHelper.showAddToContacts(contactShare: self.contactShare, fromViewController: self)
     }
 
     func didPressDismiss() {
-        Logger.info("\(self.logTag) \(#function)")
+        Logger.info("")
 
         guard let navigationController = self.navigationController else {
-            owsFail("\(logTag) in \(#function) navigationController was unexpectedly nil")
+            owsFail("navigationController was unexpectedly nil")
             return
         }
 
@@ -535,7 +535,7 @@ class ContactViewController: OWSViewController, ContactShareViewHelperDelegate {
     }
 
     func didPressPhoneNumber(phoneNumber: OWSContactPhoneNumber) {
-        Logger.info("\(self.logTag) \(#function)")
+        Logger.info("")
 
         let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
 
@@ -570,17 +570,17 @@ class ContactViewController: OWSViewController, ContactShareViewHelperDelegate {
     }
 
     func callPhoneNumberWithSystemCall(phoneNumber: OWSContactPhoneNumber) {
-        Logger.info("\(self.logTag) \(#function)")
+        Logger.info("")
 
         guard let url = NSURL(string: "tel:\(phoneNumber.phoneNumber)") else {
-            owsFail("\(ContactViewController.logTag()) could not open phone number.")
+            owsFail("could not open phone number.")
             return
         }
         UIApplication.shared.openURL(url as URL)
     }
 
     func didPressEmail(email: OWSContactEmail) {
-        Logger.info("\(self.logTag) \(#function)")
+        Logger.info("")
 
         let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         actionSheet.addAction(UIAlertAction(title: NSLocalizedString("CONTACT_VIEW_OPEN_EMAIL_IN_EMAIL_APP",
@@ -598,17 +598,17 @@ class ContactViewController: OWSViewController, ContactShareViewHelperDelegate {
     }
 
     func openEmailInEmailApp(email: OWSContactEmail) {
-        Logger.info("\(self.logTag) \(#function)")
+        Logger.info("")
 
         guard let url = NSURL(string: "mailto:\(email.email)") else {
-            owsFail("\(ContactViewController.logTag()) could not open email.")
+            owsFail("could not open email.")
             return
         }
         UIApplication.shared.openURL(url as URL)
     }
 
     func didPressAddress(address: OWSContactAddress) {
-        Logger.info("\(self.logTag) \(#function)")
+        Logger.info("")
 
         let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         actionSheet.addAction(UIAlertAction(title: NSLocalizedString("CONTACT_VIEW_OPEN_ADDRESS_IN_MAPS_APP",
@@ -628,17 +628,17 @@ class ContactViewController: OWSViewController, ContactShareViewHelperDelegate {
     }
 
     func openAddressInMaps(address: OWSContactAddress) {
-        Logger.info("\(self.logTag) \(#function)")
+        Logger.info("")
 
         let mapAddress = formatAddressForQuery(address: address)
         guard let escapedMapAddress = mapAddress.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {
-            owsFail("\(ContactViewController.logTag()) could not open address.")
+            owsFail("could not open address.")
             return
         }
         // Note that we use "q" (i.e. query) rather than "address" since we can't assume
         // this is a well-formed address.
         guard let url = URL(string: "http://maps.apple.com/?q=\(escapedMapAddress)") else {
-            owsFail("\(ContactViewController.logTag()) could not open address.")
+            owsFail("could not open address.")
             return
         }
 
@@ -646,7 +646,7 @@ class ContactViewController: OWSViewController, ContactShareViewHelperDelegate {
     }
 
     func formatAddressForQuery(address: OWSContactAddress) -> String {
-        Logger.info("\(self.logTag) \(#function)")
+        Logger.info("")
 
         // Open address in Apple Maps app.
         var addressParts = [String]()
@@ -671,7 +671,7 @@ class ContactViewController: OWSViewController, ContactShareViewHelperDelegate {
     // MARK: - ContactShareViewHelperDelegate
 
     public func didCreateOrEditContact() {
-        Logger.info("\(logTag) \(#function)")
+        Logger.info("")
         updateContent()
 
         self.dismiss(animated: true)

--- a/Signal/src/ViewControllers/ContactsPicker.swift
+++ b/Signal/src/ViewControllers/ContactsPicker.swift
@@ -43,17 +43,17 @@ public class ContactsPicker: OWSViewController, UITableViewDelegate, UITableView
     // If the app is backgrounded and then foregrounded, when OWSWindowManager calls mainWindow.makeKeyAndVisible
     // the ConversationVC's inputAccessoryView will appear *above* us unless we'd previously become first responder.
     override public var canBecomeFirstResponder: Bool {
-        Logger.debug("\(self.logTag) in \(#function)")
+        Logger.debug("")
         return true
     }
 
     override public func becomeFirstResponder() -> Bool {
-        Logger.debug("\(self.logTag) in \(#function)")
+        Logger.debug("")
         return super.becomeFirstResponder()
     }
 
     override public func resignFirstResponder() -> Bool {
-        Logger.debug("\(self.logTag) in \(#function)")
+        Logger.debug("")
         return super.resignFirstResponder()
     }
 
@@ -159,7 +159,7 @@ public class ContactsPicker: OWSViewController, UITableViewDelegate, UITableView
 
     private func reloadContacts() {
         getContacts( onError: { error in
-            Logger.error("\(self.logTag) failed to reload contacts with error:\(error)")
+            Logger.error("failed to reload contacts with error:\(error)")
         })
     }
 
@@ -211,7 +211,7 @@ public class ContactsPicker: OWSViewController, UITableViewDelegate, UITableView
                     }
                     self.sections = collatedContacts(contacts)
                 } catch let error as NSError {
-                    Logger.error("\(self.logTag) Failed to fetch contacts with error:\(error)")
+                    Logger.error("Failed to fetch contacts with error:\(error)")
                 }
         }
     }
@@ -247,7 +247,7 @@ public class ContactsPicker: OWSViewController, UITableViewDelegate, UITableView
 
     open func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: contactCellReuseIdentifier, for: indexPath) as? ContactCell else {
-            owsFail("\(logTag) in \(#function) cell had unexpected type")
+            owsFail("cell had unexpected type")
             return UITableViewCell()
         }
 
@@ -280,7 +280,7 @@ public class ContactsPicker: OWSViewController, UITableViewDelegate, UITableView
     }
 
     open func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        Logger.verbose("\(logTag) \(#function)")
+        Logger.verbose("")
 
         let cell = tableView.cellForRow(at: indexPath) as! ContactCell
         let selectedContact = cell.contact!
@@ -350,7 +350,7 @@ public class ContactsPicker: OWSViewController, UITableViewDelegate, UITableView
                 let filteredContacts = try contactStore.unifiedContacts(matching: predicate, keysToFetch: allowedContactKeys)
                     filteredSections = collatedContacts(filteredContacts)
             } catch let error as NSError {
-                Logger.error("\(self.logTag) updating search results failed with error: \(error)")
+                Logger.error("updating search results failed with error: \(error)")
             }
         }
         self.tableView.reloadData()

--- a/Signal/src/ViewControllers/CropScaleImageViewController.swift
+++ b/Signal/src/ViewControllers/CropScaleImageViewController.swift
@@ -499,7 +499,7 @@ import SignalMessaging
 
         let scaledImage = UIGraphicsGetImageFromCurrentImageContext()
         if scaledImage == nil {
-            owsFail("\(logTag) could not generate dst image.")
+            owsFail("could not generate dst image.")
         }
         UIGraphicsEndImageContext()
         return scaledImage

--- a/Signal/src/ViewControllers/DebugUI/DebugUICalling.swift
+++ b/Signal/src/ViewControllers/DebugUI/DebugUICalling.swift
@@ -37,15 +37,15 @@ class DebugUICalling: DebugUIPage {
                     hangupBuilder.setId(kFakeCallId)
                     hangupMessage = try hangupBuilder.build()
                 } catch {
-                    owsFail("\(strongSelf.logTag) could not build proto")
+                    owsFail("could not build proto")
                     return
                 }
                 let callMessage = OWSOutgoingCallMessage(thread: thread, hangupMessage: hangupMessage)
 
                 strongSelf.messageSender.sendPromise(message: callMessage).then {
-                    Logger.debug("\(strongSelf.logTag) Successfully sent hangup call message to \(thread.contactIdentifier())")
+                    Logger.debug("Successfully sent hangup call message to \(thread.contactIdentifier())")
                 }.catch { error in
-                    Logger.error("\(strongSelf.logTag) failed to send hangup call message to \(thread.contactIdentifier()) with error: \(error)")
+                    Logger.error("failed to send hangup call message to \(thread.contactIdentifier()) with error: \(error)")
                 }
             },
             OWSTableItem(title: "Send 'busy' for old call") { [weak self] in
@@ -58,16 +58,16 @@ class DebugUICalling: DebugUIPage {
                     busyBuilder.setId(kFakeCallId)
                     busyMessage = try busyBuilder.build()
                 } catch {
-                    owsFail("Couldn't build proto in \(#function)")
+                    owsFail("Couldn't build proto")
                     return
                 }
 
                 let callMessage = OWSOutgoingCallMessage(thread: thread, busyMessage: busyMessage)
 
                 strongSelf.messageSender.sendPromise(message: callMessage).then {
-                    Logger.debug("\(strongSelf.logTag) Successfully sent busy call message to \(thread.contactIdentifier())")
+                    Logger.debug("Successfully sent busy call message to \(thread.contactIdentifier())")
                 }.catch { error in
-                    Logger.error("\(strongSelf.logTag) failed to send busy call message to \(thread.contactIdentifier()) with error: \(error)")
+                    Logger.error("failed to send busy call message to \(thread.contactIdentifier()) with error: \(error)")
                 }
             }
         ]

--- a/Signal/src/ViewControllers/DebugUI/DebugUIFileBrowser.swift
+++ b/Signal/src/ViewControllers/DebugUI/DebugUIFileBrowser.swift
@@ -65,7 +65,7 @@
                     return try fileManager.contentsOfDirectory(at: fileURL,
                                                                includingPropertiesForKeys: resourceKeys)
                 } catch {
-                    owsFail("\(self.logTag) contentsOfDirectory(\(fileURL) failed with error: \(error)")
+                    owsFail("contentsOfDirectory(\(fileURL) failed with error: \(error)")
                     return []
                 }
             }()
@@ -74,13 +74,13 @@
                 let fileIcon: String = {
                     do {
                         guard let isDirectory = try fileInDirectory.resourceValues(forKeys: Set(resourceKeys)).isDirectory else {
-                            owsFail("\(logTag) unable to check isDirectory for file: \(fileInDirectory)")
+                            owsFail("unable to check isDirectory for file: \(fileInDirectory)")
                             return ""
                         }
 
                         return isDirectory ? "📁 " : ""
                     } catch {
-                        owsFail("\(logTag) failed to check isDirectory for file: \(fileInDirectory) with error: \(error)")
+                        owsFail("failed to check isDirectory for file: \(fileInDirectory) with error: \(error)")
                         return ""
                     }
                 }()
@@ -107,7 +107,7 @@
                     }
                 }
             } catch {
-                owsFail("\(logTag) failed getting attributes for file at path: \(fileURL)")
+                owsFail("failed getting attributes for file at path: \(fileURL)")
                 return []
             }
         }()
@@ -207,12 +207,12 @@
                 }
 
                 OWSAlerts.showConfirmationAlert(title: "Delete \(strongSelf.fileURL.path)?") { _ in
-                    Logger.debug("\(strongSelf.logTag) deleting file at \(strongSelf.fileURL.path)")
+                    Logger.debug("deleting file at \(strongSelf.fileURL.path)")
                     do {
                         try strongSelf.fileManager.removeItem(atPath: strongSelf.fileURL.path)
                         strongSelf.navigationController?.popViewController(animated: true)
                     } catch {
-                        owsFail("\(strongSelf.logTag) failed to remove item: \(strongSelf.fileURL) with error: \(error)")
+                        owsFail("failed to remove item: \(strongSelf.fileURL) with error: \(error)")
                     }
                 }
             },
@@ -248,7 +248,7 @@
                         let attributes = try strongSelf.fileManager.attributesOfItem(atPath: fileURL.path)
                         return attributes[FileAttributeKey.protectionKey] as? FileProtectionType
                     } catch {
-                        owsFail("\(strongSelf.logTag) failed to get current file protection for file: \(fileURL)")
+                        owsFail("failed to get current file protection for file: \(fileURL)")
                         return nil
                     }
                 }()
@@ -260,14 +260,14 @@
                 let protections: [FileProtectionType] = [.none, .complete, .completeUnlessOpen, .completeUntilFirstUserAuthentication]
                 protections.forEach { (protection: FileProtectionType) in
                     actionSheet.addAction(UIAlertAction(title: "\(protection.rawValue.replacingOccurrences(of: "NSFile", with: ""))", style: .default) { (_: UIAlertAction) in
-                        Logger.debug("\(strongSelf.logTag) chose protection: \(protection) for file: \(fileURL)")
+                        Logger.debug("chose protection: \(protection) for file: \(fileURL)")
                         let fileAttributes: [FileAttributeKey: Any] = [.protectionKey: protection]
                         do {
                             try strongSelf.fileManager.setAttributes(fileAttributes, ofItemAtPath: strongSelf.fileURL.path)
-                            Logger.debug("\(strongSelf.logTag) updated file protection at path:\(fileURL.path) to: \(protection.rawValue)")
+                            Logger.debug("updated file protection at path:\(fileURL.path) to: \(protection.rawValue)")
                             strongSelf.updateContents()
                         } catch {
-                            owsFail("\(strongSelf.logTag) failed to update file protection at path:\(fileURL.path) with error: \(error)")
+                            owsFail("failed to update file protection at path:\(fileURL.path) with error: \(error)")
                         }
                     })
                 }
@@ -301,7 +301,7 @@
 
                     let newPath = strongSelf.fileURL.appendingPathComponent(inputString).path
 
-                    Logger.debug("\(strongSelf.logTag) creating file at \(newPath)")
+                    Logger.debug("creating file at \(newPath)")
                     strongSelf.fileManager.createFile(atPath: newPath, contents: nil)
 
                     strongSelf.updateContents()
@@ -339,12 +339,12 @@
 
                     let newPath = strongSelf.fileURL.appendingPathComponent(inputString).path
 
-                    Logger.debug("\(strongSelf.logTag) creating dir at \(newPath)")
+                    Logger.debug("creating dir at \(newPath)")
                     do {
                         try strongSelf.fileManager.createDirectory(atPath: newPath, withIntermediateDirectories: false)
                         strongSelf.updateContents()
                     } catch {
-                        owsFail("\(strongSelf.logTag) Failed to create dir: \(newPath) with error: \(error)")
+                        owsFail("Failed to create dir: \(newPath) with error: \(error)")
                     }
                 })
 

--- a/Signal/src/ViewControllers/DebugUI/DebugUINotifications.swift
+++ b/Signal/src/ViewControllers/DebugUI/DebugUINotifications.swift
@@ -31,7 +31,7 @@ class DebugUINotifications: DebugUIPage {
 
     override func section(thread aThread: TSThread?) -> OWSTableSection? {
         guard let thread = aThread else {
-            owsFail("\(logTag) Notifications must specify thread.")
+            owsFail("Notifications must specify thread.")
             return nil
         }
 
@@ -41,9 +41,9 @@ class DebugUINotifications: DebugUIPage {
                     return
                 }
 
-                Logger.info("\(strongSelf.logTag) scheduling notification for incoming message.")
+                Logger.info("scheduling notification for incoming message.")
                 strongSelf.delayedNotificationDispatch {
-                    Logger.info("\(strongSelf.logTag) dispatching")
+                    Logger.info("dispatching")
                     OWSPrimaryStorage.shared().newDatabaseConnection().read { (transaction) in
                         guard let viewTransaction = transaction.ext(TSMessageDatabaseViewExtensionName) as? YapDatabaseViewTransaction  else {
                             owsFail("unable to build view transaction")
@@ -59,7 +59,7 @@ class DebugUINotifications: DebugUIPage {
                             owsFail("last message was not an incoming message.")
                             return
                         }
-                        Logger.info("\(strongSelf.logTag) notifying user of incoming message")
+                        Logger.info("notifying user of incoming message")
                         strongSelf.notificationsManager.notifyUser(for: incomingMessage, in: thread, contactsManager: strongSelf.contactsManager, transaction: transaction)
                     }
                 }

--- a/Signal/src/ViewControllers/ExperienceUpgradesPageViewController.swift
+++ b/Signal/src/ViewControllers/ExperienceUpgradesPageViewController.swift
@@ -104,10 +104,10 @@ private class IntroducingCustomNotificationAudioExperienceUpgradeViewController:
     }
 
     @objc func didTapButton(sender: UIButton) {
-        Logger.debug("\(logTag) in \(#function)")
+        Logger.debug("")
 
         guard let buttonAction = self.buttonAction else {
-            owsFail("\(logTag) button action was nil")
+            owsFail("button action was nil")
             return
         }
 
@@ -214,10 +214,10 @@ private class IntroductingReadReceiptsExperienceUpgradeViewController: Experienc
     }
 
     @objc func didTapButton(sender: UIButton) {
-        Logger.debug("\(logTag) in \(#function)")
+        Logger.debug("")
 
         guard let buttonAction = self.buttonAction else {
-            owsFail("\(logTag) button action was nil")
+            owsFail("button action was nil")
             return
         }
 
@@ -344,7 +344,7 @@ private class IntroductingProfilesExperienceUpgradeViewController: ExperienceUpg
     // MARK: - Actions
 
     @objc func didTapButton(sender: UIButton) {
-        Logger.debug("\(logTag) in \(#function)")
+        Logger.debug("")
 
         // dismiss the modally presented view controller, then proceed.
         experienceUpgradesPageViewController.dismiss(animated: true) {
@@ -383,7 +383,7 @@ private class CallKitExperienceUpgradeViewController: ExperienceUpgradeViewContr
     // MARK: - Actions
 
     @objc func didTapPrivacySettingsButton(sender: UIButton) {
-        Logger.debug("\(logTag) in \(#function)")
+        Logger.debug("")
 
         // dismiss the modally presented view controller, then proceed.
         experienceUpgradesPageViewController.dismiss(animated: true) {
@@ -515,7 +515,7 @@ public class ExperienceUpgradesPageViewController: OWSViewController, UIPageView
 
     @objc public override func viewDidLoad() {
         guard let firstViewController = allViewControllers.first else {
-            owsFail("\(logTag) no pages to show.")
+            owsFail("no pages to show.")
             dismiss(animated: true)
             return
         }
@@ -551,7 +551,7 @@ public class ExperienceUpgradesPageViewController: OWSViewController, UIPageView
         dismissButton.contentEdgeInsets = UIEdgeInsets(top: dismissInsetValue, left: dismissInsetValue, bottom: dismissInsetValue, right: dismissInsetValue)
 
         guard let carouselView = self.pageViewController.view else {
-            Logger.error("\(logTag) carousel view was unexpectedly nil")
+            Logger.error("carousel view was unexpectedly nil")
             return
         }
 
@@ -599,9 +599,9 @@ public class ExperienceUpgradesPageViewController: OWSViewController, UIPageView
     // MARK: - UIPageViewControllerDataSource
 
     public func pageViewController(_ pageViewController: UIPageViewController, viewControllerAfter viewController: UIViewController) -> UIViewController? {
-        Logger.debug("\(logTag) in \(#function)")
+        Logger.debug("")
         guard let currentIndex = self.viewControllerIndexes[viewController] else {
-            owsFail("\(logTag) unknown view controller: \(viewController)")
+            owsFail("unknown view controller: \(viewController)")
             return nil
         }
 
@@ -614,9 +614,9 @@ public class ExperienceUpgradesPageViewController: OWSViewController, UIPageView
     }
 
     public func pageViewController(_ pageViewController: UIPageViewController, viewControllerBefore viewController: UIViewController) -> UIViewController? {
-        Logger.debug("\(logTag) in \(#function)")
+        Logger.debug("")
         guard let currentIndex = self.viewControllerIndexes[viewController] else {
-            owsFail("\(logTag) unknown view controller: \(viewController)")
+            owsFail("unknown view controller: \(viewController)")
             return nil
         }
 
@@ -635,12 +635,12 @@ public class ExperienceUpgradesPageViewController: OWSViewController, UIPageView
 
     public func presentationIndex(for pageViewController: UIPageViewController) -> Int {
         guard let currentViewController = pageViewController.viewControllers?.first else {
-            Logger.error("\(logTag) unexpectedly empty view controllers.")
+            Logger.error("unexpectedly empty view controllers.")
             return 0
         }
 
         guard let currentIndex = self.viewControllerIndexes[currentViewController] else {
-            Logger.error("\(logTag) unknown view controller: \(currentViewController)")
+            Logger.error("unknown view controller: \(currentViewController)")
             return 0
         }
 
@@ -649,11 +649,11 @@ public class ExperienceUpgradesPageViewController: OWSViewController, UIPageView
 
     public func addViewController(experienceUpgrade: ExperienceUpgrade) {
         guard let uniqueId = experienceUpgrade.uniqueId else {
-            Logger.error("\(self.logTag) experienceUpgrade is missing uniqueId.")
+            Logger.error("experienceUpgrade is missing uniqueId.")
             return
         }
         guard let identifier = ExperienceUpgradeId(rawValue: uniqueId) else {
-            owsFail("\(logTag) unknown experience upgrade. skipping")
+            owsFail("unknown experience upgrade. skipping")
             return
         }
 
@@ -681,19 +681,19 @@ public class ExperienceUpgradesPageViewController: OWSViewController, UIPageView
         // Blocking write before dismiss, to be sure they're marked as complete
         // before HomeView.didAppear is re-fired.
         self.editingDBConnection.readWrite { transaction in
-            Logger.info("\(self.logTag) marking all upgrades as seen.")
+            Logger.info("marking all upgrades as seen.")
             ExperienceUpgradeFinder.shared.markAllAsSeen(transaction: transaction)
         }
         super.dismiss(animated: flag, completion: completion)
     }
 
     @objc func didTapDismissButton(sender: UIButton) {
-        Logger.debug("\(logTag) in \(#function)")
+        Logger.debug("")
         self.dismiss(animated: true)
     }
 
     @objc func handleDismissGesture(sender: AnyObject) {
-        Logger.debug("\(logTag) in \(#function)")
+        Logger.debug("")
         self.dismiss(animated: true)
     }
 }

--- a/Signal/src/ViewControllers/GifPicker/GifPickerCell.swift
+++ b/Signal/src/ViewControllers/GifPicker/GifPickerCell.swift
@@ -113,7 +113,7 @@ class GifPickerCell: UICollectionViewCell {
         // Record high quality animated rendition, but to save bandwidth, don't start downloading
         // until it's selected.
         guard let highQualityAnimatedRendition = imageInfo.pickSendingRendition() else {
-            Logger.warn("\(logTag) could not pick gif rendition: \(imageInfo.giphyId)")
+            Logger.warn("could not pick gif rendition: \(imageInfo.giphyId)")
             clearAssetRequests()
             return
         }
@@ -122,12 +122,12 @@ class GifPickerCell: UICollectionViewCell {
         // The Giphy API returns a slew of "renditions" for a given image. 
         // It's critical that we carefully "pick" the best rendition to use.
         guard let animatedRendition = imageInfo.pickPreviewRendition() else {
-            Logger.warn("\(logTag) could not pick gif rendition: \(imageInfo.giphyId)")
+            Logger.warn("could not pick gif rendition: \(imageInfo.giphyId)")
             clearAssetRequests()
             return
         }
         guard let stillRendition = imageInfo.pickStillRendition() else {
-            Logger.warn("\(logTag) could not pick still rendition: \(imageInfo.giphyId)")
+            Logger.warn("could not pick still rendition: \(imageInfo.giphyId)")
             clearAssetRequests()
             return
         }
@@ -197,7 +197,7 @@ class GifPickerCell: UICollectionViewCell {
             return
         }
         guard let image = YYImage(contentsOfFile: asset.filePath) else {
-            owsFail("\(logTag) could not load asset.")
+            owsFail("could not load asset.")
             clearViewState()
             return
         }
@@ -208,7 +208,7 @@ class GifPickerCell: UICollectionViewCell {
             imageView.ows_autoPinToSuperviewEdges()
         }
         guard let imageView = imageView else {
-            owsFail("\(logTag) missing imageview.")
+            owsFail("missing imageview.")
             clearViewState()
             return
         }
@@ -240,7 +240,7 @@ class GifPickerCell: UICollectionViewCell {
 
     public func requestRenditionForSending() -> Promise<GiphyAsset> {
         guard let renditionForSending = self.renditionForSending else {
-            owsFail("\(logTag) renditionForSending was unexpectedly nil")
+            owsFail("renditionForSending was unexpectedly nil")
             return Promise(error: GiphyError.assertionError(description: "renditionForSending was unexpectedly nil"))
         }
 
@@ -257,7 +257,7 @@ class GifPickerCell: UICollectionViewCell {
                                                         failure: { _ in
                                                             // TODO GiphyDownloader API should pass through a useful failing error
                                                             // so we can pass it through here
-                                                            Logger.error("\(self.logTag) request failed")
+                                                            Logger.error("request failed")
                                                             reject(GiphyError.fetchFailure)
         })
 

--- a/Signal/src/ViewControllers/GifPicker/GifPickerViewController.swift
+++ b/Signal/src/ViewControllers/GifPicker/GifPickerViewController.swift
@@ -22,7 +22,7 @@ class GifPickerViewController: OWSViewController, UISearchBarDelegate, UICollect
 
     private var viewMode = ViewMode.idle {
         didSet {
-            Logger.info("viewMode: \(self.viewMode)")
+            Logger.info("viewMode: \(viewMode)")
 
             updateContents()
         }
@@ -301,7 +301,7 @@ class GifPickerViewController: OWSViewController, UISearchBarDelegate, UICollect
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: kCellReuseIdentifier, for: indexPath)
 
         guard indexPath.row < imageInfos.count else {
-            Logger.warn("indexPath: \(indexPath.row) out of range for imageInfo count: \(self.imageInfos.count) ")
+            Logger.warn("indexPath: \(indexPath.row) out of range for imageInfo count: \(imageInfos.count) ")
             return cell
         }
         let imageInfo = imageInfos[indexPath.row]

--- a/Signal/src/ViewControllers/GifPicker/GifPickerViewController.swift
+++ b/Signal/src/ViewControllers/GifPicker/GifPickerViewController.swift
@@ -22,7 +22,7 @@ class GifPickerViewController: OWSViewController, UISearchBarDelegate, UICollect
 
     private var viewMode = ViewMode.idle {
         didSet {
-            Logger.info("\(logTag) viewMode: \(viewMode)")
+            Logger.info("viewMode: \(viewMode)")
 
             updateContents()
         }
@@ -81,7 +81,7 @@ class GifPickerViewController: OWSViewController, UISearchBarDelegate, UICollect
     @objc func didBecomeActive() {
         AssertIsOnMainThread()
 
-        Logger.info("\(self.logTag) \(#function)")
+        Logger.info("")
 
         // Prod cells to try to load when app becomes active.
         ensureCellState()
@@ -90,7 +90,7 @@ class GifPickerViewController: OWSViewController, UISearchBarDelegate, UICollect
     @objc func reachabilityChanged() {
         AssertIsOnMainThread()
 
-        Logger.info("\(self.logTag) \(#function)")
+        Logger.info("")
 
         // Prod cells to try to load when connectivity changes.
         ensureCellState()
@@ -99,7 +99,7 @@ class GifPickerViewController: OWSViewController, UISearchBarDelegate, UICollect
     func ensureCellState() {
         for cell in self.collectionView.visibleCells {
             guard let cell = cell as? GifPickerCell else {
-                owsFail("\(logTag) unexpected cell.")
+                owsFail("unexpected cell.")
                 return
             }
             cell.ensureCellState()
@@ -301,13 +301,13 @@ class GifPickerViewController: OWSViewController, UISearchBarDelegate, UICollect
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: kCellReuseIdentifier, for: indexPath)
 
         guard indexPath.row < imageInfos.count else {
-            Logger.warn("\(logTag) indexPath: \(indexPath.row) out of range for imageInfo count: \(imageInfos.count) ")
+            Logger.warn("indexPath: \(indexPath.row) out of range for imageInfo count: \(imageInfos.count) ")
             return cell
         }
         let imageInfo = imageInfos[indexPath.row]
 
         guard let gifCell = cell as? GifPickerCell else {
-            owsFail("\(logTag) Unexpected cell type.")
+            owsFail("Unexpected cell type.")
             return cell
         }
         gifCell.imageInfo = imageInfo
@@ -319,18 +319,18 @@ class GifPickerViewController: OWSViewController, UISearchBarDelegate, UICollect
     public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
 
         guard let cell = collectionView.cellForItem(at: indexPath) as? GifPickerCell else {
-            owsFail("\(logTag) unexpected cell.")
+            owsFail("unexpected cell.")
             return
         }
 
         guard cell.stillAsset != nil || cell.animatedAsset != nil else {
             // we don't want to let the user blindly select a gray cell
-            Logger.debug("\(logTag) ignoring selection of cell with no preview")
+            Logger.debug("ignoring selection of cell with no preview")
             return
         }
 
         guard self.hasSelectedCell == false else {
-            owsFail("\(logTag) Already selected cell")
+            owsFail("Already selected cell")
             return
         }
         self.hasSelectedCell = true
@@ -363,14 +363,14 @@ class GifPickerViewController: OWSViewController, UISearchBarDelegate, UICollect
         GiphyDownloader.sharedInstance.cancelAllRequests()
         cell.requestRenditionForSending().then { [weak self] (asset: GiphyAsset) -> Void in
             guard let strongSelf = self else {
-                Logger.info("\(GifPickerViewController.logTag()) ignoring send, since VC was dismissed before fetching finished.")
+                Logger.info("ignoring send, since VC was dismissed before fetching finished.")
                 return
             }
 
             let filePath = asset.filePath
             guard let dataSource = DataSourcePath.dataSource(withFilePath: filePath,
                 shouldDeleteOnDeallocation: false) else {
-                owsFail("\(strongSelf.logTag) couldn't load asset.")
+                owsFail("couldn't load asset.")
                 return
             }
             let attachment = SignalAttachment.attachment(dataSource: dataSource, dataUTI: asset.rendition.utiType, imageQuality: .original)
@@ -381,7 +381,7 @@ class GifPickerViewController: OWSViewController, UISearchBarDelegate, UICollect
             }
         }.catch { [weak self] error in
             guard let strongSelf = self else {
-                Logger.info("\(GifPickerViewController.logTag()) ignoring failure, since VC was dismissed before fetching finished.")
+                Logger.info("ignoring failure, since VC was dismissed before fetching finished.")
                 return
             }
 
@@ -402,7 +402,7 @@ class GifPickerViewController: OWSViewController, UISearchBarDelegate, UICollect
 
     public func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
         guard let cell = cell as? GifPickerCell else {
-            owsFail("\(logTag) unexpected cell.")
+            owsFail("unexpected cell.")
             return
         }
         // We only want to load the cells which are on-screen.
@@ -411,7 +411,7 @@ class GifPickerViewController: OWSViewController, UISearchBarDelegate, UICollect
 
     public func collectionView(_ collectionView: UICollectionView, didEndDisplaying cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
         guard let cell = cell as? GifPickerCell else {
-            owsFail("\(logTag) unexpected cell.")
+            owsFail("unexpected cell.")
             return
         }
         cell.isCellVisible = false
@@ -463,7 +463,7 @@ class GifPickerViewController: OWSViewController, UISearchBarDelegate, UICollect
         let query = (text as String).trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
 
         if (viewMode == .searching || viewMode == .results) && lastQuery == query {
-            Logger.info("\(logTag) ignoring duplicate search: \(query)")
+            Logger.info("ignoring duplicate search: \(query)")
             return
         }
 
@@ -471,7 +471,7 @@ class GifPickerViewController: OWSViewController, UISearchBarDelegate, UICollect
     }
 
     private func search(query: String) {
-        Logger.info("\(logTag) searching: \(query)")
+        Logger.info("searching: \(query)")
 
         progressiveSearchTimer?.invalidate()
         progressiveSearchTimer = nil
@@ -482,7 +482,7 @@ class GifPickerViewController: OWSViewController, UISearchBarDelegate, UICollect
 
         GiphyAPI.sharedInstance.search(query: query, success: { [weak self] imageInfos in
             guard let strongSelf = self else { return }
-            Logger.info("\(strongSelf.logTag) search complete")
+            Logger.info("search complete")
             strongSelf.imageInfos = imageInfos
             if imageInfos.count > 0 {
                 strongSelf.viewMode = .results
@@ -492,7 +492,7 @@ class GifPickerViewController: OWSViewController, UISearchBarDelegate, UICollect
         },
             failure: { [weak self] _ in
                 guard let strongSelf = self else { return }
-                Logger.info("\(strongSelf.logTag) search failed.")
+                Logger.info("search failed.")
                 // TODO: Present this error to the user.
                 strongSelf.viewMode = .error
         })

--- a/Signal/src/ViewControllers/GifPicker/GifPickerViewController.swift
+++ b/Signal/src/ViewControllers/GifPicker/GifPickerViewController.swift
@@ -22,7 +22,7 @@ class GifPickerViewController: OWSViewController, UISearchBarDelegate, UICollect
 
     private var viewMode = ViewMode.idle {
         didSet {
-            Logger.info("viewMode: \(viewMode)")
+            Logger.info("viewMode: \(self.viewMode)")
 
             updateContents()
         }
@@ -301,7 +301,7 @@ class GifPickerViewController: OWSViewController, UISearchBarDelegate, UICollect
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: kCellReuseIdentifier, for: indexPath)
 
         guard indexPath.row < imageInfos.count else {
-            Logger.warn("indexPath: \(indexPath.row) out of range for imageInfo count: \(imageInfos.count) ")
+            Logger.warn("indexPath: \(indexPath.row) out of range for imageInfo count: \(self.imageInfos.count) ")
             return cell
         }
         let imageInfo = imageInfos[indexPath.row]

--- a/Signal/src/ViewControllers/HomeView/ConversationSearchViewController.swift
+++ b/Signal/src/ViewControllers/HomeView/ConversationSearchViewController.swift
@@ -122,17 +122,17 @@ class ConversationSearchViewController: UITableViewController {
         tableView.deselectRow(at: indexPath, animated: false)
 
         guard let searchSection = SearchSection(rawValue: indexPath.section) else {
-            owsFail("\(logTag) unknown section selected.")
+            owsFail("unknown section selected.")
             return
         }
 
         switch searchSection {
         case .noResults:
-            owsFail("\(logTag) shouldn't be able to tap 'no results' section")
+            owsFail("shouldn't be able to tap 'no results' section")
         case .conversations:
             let sectionResults = searchResultSet.conversations
             guard let searchResult = sectionResults[safe: indexPath.row] else {
-                owsFail("\(logTag) unknown row selected.")
+                owsFail("unknown row selected.")
                 return
             }
 
@@ -142,7 +142,7 @@ class ConversationSearchViewController: UITableViewController {
         case .contacts:
             let sectionResults = searchResultSet.contacts
             guard let searchResult = sectionResults[safe: indexPath.row] else {
-                owsFail("\(logTag) unknown row selected.")
+                owsFail("unknown row selected.")
                 return
             }
 
@@ -151,7 +151,7 @@ class ConversationSearchViewController: UITableViewController {
         case .messages:
             let sectionResults = searchResultSet.messages
             guard let searchResult = sectionResults[safe: indexPath.row] else {
-                owsFail("\(logTag) unknown row selected.")
+                owsFail("unknown row selected.")
                 return
             }
 
@@ -247,7 +247,7 @@ class ConversationSearchViewController: UITableViewController {
                 if let messageDate = searchResult.messageDate {
                     overrideDate = messageDate
                 } else {
-                    owsFail("\(ConversationSearchViewController.logTag()) message search result is missing message timestamp")
+                    owsFail("message search result is missing message timestamp")
                 }
 
                 // Note that we only use the snippet for message results,
@@ -260,7 +260,7 @@ class ConversationSearchViewController: UITableViewController {
                                                             NSAttributedStringKey.foregroundColor: Theme.secondaryColor
                     ])
                 } else {
-                    owsFail("\(ConversationSearchViewController.logTag()) message search result is missing message snippet")
+                    owsFail("message search result is missing message snippet")
                 }
             }
 

--- a/Signal/src/ViewControllers/InviteFlow.swift
+++ b/Signal/src/ViewControllers/InviteFlow.swift
@@ -60,12 +60,12 @@ class InviteFlow: NSObject, MFMessageComposeViewControllerDelegate, MFMailCompos
 
     func tweetAction() -> UIAlertAction? {
         guard canTweet()  else {
-            Logger.info("\(logTag) Twitter not supported.")
+            Logger.info("Twitter not supported.")
             return nil
         }
 
         guard let twitterViewController = SLComposeViewController(forServiceType: SLServiceTypeTwitter) else {
-            Logger.error("\(logTag) unable to build twitter controller.")
+            Logger.error("unable to build twitter controller.")
             return nil
         }
 
@@ -78,7 +78,7 @@ class InviteFlow: NSObject, MFMessageComposeViewControllerDelegate, MFMailCompos
 
         let tweetTitle = NSLocalizedString("SHARE_ACTION_TWEET", comment: "action sheet item")
         return UIAlertAction(title: tweetTitle, style: .default) { _ in
-            Logger.debug("\(self.logTag) Chose tweet")
+            Logger.debug("Chose tweet")
 
             self.presentingViewController.present(twitterViewController, animated: true, completion: nil)
         }
@@ -91,10 +91,10 @@ class InviteFlow: NSObject, MFMessageComposeViewControllerDelegate, MFMailCompos
     // MARK: ContactsPickerDelegate
 
     func contactsPicker(_: ContactsPicker, didSelectMultipleContacts contacts: [Contact]) {
-        Logger.debug("\(logTag) didSelectContacts:\(contacts)")
+        Logger.debug("didSelectContacts:\(contacts)")
 
         guard let inviteChannel = channel else {
-            Logger.error("\(logTag) unexpected nil channel after returning from contact picker.")
+            Logger.error("unexpected nil channel after returning from contact picker.")
             self.presentingViewController.dismiss(animated: true)
             return
         }
@@ -107,13 +107,13 @@ class InviteFlow: NSObject, MFMessageComposeViewControllerDelegate, MFMailCompos
             let recipients: [String] = contacts.map { $0.emails.first }.filter { $0 != nil }.map { $0! }
             sendMailTo(emails: recipients)
         default:
-            Logger.error("\(logTag) unexpected channel after returning from contact picker: \(inviteChannel)")
+            Logger.error("unexpected channel after returning from contact picker: \(inviteChannel)")
         }
     }
 
     func contactsPicker(_: ContactsPicker, shouldSelectContact contact: Contact) -> Bool {
         guard let inviteChannel = channel else {
-            Logger.error("\(logTag) unexpected nil channel in contact picker.")
+            Logger.error("unexpected nil channel in contact picker.")
             return true
         }
 
@@ -123,25 +123,25 @@ class InviteFlow: NSObject, MFMessageComposeViewControllerDelegate, MFMailCompos
         case .mail:
             return contact.emails.count > 0
         default:
-            Logger.error("\(logTag) unexpected channel after returning from contact picker: \(inviteChannel)")
+            Logger.error("unexpected channel after returning from contact picker: \(inviteChannel)")
         }
         return true
     }
 
     func contactsPicker(_: ContactsPicker, contactFetchDidFail error: NSError) {
-        Logger.error("\(self.logTag) in \(#function) with error: \(error)")
+        Logger.error("with error: \(error)")
         self.presentingViewController.dismiss(animated: true) {
             OWSAlerts.showErrorAlert(message: NSLocalizedString("ERROR_COULD_NOT_FETCH_CONTACTS", comment: "Error indicating that the phone's contacts could not be retrieved."))
         }
     }
 
     func contactsPickerDidCancel(_: ContactsPicker) {
-        Logger.debug("\(self.logTag) in \(#function)")
+        Logger.debug("")
         self.presentingViewController.dismiss(animated: true)
     }
 
     func contactsPicker(_: ContactsPicker, didSelectContact contact: Contact) {
-        owsFail("\(logTag) in \(#function) InviteFlow only supports multi-select")
+        owsFail("InviteFlow only supports multi-select")
         self.presentingViewController.dismiss(animated: true)
     }
 
@@ -149,13 +149,13 @@ class InviteFlow: NSObject, MFMessageComposeViewControllerDelegate, MFMailCompos
 
     func messageAction() -> UIAlertAction? {
         guard MFMessageComposeViewController.canSendText() else {
-            Logger.info("\(logTag) Device cannot send text")
+            Logger.info("Device cannot send text")
             return nil
         }
 
         let messageTitle = NSLocalizedString("SHARE_ACTION_MESSAGE", comment: "action sheet item to open native messages app")
         return UIAlertAction(title: messageTitle, style: .default) { _ in
-            Logger.debug("\(self.logTag) Chose message.")
+            Logger.debug("Chose message.")
             self.channel = .message
             let picker = ContactsPicker(allowsMultipleSelection: true, subtitleCellType: .phoneNumber)
             picker.contactsPickerDelegate = self
@@ -206,9 +206,9 @@ class InviteFlow: NSObject, MFMessageComposeViewControllerDelegate, MFMailCompos
                 warning.addAction(UIAlertAction(title: CommonStrings.dismissButton, style: .default, handler: nil))
                 self.presentingViewController.present(warning, animated: true, completion: nil)
             case .sent:
-                Logger.debug("\(self.logTag) user successfully invited their friends via SMS.")
+                Logger.debug("user successfully invited their friends via SMS.")
             case .cancelled:
-                Logger.debug("\(self.logTag) user cancelled message invite")
+                Logger.debug("user cancelled message invite")
             }
         }
     }
@@ -217,13 +217,13 @@ class InviteFlow: NSObject, MFMessageComposeViewControllerDelegate, MFMailCompos
 
     func mailAction() -> UIAlertAction? {
         guard MFMailComposeViewController.canSendMail() else {
-            Logger.info("\(logTag) Device cannot send mail")
+            Logger.info("Device cannot send mail")
             return nil
         }
 
         let mailActionTitle = NSLocalizedString("SHARE_ACTION_MAIL", comment: "action sheet item to open native mail app")
         return UIAlertAction(title: mailActionTitle, style: .default) { _ in
-            Logger.debug("\(self.logTag) Chose mail.")
+            Logger.debug("Chose mail.")
             self.channel = .mail
 
             let picker = ContactsPicker(allowsMultipleSelection: true, subtitleCellType: .email)
@@ -260,11 +260,11 @@ class InviteFlow: NSObject, MFMessageComposeViewControllerDelegate, MFMailCompos
                 warning.addAction(UIAlertAction(title: CommonStrings.dismissButton, style: .default, handler: nil))
                 self.presentingViewController.present(warning, animated: true, completion: nil)
             case .sent:
-                Logger.debug("\(self.logTag) user successfully invited their friends via mail.")
+                Logger.debug("user successfully invited their friends via mail.")
             case .saved:
-                Logger.debug("\(self.logTag) user saved mail invite.")
+                Logger.debug("user saved mail invite.")
             case .cancelled:
-                Logger.debug("\(self.logTag) user cancelled mail invite.")
+                Logger.debug("user cancelled mail invite.")
             }
         }
     }

--- a/Signal/src/ViewControllers/MediaGalleryViewController.swift
+++ b/Signal/src/ViewControllers/MediaGalleryViewController.swift
@@ -35,7 +35,7 @@ public struct MediaGalleryItem: Equatable, Hashable {
 
     var thumbnailImage: UIImage {
         guard let image = attachmentStream.thumbnailImage() else {
-            owsFail("\(logTag) in \(#function) unexpectedly unable to build attachment thumbnail")
+            owsFail("unexpectedly unable to build attachment thumbnail")
             return UIImage()
         }
 
@@ -44,7 +44,7 @@ public struct MediaGalleryItem: Equatable, Hashable {
 
     var fullSizedImage: UIImage {
         guard let image = attachmentStream.image() else {
-            owsFail("\(logTag) in \(#function) unexpectedly unable to build attachment image")
+            owsFail("unexpectedly unable to build attachment image")
             return UIImage()
         }
 
@@ -199,7 +199,7 @@ class MediaGalleryViewController: OWSNavigationController, MediaGalleryDataSourc
     private let fetchRangeSize: UInt = 10
 
     deinit {
-        Logger.debug("\(logTag) deinit")
+        Logger.debug("deinit")
     }
 
     @objc
@@ -224,17 +224,17 @@ class MediaGalleryViewController: OWSNavigationController, MediaGalleryDataSourc
     // If the app is backgrounded and then foregrounded, when OWSWindowManager calls mainWindow.makeKeyAndVisible
     // the ConversationVC's inputAccessoryView will appear *above* us unless we'd previously become first responder.
     override public var canBecomeFirstResponder: Bool {
-        Logger.debug("\(self.logTag) in \(#function)")
+        Logger.debug("")
         return true
     }
 
     override public func becomeFirstResponder() -> Bool {
-        Logger.debug("\(self.logTag) in \(#function)")
+        Logger.debug("")
         return super.becomeFirstResponder()
     }
 
     override public func resignFirstResponder() -> Bool {
-        Logger.debug("\(self.logTag) in \(#function)")
+        Logger.debug("")
         return super.resignFirstResponder()
     }
 
@@ -282,7 +282,7 @@ class MediaGalleryViewController: OWSNavigationController, MediaGalleryDataSourc
         }
 
         guard let initialDetailItem = galleryItem else {
-            owsFail("\(logTag) in \(#function) unexpectedly failed to build initialDetailItem.")
+            owsFail("unexpectedly failed to build initialDetailItem.")
             return
         }
 
@@ -329,7 +329,7 @@ class MediaGalleryViewController: OWSNavigationController, MediaGalleryDataSourc
         self.view.alpha = 0.0
 
         guard let detailView = pageViewController.view else {
-            owsFail("\(logTag) in \(#function) detailView was unexpectedly nil")
+            owsFail("detailView was unexpectedly nil")
             return
         }
 
@@ -454,7 +454,7 @@ class MediaGalleryViewController: OWSNavigationController, MediaGalleryDataSourc
             //
 
             guard let pageViewController = self.pageViewController else {
-                owsFail("\(logTag) in \(#function) pageViewController was unexpectedly nil")
+                owsFail("pageViewController was unexpectedly nil")
                 self.dismiss(animated: true)
 
                 return
@@ -473,7 +473,7 @@ class MediaGalleryViewController: OWSNavigationController, MediaGalleryDataSourc
         UIApplication.shared.isStatusBarHidden = false
 
         guard let detailView = mediaPageViewController.view else {
-            owsFail("\(logTag) in \(#function) detailView was unexpectedly nil")
+            owsFail("detailView was unexpectedly nil")
             self.presentingViewController?.dismiss(animated: false, completion: completion)
             return
         }
@@ -520,7 +520,7 @@ class MediaGalleryViewController: OWSNavigationController, MediaGalleryDataSourc
                            options: .curveEaseInOut,
                            animations: {
                             guard let replacingView = self.replacingView else {
-                                owsFail("\(self.logTag) in \(#function) replacingView was unexpectedly nil")
+                                owsFail("replacingView was unexpectedly nil")
                                 self.presentingViewController?.dismiss(animated: false, completion: completion)
                                 return
                             }
@@ -533,7 +533,7 @@ class MediaGalleryViewController: OWSNavigationController, MediaGalleryDataSourc
             })
         } else {
             guard let replacingView = self.replacingView else {
-                owsFail("\(self.logTag) in \(#function) replacingView was unexpectedly nil")
+                owsFail("replacingView was unexpectedly nil")
                 self.presentingViewController?.dismiss(animated: false, completion: completion)
                 return
             }
@@ -549,12 +549,12 @@ class MediaGalleryViewController: OWSNavigationController, MediaGalleryDataSourc
         }
 
         guard let originRect = self.originRect else {
-            owsFail("\(logTag) in \(#function) originRect was unexpectedly nil")
+            owsFail("originRect was unexpectedly nil")
             return
         }
 
         guard let presentationSuperview = self.presentationView.superview else {
-            owsFail("\(logTag) in \(#function) presentationView.superview was unexpectedly nil")
+            owsFail("presentationView.superview was unexpectedly nil")
             return
         }
 
@@ -613,7 +613,7 @@ class MediaGalleryViewController: OWSNavigationController, MediaGalleryDataSourc
 
     func buildGalleryItem(message: TSMessage, transaction: YapDatabaseReadTransaction) -> MediaGalleryItem? {
         guard let attachmentStream = message.attachment(with: transaction) as? TSAttachmentStream else {
-            owsFail("\(self.logTag) in \(#function) attachment was unexpectedly empty")
+            owsFail("attachment was unexpectedly empty")
             return nil
         }
 
@@ -623,7 +623,7 @@ class MediaGalleryViewController: OWSNavigationController, MediaGalleryDataSourc
     // Range instead of indexSet since it's contiguous?
     var fetchedIndexSet = IndexSet() {
         didSet {
-            Logger.debug("\(logTag) in \(#function) \(oldValue) -> \(fetchedIndexSet)")
+            Logger.debug("\(oldValue) -> \(fetchedIndexSet)")
         }
     }
 
@@ -670,7 +670,7 @@ class MediaGalleryViewController: OWSNavigationController, MediaGalleryDataSourc
 
                 let requestSet = IndexSet(integersIn: requestRange)
                 guard !self.fetchedIndexSet.contains(integersIn: requestSet) else {
-                    Logger.debug("\(self.logTag) in \(#function) all requested messages have already been loaded.")
+                    Logger.debug("all requested messages have already been loaded.")
                     return
                 }
 
@@ -682,21 +682,21 @@ class MediaGalleryViewController: OWSNavigationController, MediaGalleryDataSourc
                 let isFetchingEdgeOfGallery = (self.fetchedIndexSet.count - unfetchedSet.count) < requestSet.count
 
                 guard isSubstantialRequest || isFetchingEdgeOfGallery else {
-                    Logger.debug("\(self.logTag) in \(#function) ignoring small fetch request: \(unfetchedSet.count)")
+                    Logger.debug("ignoring small fetch request: \(unfetchedSet.count)")
                     return
                 }
 
-                Logger.debug("\(self.logTag) in \(#function) fetching set: \(unfetchedSet)")
+                Logger.debug("fetching set: \(unfetchedSet)")
                 let nsRange: NSRange = NSRange(location: unfetchedSet.min()!, length: unfetchedSet.count)
                 self.mediaGalleryFinder.enumerateMediaMessages(range: nsRange, transaction: transaction) { (message: TSMessage) in
 
                     guard !self.deletedMessages.contains(message) else {
-                        Logger.debug("\(self.logTag) skipping \(message) which has been deleted.")
+                        Logger.debug("skipping \(message) which has been deleted.")
                         return
                     }
 
                     guard let item: MediaGalleryItem = self.buildGalleryItem(message: message, transaction: transaction) else {
-                        owsFail("\(self.logTag) in \(#function) unexpectedly failed to buildGalleryItem")
+                        owsFail("unexpectedly failed to buildGalleryItem")
                         return
                     }
 
@@ -775,7 +775,7 @@ class MediaGalleryViewController: OWSNavigationController, MediaGalleryDataSourc
     func delete(items: [MediaGalleryItem], initiatedBy: MediaGalleryDataSourceDelegate) {
         AssertIsOnMainThread()
 
-        Logger.info("\(logTag) in \(#function) with items: \(items.map { ($0.attachmentStream, $0.message.timestamp) })")
+        Logger.info("with items: \(items.map { ($0.attachmentStream, $0.message.timestamp) })")
 
         deletedGalleryItems.formUnion(items)
         dataSourceDelegates.forEach { $0.value?.mediaGalleryDataSource(self, willDelete: items, initiatedBy: initiatedBy) }
@@ -795,40 +795,40 @@ class MediaGalleryViewController: OWSNavigationController, MediaGalleryDataSourc
 
         for item in items {
             guard let itemIndex = galleryItems.index(of: item) else {
-                owsFail("\(logTag) in \(#function) removing unknown item.")
+                owsFail("removing unknown item.")
                 return
             }
 
             self.galleryItems.remove(at: itemIndex)
 
             guard let sectionIndex = sectionDates.index(where: { $0 == item.galleryDate }) else {
-                owsFail("\(logTag) in \(#function) item with unknown date.")
+                owsFail("item with unknown date.")
                 return
             }
 
             guard var sectionItems = self.sections[item.galleryDate] else {
-                owsFail("\(logTag) in \(#function) item with unknown section")
+                owsFail("item with unknown section")
                 return
             }
 
             guard let sectionRowIndex = sectionItems.index(of: item) else {
-                owsFail("\(logTag) in \(#function) item with unknown sectionRowIndex")
+                owsFail("item with unknown sectionRowIndex")
                 return
             }
 
             // We need to calculate the index of the deleted item with respect to it's original position.
             guard let originalSectionIndex = originalSectionDates.index(where: { $0 == item.galleryDate }) else {
-                owsFail("\(logTag) in \(#function) item with unknown date.")
+                owsFail("item with unknown date.")
                 return
             }
 
             guard let originalSectionItems = originalSections[item.galleryDate] else {
-                owsFail("\(logTag) in \(#function) item with unknown section")
+                owsFail("item with unknown section")
                 return
             }
 
             guard let originalSectionRowIndex = originalSectionItems.index(of: item) else {
-                owsFail("\(logTag) in \(#function) item with unknown sectionRowIndex")
+                owsFail("item with unknown sectionRowIndex")
                 return
             }
 
@@ -853,12 +853,12 @@ class MediaGalleryViewController: OWSNavigationController, MediaGalleryDataSourc
     let kGallerySwipeLoadBatchSize: UInt = 5
 
     internal func galleryItem(after currentItem: MediaGalleryItem) -> MediaGalleryItem? {
-        Logger.debug("\(logTag) in \(#function)")
+        Logger.debug("")
 
         self.ensureGalleryItemsLoaded(.after, item: currentItem, amount: kGallerySwipeLoadBatchSize)
 
         guard let currentIndex = galleryItems.index(of: currentItem) else {
-            owsFail("currentIndex was unexpectedly nil in \(#function)")
+            owsFail("currentIndex was unexpectedly nil")
             return nil
         }
 
@@ -869,7 +869,7 @@ class MediaGalleryViewController: OWSNavigationController, MediaGalleryDataSourc
         }
 
         guard !deletedGalleryItems.contains(nextItem) else {
-            Logger.debug("\(self.logTag) in \(#function) nextItem was deleted - Recursing.")
+            Logger.debug("nextItem was deleted - Recursing.")
             return galleryItem(after: nextItem)
         }
 
@@ -877,12 +877,12 @@ class MediaGalleryViewController: OWSNavigationController, MediaGalleryDataSourc
     }
 
     internal func galleryItem(before currentItem: MediaGalleryItem) -> MediaGalleryItem? {
-        Logger.debug("\(logTag) in \(#function)")
+        Logger.debug("")
 
         self.ensureGalleryItemsLoaded(.before, item: currentItem, amount: kGallerySwipeLoadBatchSize)
 
         guard let currentIndex = galleryItems.index(of: currentItem) else {
-            owsFail("currentIndex was unexpectedly nil in \(#function)")
+            owsFail("currentIndex was unexpectedly nil")
             return nil
         }
 
@@ -893,7 +893,7 @@ class MediaGalleryViewController: OWSNavigationController, MediaGalleryDataSourc
         }
 
         guard !deletedGalleryItems.contains(previousItem) else {
-            Logger.debug("\(self.logTag) in \(#function) previousItem was deleted - Recursing.")
+            Logger.debug("previousItem was deleted - Recursing.")
             return galleryItem(before: previousItem)
         }
 

--- a/Signal/src/ViewControllers/MediaGalleryViewController.swift
+++ b/Signal/src/ViewControllers/MediaGalleryViewController.swift
@@ -623,7 +623,7 @@ class MediaGalleryViewController: OWSNavigationController, MediaGalleryDataSourc
     // Range instead of indexSet since it's contiguous?
     var fetchedIndexSet = IndexSet() {
         didSet {
-            Logger.debug("\(oldValue) -> \(self.fetchedIndexSet)")
+            Logger.debug("\(oldValue) -> \(fetchedIndexSet)")
         }
     }
 

--- a/Signal/src/ViewControllers/MediaGalleryViewController.swift
+++ b/Signal/src/ViewControllers/MediaGalleryViewController.swift
@@ -623,7 +623,7 @@ class MediaGalleryViewController: OWSNavigationController, MediaGalleryDataSourc
     // Range instead of indexSet since it's contiguous?
     var fetchedIndexSet = IndexSet() {
         didSet {
-            Logger.debug("\(oldValue) -> \(fetchedIndexSet)")
+            Logger.debug("\(oldValue) -> \(self.fetchedIndexSet)")
         }
     }
 

--- a/Signal/src/ViewControllers/MediaPageViewController.swift
+++ b/Signal/src/ViewControllers/MediaPageViewController.swift
@@ -120,7 +120,7 @@ class MediaPageViewController: UIPageViewController, UIPageViewControllerDataSou
     }
 
     deinit {
-        Logger.debug("\(logTag) deinit")
+        Logger.debug("deinit")
     }
 
     var footerBar: UIToolbar!
@@ -192,7 +192,7 @@ class MediaPageViewController: UIPageViewController, UIPageViewControllerDataSou
     }
 
     override func didReceiveMemoryWarning() {
-        Logger.info("\(logTag) in \(#function)")
+        Logger.info("")
         super.didReceiveMemoryWarning()
 
         self.cachedPages = [:]
@@ -214,12 +214,12 @@ class MediaPageViewController: UIPageViewController, UIPageViewControllerDataSou
 
     @objc
     public func didPressAllMediaButton(sender: Any) {
-        Logger.debug("\(logTag) in \(#function)")
+        Logger.debug("")
 
         currentViewController.stopAnyVideo()
 
         guard let mediaGalleryDataSource = self.mediaGalleryDataSource else {
-            owsFail("\(logTag) in \(#function) mediaGalleryDataSource was unexpectedly nil")
+            owsFail("mediaGalleryDataSource was unexpectedly nil")
             return
         }
         mediaGalleryDataSource.showAllMedia(focusedItem: currentItem)
@@ -227,7 +227,7 @@ class MediaPageViewController: UIPageViewController, UIPageViewControllerDataSou
 
     @objc
     public func didSwipeView(sender: Any) {
-        Logger.debug("\(logTag) in \(#function)")
+        Logger.debug("")
 
         self.dismissSelf(animated: true)
     }
@@ -258,7 +258,7 @@ class MediaPageViewController: UIPageViewController, UIPageViewControllerDataSou
         // TODO do we still need this? seems like a vestige
         // from when media detail view was used for attachment approval
         if self.footerBar == nil {
-            owsFail("\(logTag) No footer bar visible.")
+            owsFail("No footer bar visible.")
             return
         }
 
@@ -291,7 +291,7 @@ class MediaPageViewController: UIPageViewController, UIPageViewControllerDataSou
     @objc
     public func didPressShare(_ sender: Any) {
         guard let currentViewController = self.viewControllers?[0] as? MediaDetailViewController else {
-            owsFail("\(logTag) in \(#function) currentViewController was unexpectedly nil")
+            owsFail("currentViewController was unexpectedly nil")
             return
         }
         currentViewController.didPressShare(sender)
@@ -300,12 +300,12 @@ class MediaPageViewController: UIPageViewController, UIPageViewControllerDataSou
     @objc
     public func didPressDelete(_ sender: Any) {
         guard let currentViewController = self.viewControllers?[0] as? MediaDetailViewController else {
-            owsFail("\(logTag) in \(#function) currentViewController was unexpectedly nil")
+            owsFail("currentViewController was unexpectedly nil")
             return
         }
 
         guard let mediaGalleryDataSource = self.mediaGalleryDataSource else {
-            owsFail("\(logTag) in \(#function) mediaGalleryDataSource was unexpectedly nil")
+            owsFail("mediaGalleryDataSource was unexpectedly nil")
             return
         }
 
@@ -324,15 +324,15 @@ class MediaPageViewController: UIPageViewController, UIPageViewControllerDataSou
     // MARK: MediaGalleryDataSourceDelegate
 
     func mediaGalleryDataSource(_ mediaGalleryDataSource: MediaGalleryDataSource, willDelete items: [MediaGalleryItem], initiatedBy: MediaGalleryDataSourceDelegate) {
-        Logger.debug("\(self.logTag) in \(#function)")
+        Logger.debug("")
 
         guard let currentItem = self.currentItem else {
-              owsFail("\(logTag) in \(#function) currentItem was unexpectedly nil")
+              owsFail("currentItem was unexpectedly nil")
             return
         }
 
         guard items.contains(currentItem) else {
-            Logger.debug("\(self.logTag) in \(#function) irrelevant item")
+            Logger.debug("irrelevant item")
             return
         }
 
@@ -361,7 +361,7 @@ class MediaPageViewController: UIPageViewController, UIPageViewControllerDataSou
     @objc
     public func didPressPlayBarButton(_ sender: Any) {
         guard let currentViewController = self.viewControllers?[0] as? MediaDetailViewController else {
-            owsFail("\(logTag) in \(#function) currentViewController was unexpectedly nil")
+            owsFail("currentViewController was unexpectedly nil")
             return
         }
         currentViewController.didPressPlayBarButton(sender)
@@ -370,7 +370,7 @@ class MediaPageViewController: UIPageViewController, UIPageViewControllerDataSou
     @objc
     public func didPressPauseBarButton(_ sender: Any) {
         guard let currentViewController = self.viewControllers?[0] as? MediaDetailViewController else {
-            owsFail("\(logTag) in \(#function) currentViewController was unexpectedly nil")
+            owsFail("currentViewController was unexpectedly nil")
             return
         }
         currentViewController.didPressPauseBarButton(sender)
@@ -379,12 +379,12 @@ class MediaPageViewController: UIPageViewController, UIPageViewControllerDataSou
     // MARK: UIPageViewControllerDelegate
 
     public func pageViewController(_ pageViewController: UIPageViewController, willTransitionTo pendingViewControllers: [UIViewController]) {
-        Logger.debug("\(logTag) in \(#function)")
+        Logger.debug("")
 
         assert(pendingViewControllers.count == 1)
         pendingViewControllers.forEach { viewController in
             guard let pendingPage = viewController as? MediaDetailViewController else {
-                owsFail("\(logTag) in \(#function) unexpected mediaDetailViewController: \(viewController)")
+                owsFail("unexpected mediaDetailViewController: \(viewController)")
                 return
             }
 
@@ -394,12 +394,12 @@ class MediaPageViewController: UIPageViewController, UIPageViewControllerDataSou
     }
 
     public func pageViewController(_ pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [UIViewController], transitionCompleted: Bool) {
-        Logger.debug("\(logTag) in \(#function)")
+        Logger.debug("")
 
         assert(previousViewControllers.count == 1)
         previousViewControllers.forEach { viewController in
             guard let previousPage = viewController as? MediaDetailViewController else {
-                owsFail("\(logTag) in \(#function) unexpected mediaDetailViewController: \(viewController)")
+                owsFail("unexpected mediaDetailViewController: \(viewController)")
                 return
             }
 
@@ -416,15 +416,15 @@ class MediaPageViewController: UIPageViewController, UIPageViewControllerDataSou
     // MARK: UIPageViewControllerDataSource
 
     public func pageViewController(_ pageViewController: UIPageViewController, viewControllerBefore viewController: UIViewController) -> UIViewController? {
-        Logger.debug("\(logTag) in \(#function)")
+        Logger.debug("")
 
         guard let previousDetailViewController = viewController as? MediaDetailViewController else {
-            owsFail("\(logTag) in \(#function) unexpected viewController: \(viewController)")
+            owsFail("unexpected viewController: \(viewController)")
             return nil
         }
 
         guard let mediaGalleryDataSource = self.mediaGalleryDataSource else {
-            owsFail("\(logTag) in \(#function) mediaGalleryDataSource was unexpectedly nil")
+            owsFail("mediaGalleryDataSource was unexpectedly nil")
             return nil
         }
 
@@ -441,15 +441,15 @@ class MediaPageViewController: UIPageViewController, UIPageViewControllerDataSou
     }
 
     public func pageViewController(_ pageViewController: UIPageViewController, viewControllerAfter viewController: UIViewController) -> UIViewController? {
-        Logger.debug("\(logTag) in \(#function)")
+        Logger.debug("")
 
         guard let previousDetailViewController = viewController as? MediaDetailViewController else {
-            owsFail("\(logTag) in \(#function) unexpected viewController: \(viewController)")
+            owsFail("unexpected viewController: \(viewController)")
             return nil
         }
 
         guard let mediaGalleryDataSource = self.mediaGalleryDataSource else {
-            owsFail("\(logTag) in \(#function) mediaGalleryDataSource was unexpectedly nil")
+            owsFail("mediaGalleryDataSource was unexpectedly nil")
             return nil
         }
 
@@ -469,11 +469,11 @@ class MediaPageViewController: UIPageViewController, UIPageViewControllerDataSou
     private func buildGalleryPage(galleryItem: MediaGalleryItem) -> MediaDetailViewController? {
 
         if let cachedPage = cachedPages[galleryItem] {
-            Logger.debug("\(logTag) in \(#function) cache hit.")
+            Logger.debug("cache hit.")
             return cachedPage
         }
 
-        Logger.debug("\(logTag) in \(#function) cache miss.")
+        Logger.debug("cache miss.")
         var fetchedItem: ConversationViewItem?
         self.uiDatabaseConnection.read { transaction in
             let message = galleryItem.message
@@ -504,7 +504,7 @@ class MediaPageViewController: UIPageViewController, UIPageViewControllerDataSou
         currentViewController.stopAnyVideo()
 
         guard let mediaGalleryDataSource = self.mediaGalleryDataSource else {
-            owsFail("\(logTag) in \(#function) mediaGalleryDataSource was unexpectedly nil")
+            owsFail("mediaGalleryDataSource was unexpectedly nil")
             self.presentingViewController?.dismiss(animated: true)
 
             return
@@ -517,28 +517,28 @@ class MediaPageViewController: UIPageViewController, UIPageViewControllerDataSou
 
     @objc
     public func mediaDetailViewControllerDidTapMedia(_ mediaDetailViewController: MediaDetailViewController) {
-        Logger.debug("\(logTag) in \(#function)")
+        Logger.debug("")
 
         self.shouldHideToolbars = !self.shouldHideToolbars
     }
 
     public func mediaDetailViewController(_ mediaDetailViewController: MediaDetailViewController, requestDelete conversationViewItem: ConversationViewItem) {
         guard let mediaGalleryDataSource = self.mediaGalleryDataSource else {
-            owsFail("\(logTag) in \(#function) mediaGalleryDataSource was unexpectedly nil")
+            owsFail("mediaGalleryDataSource was unexpectedly nil")
             self.presentingViewController?.dismiss(animated: true)
 
             return
         }
 
         guard let message = conversationViewItem.interaction as? TSMessage else {
-            owsFail("\(logTag) in \(#function) unexpected interaction: \(type(of: conversationViewItem))")
+            owsFail("unexpected interaction: \(type(of: conversationViewItem))")
             self.presentingViewController?.dismiss(animated: true)
 
             return
         }
 
         guard let galleryItem = self.mediaGalleryDataSource?.galleryItems.first(where: { $0.message == message }) else {
-            owsFail("\(logTag) in \(#function) unexpected interaction: \(type(of: conversationViewItem))")
+            owsFail("unexpected interaction: \(type(of: conversationViewItem))")
             self.presentingViewController?.dismiss(animated: true)
 
             return
@@ -551,7 +551,7 @@ class MediaPageViewController: UIPageViewController, UIPageViewControllerDataSou
 
     public func mediaDetailViewController(_ mediaDetailViewController: MediaDetailViewController, isPlayingVideo: Bool) {
         guard mediaDetailViewController == currentViewController else {
-            Logger.verbose("\(logTag) in \(#function) ignoring stale delegate.")
+            Logger.verbose("ignoring stale delegate.")
             return
         }
 
@@ -572,7 +572,7 @@ class MediaPageViewController: UIPageViewController, UIPageViewControllerDataSou
         case is TSOutgoingMessage:
             return NSLocalizedString("MEDIA_GALLERY_SENDER_NAME_YOU", comment: "Short sender label for media sent by you")
         default:
-            owsFail("\(logTag) Unknown message type: \(type(of: message))")
+            owsFail("Unknown message type: \(type(of: message))")
             return ""
         }
     }
@@ -609,7 +609,7 @@ class MediaPageViewController: UIPageViewController, UIPageViewControllerDataSou
 
     private func updateTitle() {
         guard let currentItem = self.currentItem else {
-            owsFail("\(logTag) currentItem was unexpectedly nil")
+            owsFail("currentItem was unexpectedly nil")
             return
         }
         updateTitle(item: currentItem)

--- a/Signal/src/ViewControllers/MediaTileViewController.swift
+++ b/Signal/src/ViewControllers/MediaTileViewController.swift
@@ -14,14 +14,14 @@ public class MediaTileViewController: UICollectionViewController, MediaGalleryDa
 
     private var galleryItems: [GalleryDate: [MediaGalleryItem]] {
         guard let mediaGalleryDataSource = self.mediaGalleryDataSource else {
-            owsFail("\(logTag) in \(#function) mediaGalleryDataSource was unexpectedly nil")
+            owsFail("mediaGalleryDataSource was unexpectedly nil")
             return [:]
         }
         return mediaGalleryDataSource.sections
     }
     private var galleryDates: [GalleryDate] {
         guard let mediaGalleryDataSource = self.mediaGalleryDataSource else {
-            owsFail("\(logTag) in \(#function) mediaGalleryDataSource was unexpectedly nil")
+            owsFail("mediaGalleryDataSource was unexpectedly nil")
             return []
         }
         return mediaGalleryDataSource.sectionDates
@@ -33,7 +33,7 @@ public class MediaTileViewController: UICollectionViewController, MediaGalleryDa
     public weak var delegate: MediaTileViewControllerDelegate?
 
     deinit {
-        Logger.debug("\(logTag) deinit")
+        Logger.debug("deinit")
     }
 
     fileprivate let mediaTileViewLayout: MediaTileViewLayout
@@ -76,7 +76,7 @@ public class MediaTileViewController: UICollectionViewController, MediaGalleryDa
         self.title = MediaStrings.allMedia
 
         guard let collectionView = self.collectionView else {
-            owsFail("\(logTag) in \(#function) collectionView was unexpectedly nil")
+            owsFail("collectionView was unexpectedly nil")
             return
         }
 
@@ -131,11 +131,11 @@ public class MediaTileViewController: UICollectionViewController, MediaGalleryDa
         }
 
         guard let indexPath = self.indexPath(galleryItem: focusedItem) else {
-            owsFail("\(logTag) unexpectedly unable to find indexPath for focusedItem: \(focusedItem)")
+            owsFail("unexpectedly unable to find indexPath for focusedItem: \(focusedItem)")
             return
         }
 
-        Logger.debug("\(logTag) scrolling to focused item at indexPath: \(indexPath)")
+        Logger.debug("scrolling to focused item at indexPath: \(indexPath)")
         self.view.layoutIfNeeded()
         self.collectionView?.scrollToItem(at: indexPath, at: .centeredVertically, animated: false)
         self.autoLoadMoreIfNecessary()
@@ -157,7 +157,7 @@ public class MediaTileViewController: UICollectionViewController, MediaGalleryDa
 
     override public func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
 
-        Logger.debug("\(self.logTag) in \(#function)")
+        Logger.debug("")
 
         guard galleryDates.count > 0 else {
             return false
@@ -173,7 +173,7 @@ public class MediaTileViewController: UICollectionViewController, MediaGalleryDa
 
     override public func collectionView(_ collectionView: UICollectionView, shouldDeselectItemAt indexPath: IndexPath) -> Bool {
 
-        Logger.debug("\(self.logTag) in \(#function)")
+        Logger.debug("")
 
         guard galleryDates.count > 0 else {
             return false
@@ -189,7 +189,7 @@ public class MediaTileViewController: UICollectionViewController, MediaGalleryDa
 
     public override func collectionView(_ collectionView: UICollectionView, shouldHighlightItemAt indexPath: IndexPath) -> Bool {
 
-        Logger.debug("\(self.logTag) in \(#function)")
+        Logger.debug("")
 
         guard galleryDates.count > 0 else {
             return false
@@ -204,15 +204,15 @@ public class MediaTileViewController: UICollectionViewController, MediaGalleryDa
     }
 
     override public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        Logger.debug("\(self.logTag) in \(#function)")
+        Logger.debug("")
 
         guard let galleryCell = self.collectionView(collectionView, cellForItemAt: indexPath) as? MediaGalleryCell else {
-            owsFail("\(logTag) in \(#function) galleryCell was unexpectedly nil")
+            owsFail("galleryCell was unexpectedly nil")
             return
         }
 
         guard let galleryItem = galleryCell.item else {
-            owsFail("\(logTag) in \(#function) galleryItem was unexpectedly nil")
+            owsFail("galleryItem was unexpectedly nil")
             return
         }
 
@@ -225,7 +225,7 @@ public class MediaTileViewController: UICollectionViewController, MediaGalleryDa
     }
 
     public override func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
-        Logger.debug("\(self.logTag) in \(#function)")
+        Logger.debug("")
 
         if isInBatchSelectMode {
             updateDeleteButton()
@@ -268,12 +268,12 @@ public class MediaTileViewController: UICollectionViewController, MediaGalleryDa
         }
 
         guard let sectionDate = self.galleryDates[safe: sectionIdx - 1] else {
-            owsFail("\(logTag) in \(#function) unknown section: \(sectionIdx)")
+            owsFail("unknown section: \(sectionIdx)")
             return 0
         }
 
         guard let section = self.galleryItems[sectionDate] else {
-            owsFail("\(logTag) in \(#function) no section for date: \(sectionDate)")
+            owsFail("no section for date: \(sectionDate)")
             return 0
         }
 
@@ -287,7 +287,7 @@ public class MediaTileViewController: UICollectionViewController, MediaGalleryDa
         guard galleryDates.count > 0 else {
             guard let sectionHeader = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: MediaGalleryStaticHeader.reuseIdentifier, for: indexPath) as? MediaGalleryStaticHeader else {
 
-                owsFail("\(logTag) in \(#function) unable to build section header for kLoadOlderSectionIdx")
+                owsFail("unable to build section header for kLoadOlderSectionIdx")
                 return defaultView
             }
             let title = NSLocalizedString("GALLERY_TILES_EMPTY_GALLERY", comment: "Label indicating media gallery is empty")
@@ -300,7 +300,7 @@ public class MediaTileViewController: UICollectionViewController, MediaGalleryDa
             case kLoadOlderSectionIdx:
                 guard let sectionHeader = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: MediaGalleryStaticHeader.reuseIdentifier, for: indexPath) as? MediaGalleryStaticHeader else {
 
-                    owsFail("\(logTag) in \(#function) unable to build section header for kLoadOlderSectionIdx")
+                    owsFail("unable to build section header for kLoadOlderSectionIdx")
                     return defaultView
                 }
                 let title = NSLocalizedString("GALLERY_TILES_LOADING_OLDER_LABEL", comment: "Label indicating loading is in progress")
@@ -309,7 +309,7 @@ public class MediaTileViewController: UICollectionViewController, MediaGalleryDa
             case loadNewerSectionIdx:
                 guard let sectionHeader = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: MediaGalleryStaticHeader.reuseIdentifier, for: indexPath) as? MediaGalleryStaticHeader else {
 
-                    owsFail("\(logTag) in \(#function) unable to build section header for kLoadOlderSectionIdx")
+                    owsFail("unable to build section header for kLoadOlderSectionIdx")
                     return defaultView
                 }
                 let title = NSLocalizedString("GALLERY_TILES_LOADING_MORE_RECENT_LABEL", comment: "Label indicating loading is in progress")
@@ -317,11 +317,11 @@ public class MediaTileViewController: UICollectionViewController, MediaGalleryDa
                 return sectionHeader
             default:
                 guard let sectionHeader = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: MediaGallerySectionHeader.reuseIdentifier, for: indexPath) as? MediaGallerySectionHeader else {
-                    owsFail("\(logTag) in \(#function) unable to build section header for indexPath: \(indexPath)")
+                    owsFail("unable to build section header for indexPath: \(indexPath)")
                     return defaultView
                 }
                 guard let date = self.galleryDates[safe: indexPath.section - 1] else {
-                    owsFail("\(logTag) in \(#function) unknown section for indexPath: \(indexPath)")
+                    owsFail("unknown section for indexPath: \(indexPath)")
                     return defaultView
                 }
 
@@ -334,30 +334,30 @@ public class MediaTileViewController: UICollectionViewController, MediaGalleryDa
     }
 
     override public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        Logger.debug("\(logTag) in \(#function) indexPath: \(indexPath)")
+        Logger.debug("indexPath: \(indexPath)")
 
         let defaultCell = UICollectionViewCell()
 
         guard galleryDates.count > 0 else {
-            owsFail("\(logTag) in \(#function) unexpected cell for loadNewerSectionIdx")
+            owsFail("unexpected cell for loadNewerSectionIdx")
             return defaultCell
         }
 
         switch indexPath.section {
         case kLoadOlderSectionIdx:
-            owsFail("\(logTag) in \(#function) unexpected cell for kLoadOlderSectionIdx")
+            owsFail("unexpected cell for kLoadOlderSectionIdx")
             return defaultCell
         case loadNewerSectionIdx:
-            owsFail("\(logTag) in \(#function) unexpected cell for loadNewerSectionIdx")
+            owsFail("unexpected cell for loadNewerSectionIdx")
             return defaultCell
         default:
             guard let galleryItem = galleryItem(at: indexPath) else {
-                owsFail("\(logTag) in \(#function) no message for path: \(indexPath)")
+                owsFail("no message for path: \(indexPath)")
                 return defaultCell
             }
 
             guard let cell = self.collectionView?.dequeueReusableCell(withReuseIdentifier: MediaGalleryCell.reuseIdentifier, for: indexPath) as? MediaGalleryCell else {
-                owsFail("\(logTag) in \(#function) unexpected cell for indexPath: \(indexPath)")
+                owsFail("unexpected cell for indexPath: \(indexPath)")
                 return defaultCell
             }
 
@@ -369,17 +369,17 @@ public class MediaTileViewController: UICollectionViewController, MediaGalleryDa
 
     func galleryItem(at indexPath: IndexPath) -> MediaGalleryItem? {
         guard let sectionDate = self.galleryDates[safe: indexPath.section - 1] else {
-            owsFail("\(logTag) in \(#function) unknown section: \(indexPath.section)")
+            owsFail("unknown section: \(indexPath.section)")
             return nil
         }
 
         guard let sectionItems = self.galleryItems[sectionDate] else {
-            owsFail("\(logTag) in \(#function) no section for date: \(sectionDate)")
+            owsFail("no section for date: \(sectionDate)")
             return nil
         }
 
         guard let galleryItem = sectionItems[safe: indexPath.row] else {
-            owsFail("\(logTag) in \(#function) no message for row: \(indexPath.row)")
+            owsFail("no message for row: \(indexPath.row)")
             return nil
         }
 
@@ -400,7 +400,7 @@ public class MediaTileViewController: UICollectionViewController, MediaGalleryDa
         }
 
         guard let mediaGalleryDataSource = self.mediaGalleryDataSource else {
-            owsFail("\(logTag) in \(#function) mediaGalleryDataSource was unexpectedly nil")
+            owsFail("mediaGalleryDataSource was unexpectedly nil")
             return CGSize.zero
         }
 
@@ -428,7 +428,7 @@ public class MediaTileViewController: UICollectionViewController, MediaGalleryDa
 
     func updateDeleteButton() {
         guard let collectionView = self.collectionView else {
-            owsFail("\(logTag) in \(#function) collectionView was unexpectedly nil")
+            owsFail("collectionView was unexpectedly nil")
             return
         }
 
@@ -455,7 +455,7 @@ public class MediaTileViewController: UICollectionViewController, MediaGalleryDa
         isInBatchSelectMode = true
 
         guard let collectionView = self.collectionView else {
-            owsFail("\(logTag) in \(#function) collectionView was unexpectedly nil")
+            owsFail("collectionView was unexpectedly nil")
             return
         }
 
@@ -487,7 +487,7 @@ public class MediaTileViewController: UICollectionViewController, MediaGalleryDa
         isInBatchSelectMode = false
 
         guard let collectionView = self.collectionView else {
-            owsFail("\(logTag) in \(#function) collectionView was unexpectedly nil")
+            owsFail("collectionView was unexpectedly nil")
             return
         }
 
@@ -509,22 +509,22 @@ public class MediaTileViewController: UICollectionViewController, MediaGalleryDa
 
     @objc
     func didPressDelete(_ sender: Any) {
-        Logger.debug("\(self.logTag) in \(#function)")
+        Logger.debug("")
 
         guard let collectionView = self.collectionView else {
-            owsFail("\(logTag) in \(#function) collectionView was unexpectedly nil")
+            owsFail("collectionView was unexpectedly nil")
             return
         }
 
         guard let indexPaths = collectionView.indexPathsForSelectedItems else {
-            owsFail("\(logTag) in \(#function) indexPaths was unexpectedly nil")
+            owsFail("indexPaths was unexpectedly nil")
             return
         }
 
         let items: [MediaGalleryItem] = indexPaths.compactMap { return self.galleryItem(at: $0) }
 
         guard let mediaGalleryDataSource = self.mediaGalleryDataSource else {
-            owsFail("\(logTag) in \(#function) mediaGalleryDataSource was unexpectedly nil")
+            owsFail("mediaGalleryDataSource was unexpectedly nil")
             return
         }
 
@@ -557,10 +557,10 @@ public class MediaTileViewController: UICollectionViewController, MediaGalleryDa
     // MARK: MediaGalleryDataSourceDelegate
 
     func mediaGalleryDataSource(_ mediaGalleryDataSource: MediaGalleryDataSource, willDelete items: [MediaGalleryItem], initiatedBy: MediaGalleryDataSourceDelegate) {
-        Logger.debug("\(self.logTag) in \(#function)")
+        Logger.debug("")
 
         guard let collectionView = self.collectionView else {
-            owsFail("\(logTag) in \(#function) collectionView was unexpectedly nil")
+            owsFail("collectionView was unexpectedly nil")
             return
         }
 
@@ -570,10 +570,10 @@ public class MediaTileViewController: UICollectionViewController, MediaGalleryDa
     }
 
     func mediaGalleryDataSource(_ mediaGalleryDataSource: MediaGalleryDataSource, deletedSections: IndexSet, deletedItems: [IndexPath]) {
-        Logger.debug("\(self.logTag) in \(#function) with deletedSections: \(deletedSections) deletedItems: \(deletedItems)")
+        Logger.debug("with deletedSections: \(deletedSections) deletedItems: \(deletedItems)")
 
         guard let collectionView = self.collectionView else {
-            owsFail("\(logTag) in \(#function) collectionView was unexpetedly nil")
+            owsFail("collectionView was unexpetedly nil")
             return
         }
 
@@ -625,12 +625,12 @@ public class MediaTileViewController: UICollectionViewController, MediaGalleryDa
         }
 
         guard let collectionView = self.collectionView else {
-            owsFail("\(logTag) in \(#function) collectionView was unexpectedly nil")
+            owsFail("collectionView was unexpectedly nil")
             return
         }
 
         guard let mediaGalleryDataSource = self.mediaGalleryDataSource else {
-            owsFail("\(logTag) in \(#function) mediaGalleryDataSource was unexpectedly nil")
+            owsFail("mediaGalleryDataSource was unexpectedly nil")
             return
         }
 
@@ -641,7 +641,7 @@ public class MediaTileViewController: UICollectionViewController, MediaGalleryDa
             // Near the top, load older content
 
             guard let oldestLoadedItem = self.oldestLoadedItem else {
-                Logger.debug("\(logTag) in \(#function) no oldest item")
+                Logger.debug("no oldest item")
                 return
             }
 
@@ -650,7 +650,7 @@ public class MediaTileViewController: UICollectionViewController, MediaGalleryDa
             }
 
             guard !isFetchingMoreData else {
-                Logger.debug("\(logTag) in \(#function) already fetching more data")
+                Logger.debug("already fetching more data")
                 return
             }
             isFetchingMoreData = true
@@ -666,13 +666,13 @@ public class MediaTileViewController: UICollectionViewController, MediaGalleryDa
             mediaTileViewLayout.contentSizeBeforeInsertingToTop = collectionView.contentSize
             collectionView.performBatchUpdates({
                 mediaGalleryDataSource.ensureGalleryItemsLoaded(.before, item: oldestLoadedItem, amount: self.kMediaTileViewLoadBatchSize) { addedSections, addedItems in
-                    Logger.debug("\(self.logTag) in \(#function) insertingSections: \(addedSections) items: \(addedItems)")
+                    Logger.debug("insertingSections: \(addedSections) items: \(addedItems)")
 
                     collectionView.insertSections(addedSections)
                     collectionView.insertItems(at: addedItems)
                 }
             }, completion: { finished in
-                Logger.debug("\(self.logTag) in \(#function) performBatchUpdates finished: \(finished)")
+                Logger.debug("performBatchUpdates finished: \(finished)")
                 self.isFetchingMoreData = false
                 CATransaction.commit()
             })
@@ -681,7 +681,7 @@ public class MediaTileViewController: UICollectionViewController, MediaGalleryDa
             // Near the bottom, load newer content
 
             guard let mostRecentLoadedItem = self.mostRecentLoadedItem else {
-                Logger.debug("\(logTag) in \(#function) no mostRecent item")
+                Logger.debug("no mostRecent item")
                 return
             }
 
@@ -690,7 +690,7 @@ public class MediaTileViewController: UICollectionViewController, MediaGalleryDa
             }
 
             guard !isFetchingMoreData else {
-                Logger.debug("\(logTag) in \(#function) already fetching more data")
+                Logger.debug("already fetching more data")
                 return
             }
             isFetchingMoreData = true
@@ -700,12 +700,12 @@ public class MediaTileViewController: UICollectionViewController, MediaGalleryDa
             UIView.performWithoutAnimation {
                 collectionView.performBatchUpdates({
                     mediaGalleryDataSource.ensureGalleryItemsLoaded(.after, item: mostRecentLoadedItem, amount: self.kMediaTileViewLoadBatchSize) { addedSections, addedItems in
-                        Logger.debug("\(self.logTag) in \(#function) insertingSections: \(addedSections), items: \(addedItems)")
+                        Logger.debug("insertingSections: \(addedSections), items: \(addedItems)")
                         collectionView.insertSections(addedSections)
                         collectionView.insertItems(at: addedItems)
                     }
                 }, completion: { finished in
-                    Logger.debug("\(self.logTag) in \(#function) performBatchUpdates finished: \(finished)")
+                    Logger.debug("performBatchUpdates finished: \(finished)")
                     self.isFetchingMoreData = false
                     CATransaction.commit()
                 })

--- a/Signal/src/ViewControllers/MenuActionsViewController.swift
+++ b/Signal/src/ViewControllers/MenuActionsViewController.swift
@@ -36,7 +36,7 @@ class MenuActionsViewController: UIViewController, MenuActionSheetDelegate {
     private let actionSheetView: MenuActionSheetView
 
     deinit {
-        Logger.verbose("\(logTag) in \(#function)")
+        Logger.verbose("")
         assert(didInformDelegateOfDismissalAnimation)
         assert(didInformDelegateThatDisappearenceCompleted)
     }
@@ -80,7 +80,7 @@ class MenuActionsViewController: UIViewController, MenuActionSheetDelegate {
     }
 
     override func viewDidDisappear(_ animated: Bool) {
-        Logger.debug("\(logTag) in \(#function)")
+        Logger.debug("")
         super.viewDidDisappear(animated)
 
         // When the user has manually dismissed the menu, we do a nice animation
@@ -97,13 +97,13 @@ class MenuActionsViewController: UIViewController, MenuActionSheetDelegate {
 
     private func addSnapshotFocusedView() -> UIView? {
         guard let snapshotView = self.focusedView.snapshotView(afterScreenUpdates: false) else {
-            owsFail("\(self.logTag) in \(#function) snapshotView was unexpectedly nil")
+            owsFail("snapshotView was unexpectedly nil")
             return nil
         }
         view.addSubview(snapshotView)
 
         guard let focusedViewSuperview = focusedView.superview else {
-            owsFail("\(self.logTag) in \(#function) focusedViewSuperview was unexpectedly nil")
+            owsFail("focusedViewSuperview was unexpectedly nil")
             return nil
         }
 
@@ -115,18 +115,18 @@ class MenuActionsViewController: UIViewController, MenuActionSheetDelegate {
 
     private func animatePresentation() {
         guard let actionSheetViewVerticalConstraint = self.actionSheetViewVerticalConstraint else {
-            owsFail("\(self.logTag) in \(#function) actionSheetViewVerticalConstraint was unexpectedly nil")
+            owsFail("actionSheetViewVerticalConstraint was unexpectedly nil")
             return
         }
 
         guard let focusedViewSuperview = focusedView.superview else {
-            owsFail("\(self.logTag) in \(#function) focusedViewSuperview was unexpectedly nil")
+            owsFail("focusedViewSuperview was unexpectedly nil")
             return
         }
 
         // darken background
         guard let snapshotView = addSnapshotFocusedView() else {
-            owsFail("\(self.logTag) in \(#function) snapshotView was unexpectedly nil")
+            owsFail("snapshotView was unexpectedly nil")
             return
         }
 
@@ -169,19 +169,19 @@ class MenuActionsViewController: UIViewController, MenuActionSheetDelegate {
 
     private func animateDismiss(action: MenuAction?) {
         guard let actionSheetViewVerticalConstraint = self.actionSheetViewVerticalConstraint else {
-            owsFail("\(self.logTag) in \(#function) actionSheetVerticalConstraint was unexpectedly nil")
+            owsFail("actionSheetVerticalConstraint was unexpectedly nil")
             self.delegate?.menuActionsDidHide(self)
             return
         }
 
         guard let snapshotView = self.snapshotView else {
-            owsFail("\(self.logTag) in \(#function) snapshotView was unexpectedly nil")
+            owsFail("snapshotView was unexpectedly nil")
             self.delegate?.menuActionsDidHide(self)
             return
         }
 
         guard let presentationFocusOffset = self.presentationFocusOffset else {
-            owsFail("\(self.logTag) in \(#function) presentationFocusOffset was unexpectedly nil")
+            owsFail("presentationFocusOffset was unexpectedly nil")
             self.delegate?.menuActionsDidHide(self)
             return
         }
@@ -214,7 +214,7 @@ class MenuActionsViewController: UIViewController, MenuActionSheetDelegate {
     var didInformDelegateThatDisappearenceCompleted = false
     func ensureDelegateIsInformedThatDisappearenceCompleted() {
         guard !didInformDelegateThatDisappearenceCompleted else {
-            Logger.debug("\(logTag) in \(#function) ignoring redundant 'disappeared' notification")
+            Logger.debug("ignoring redundant 'disappeared' notification")
             return
         }
         didInformDelegateThatDisappearenceCompleted = true
@@ -225,13 +225,13 @@ class MenuActionsViewController: UIViewController, MenuActionSheetDelegate {
     var didInformDelegateOfDismissalAnimation = false
     func ensureDelegateIsInformedOfDismissalAnimation() {
         guard !didInformDelegateOfDismissalAnimation else {
-            Logger.debug("\(logTag) in \(#function) ignoring redundant 'dismissal' notification")
+            Logger.debug("ignoring redundant 'dismissal' notification")
             return
         }
         didInformDelegateOfDismissalAnimation = true
 
         guard let presentationFocusOffset = self.presentationFocusOffset else {
-            owsFail("\(self.logTag) in \(#function) presentationFocusOffset was unexpectedly nil")
+            owsFail("presentationFocusOffset was unexpectedly nil")
             self.delegate?.menuActionsDidHide(self)
             return
         }
@@ -319,14 +319,14 @@ class MenuActionSheetView: UIView, MenuActionViewDelegate {
             let location = gesture.location(in: self)
             highlightActionView(location: location, fromView: self)
         case .ended:
-            Logger.debug("\(logTag) in \(#function) ended")
+            Logger.debug("ended")
             let location = gesture.location(in: self)
             selectActionView(location: location, fromView: self)
         case .cancelled:
-            Logger.debug("\(logTag) in \(#function) canceled")
+            Logger.debug("canceled")
             unhighlightAllActionViews()
         case .failed:
-            Logger.debug("\(logTag) in \(#function) failed")
+            Logger.debug("failed")
             unhighlightAllActionViews()
         }
     }
@@ -481,7 +481,7 @@ class MenuActionView: UIButton {
 
     @objc
     func didPress(sender: Any) {
-        Logger.debug("\(logTag) in \(#function)")
+        Logger.debug("")
         self.delegate?.actionView(self, didSelectAction: action)
     }
 

--- a/Signal/src/ViewControllers/MessageDetailViewController.swift
+++ b/Signal/src/ViewControllers/MessageDetailViewController.swift
@@ -89,7 +89,7 @@ class MessageDetailViewController: OWSViewController, MediaGalleryDataSourceDele
     }
 
     override public func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        Logger.debug("\(self.logTag) in \(#function)")
+        Logger.debug("")
 
         super.viewWillTransition(to: size, with: coordinator)
 
@@ -181,7 +181,7 @@ class MessageDetailViewController: OWSViewController, MediaGalleryDataSourceDele
 
     private func updateContent() {
         guard let contentView = contentView else {
-            owsFail("\(logTag) Missing contentView")
+            owsFail("Missing contentView")
             return
         }
 
@@ -234,7 +234,7 @@ class MessageDetailViewController: OWSViewController, MediaGalleryDataSourceDele
 
                 for recipientId in messageRecipientIds {
                     guard let recipientState = outgoingMessage.recipientState(forRecipientId: recipientId) else {
-                        owsFail("\(self.logTag) no message status for recipient: \(recipientId).")
+                        owsFail("no message status for recipient: \(recipientId).")
                         continue
                     }
 
@@ -370,7 +370,7 @@ class MessageDetailViewController: OWSViewController, MediaGalleryDataSourceDele
 
         if rows.isEmpty {
             // Neither attachment nor body.
-            owsFail("\(self.logTag) Message has neither attachment nor body.")
+            owsFail("Message has neither attachment nor body.")
             rows.append(valueRow(name: NSLocalizedString("MESSAGE_METADATA_VIEW_NO_ATTACHMENT_OR_BODY",
                                                          comment: "Label for messages without a body or attachment in the 'message metadata' view."),
                                  value: ""))
@@ -389,7 +389,7 @@ class MessageDetailViewController: OWSViewController, MediaGalleryDataSourceDele
         }
 
         guard let attachment = TSAttachment.fetch(uniqueId: attachmentId, transaction: transaction) else {
-            Logger.warn("\(logTag) Missing attachment. Was it deleted?")
+            Logger.warn("Missing attachment. Was it deleted?")
             return nil
         }
 
@@ -400,7 +400,7 @@ class MessageDetailViewController: OWSViewController, MediaGalleryDataSourceDele
         var rows = [UIView]()
 
         guard let attachment = self.attachment else {
-            Logger.warn("\(logTag) Missing attachment. Was it deleted?")
+            Logger.warn("Missing attachment. Was it deleted?")
             return rows
         }
 
@@ -513,7 +513,7 @@ class MessageDetailViewController: OWSViewController, MediaGalleryDataSourceDele
 
     @objc func shareButtonPressed() {
         guard let attachmentStream = attachmentStream else {
-            Logger.error("\(logTag) Share button should only be shown with attachment, but no attachment found.")
+            Logger.error("Share button should only be shown with attachment, but no attachment found.")
             return
         }
         AttachmentSharing.showShareUI(forAttachment: attachmentStream)
@@ -528,11 +528,11 @@ class MessageDetailViewController: OWSViewController, MediaGalleryDataSourceDele
 
         self.uiDatabaseConnection.read { transaction in
             guard let uniqueId = self.message.uniqueId else {
-                Logger.error("\(self.logTag) Message is missing uniqueId.")
+                Logger.error("Message is missing uniqueId.")
                 return
             }
             guard let newMessage = TSInteraction.fetch(uniqueId: uniqueId, transaction: transaction) as? TSMessage else {
-                Logger.error("\(self.logTag) Couldn't reload message.")
+                Logger.error("Couldn't reload message.")
                 return
             }
             self.message = newMessage
@@ -551,13 +551,13 @@ class MessageDetailViewController: OWSViewController, MediaGalleryDataSourceDele
         let notifications = self.uiDatabaseConnection.beginLongLivedReadTransaction()
 
         guard let uniqueId = self.message.uniqueId else {
-            Logger.error("\(self.logTag) Message is missing uniqueId.")
+            Logger.error("Message is missing uniqueId.")
             return
         }
         guard self.uiDatabaseConnection.hasChange(forKey: uniqueId,
                                                  inCollection: TSInteraction.collection(),
                                                  in: notifications) else {
-                                                    Logger.debug("\(logTag) No relevant changes.")
+                                                    Logger.debug("No relevant changes.")
                                                     return
         }
 
@@ -627,7 +627,7 @@ class MessageDetailViewController: OWSViewController, MediaGalleryDataSourceDele
 
     func didTapContactShare(_ viewItem: ConversationViewItem) {
         guard let contactShare = viewItem.contactShare else {
-            owsFail("\(logTag) missing contact.")
+            owsFail("missing contact.")
             return
         }
         let contactViewController = ContactViewController(contactShare: contactShare)
@@ -652,12 +652,12 @@ class MessageDetailViewController: OWSViewController, MediaGalleryDataSourceDele
         AssertIsOnMainThread()
 
         guard let mediaURL = attachmentStream.mediaURL() else {
-            owsFail("\(logTag) in \(#function) mediaURL was unexpectedly nil for attachment: \(attachmentStream)")
+            owsFail("mediaURL was unexpectedly nil for attachment: \(attachmentStream)")
             return
         }
 
         guard FileManager.default.fileExists(atPath: mediaURL.path) else {
-            owsFail("\(logTag) in \(#function) audio file missing at path: \(mediaURL)")
+            owsFail("audio file missing at path: \(mediaURL)")
             return
         }
 
@@ -682,7 +682,7 @@ class MessageDetailViewController: OWSViewController, MediaGalleryDataSourceDele
 
     func didTapTruncatedTextMessage(_ conversationItem: ConversationViewItem) {
         guard let navigationController = self.navigationController else {
-            owsFail("\(logTag) in \(#function) navigationController was unexpectedly nil")
+            owsFail("navigationController was unexpectedly nil")
             return
         }
 
@@ -717,11 +717,11 @@ class MessageDetailViewController: OWSViewController, MediaGalleryDataSourceDele
     // MediaGalleryDataSourceDelegate
 
     func mediaGalleryDataSource(_ mediaGalleryDataSource: MediaGalleryDataSource, willDelete items: [MediaGalleryItem], initiatedBy: MediaGalleryDataSourceDelegate) {
-        Logger.info("\(self.logTag) in \(#function)")
+        Logger.info("")
 
         guard (items.map({ $0.message }) == [self.message]) else {
             // Should only be one message we can delete when viewing message details
-            owsFail("\(logTag) in \(#function) Unexpectedly informed of irrelevant message deletion")
+            owsFail("Unexpectedly informed of irrelevant message deletion")
             return
         }
 

--- a/Signal/src/ViewControllers/OWS2FAReminderViewController.swift
+++ b/Signal/src/ViewControllers/OWS2FAReminderViewController.swift
@@ -96,7 +96,7 @@ public class OWS2FAReminderViewController: UIViewController, PinEntryViewDelegat
     }
 
     private func didSubmitCorrectPin() {
-        Logger.info("noWrongGuesses: \(self.noWrongGuesses)")
+        Logger.info("noWrongGuesses: \(noWrongGuesses)")
 
         self.dismiss(animated: true)
 

--- a/Signal/src/ViewControllers/OWS2FAReminderViewController.swift
+++ b/Signal/src/ViewControllers/OWS2FAReminderViewController.swift
@@ -96,7 +96,7 @@ public class OWS2FAReminderViewController: UIViewController, PinEntryViewDelegat
     }
 
     private func didSubmitCorrectPin() {
-        Logger.info("noWrongGuesses: \(noWrongGuesses)")
+        Logger.info("noWrongGuesses: \(self.noWrongGuesses)")
 
         self.dismiss(animated: true)
 

--- a/Signal/src/ViewControllers/OWS2FAReminderViewController.swift
+++ b/Signal/src/ViewControllers/OWS2FAReminderViewController.swift
@@ -59,7 +59,7 @@ public class OWS2FAReminderViewController: UIViewController, PinEntryViewDelegat
 
     // MARK: PinEntryViewDelegate
     public func pinEntryView(_ entryView: PinEntryView, submittedPinCode pinCode: String) {
-        Logger.info("\(logTag) in \(#function)")
+        Logger.info("")
         if checkResult(pinCode: pinCode) {
             didSubmitCorrectPin()
         } else {
@@ -76,7 +76,7 @@ public class OWS2FAReminderViewController: UIViewController, PinEntryViewDelegat
     }
 
     public func pinEntryViewForgotPinLinkTapped(_ entryView: PinEntryView) {
-        Logger.info("\(logTag) in \(#function)")
+        Logger.info("")
         let alertBody = NSLocalizedString("REMINDER_2FA_FORGOT_PIN_ALERT_MESSAGE",
                                           comment: "Alert message explaining what happens if you forget your 'two-factor auth pin'")
         OWSAlerts.showAlert(title: nil, message: alertBody)
@@ -86,7 +86,7 @@ public class OWS2FAReminderViewController: UIViewController, PinEntryViewDelegat
 
     @objc
     private func didPressCloseButton(sender: UIButton) {
-        Logger.info("\(logTag) in \(#function)")
+        Logger.info("")
         // We'll ask again next time they launch
         self.dismiss(animated: true)
     }
@@ -96,7 +96,7 @@ public class OWS2FAReminderViewController: UIViewController, PinEntryViewDelegat
     }
 
     private func didSubmitCorrectPin() {
-        Logger.info("\(logTag) in \(#function) noWrongGuesses: \(noWrongGuesses)")
+        Logger.info("noWrongGuesses: \(noWrongGuesses)")
 
         self.dismiss(animated: true)
 
@@ -106,7 +106,7 @@ public class OWS2FAReminderViewController: UIViewController, PinEntryViewDelegat
     var noWrongGuesses = true
     private func didSubmitWrongPin() {
         noWrongGuesses = false
-        Logger.info("\(logTag) in \(#function)")
+        Logger.info("")
         let alertTitle = NSLocalizedString("REMINDER_2FA_WRONG_PIN_ALERT_TITLE",
                                           comment: "Alert title after wrong guess for 'two-factor auth pin' reminder activity")
         let alertBody = NSLocalizedString("REMINDER_2FA_WRONG_PIN_ALERT_BODY",

--- a/Signal/src/ViewControllers/SafetyNumberConfirmationAlert.swift
+++ b/Signal/src/ViewControllers/SafetyNumberConfirmationAlert.swift
@@ -65,7 +65,7 @@ public class SafetyNumberConfirmationAlert: NSObject {
         let actionSheetController = UIAlertController(title: title, message: body, preferredStyle: .actionSheet)
 
         let confirmAction = UIAlertAction(title: confirmationText, style: .default) { _ in
-            Logger.info("\(self.logTag) Confirmed identity: \(untrustedIdentity)")
+            Logger.info("Confirmed identity: \(untrustedIdentity)")
 
         self.primaryStorage.newDatabaseConnection().asyncReadWrite { (transaction) in
             OWSIdentityManager.shared().setVerificationState(.default, identityKey: untrustedIdentity.identityKey, recipientId: untrustedIdentity.recipientId, isUserInitiatedChange: true, transaction: transaction)
@@ -77,7 +77,7 @@ public class SafetyNumberConfirmationAlert: NSObject {
         actionSheetController.addAction(confirmAction)
 
         let showSafetyNumberAction = UIAlertAction(title: NSLocalizedString("VERIFY_PRIVACY", comment: "Label for button or row which allows users to verify the safety number of another user."), style: .default) { _ in
-            Logger.info("\(self.logTag) Opted to show Safety Number for identity: \(untrustedIdentity)")
+            Logger.info("Opted to show Safety Number for identity: \(untrustedIdentity)")
 
             self.presentSafetyNumberViewController(theirIdentityKey: untrustedIdentity.identityKey,
                                                    theirRecipientId: untrustedIdentity.recipientId,
@@ -90,7 +90,7 @@ public class SafetyNumberConfirmationAlert: NSObject {
         // We can't use the default `OWSAlerts.cancelAction` because we need to specify that the completion
         // handler is called.
         let cancelAction = UIAlertAction(title: CommonStrings.cancelButton, style: .cancel) { _ in
-            Logger.info("\(self.logTag) user canceled.")
+            Logger.info("user canceled.")
             completion(false)
         }
         actionSheetController.addAction(cancelAction)
@@ -103,7 +103,7 @@ public class SafetyNumberConfirmationAlert: NSObject {
 
     public func presentSafetyNumberViewController(theirIdentityKey: Data, theirRecipientId: String, theirDisplayName: String, completion: (() -> Void)? = nil) {
         guard let fromViewController = UIApplication.shared.frontmostViewController else {
-            Logger.info("\(self.logTag) Missing frontmostViewController")
+            Logger.info("Missing frontmostViewController")
             return
         }
         FingerprintViewController.present(from: fromViewController, recipientId: theirRecipientId)

--- a/Signal/src/ViewControllers/Utils/MessageRecipientStatusUtils.swift
+++ b/Signal/src/ViewControllers/Utils/MessageRecipientStatusUtils.swift
@@ -127,7 +127,7 @@ public class MessageRecipientStatusUtils: NSObject {
             return (.sent, NSLocalizedString("MESSAGE_STATUS_SENT",
                                      comment: "status message for sent messages"))
         default:
-            owsFail("\(self.logTag) Message has unexpected status: \(outgoingMessage.messageState).")
+            owsFail("Message has unexpected status: \(outgoingMessage.messageState).")
             return (.sent, NSLocalizedString("MESSAGE_STATUS_SENT",
                                      comment: "status message for sent messages"))
         }

--- a/Signal/src/call/CallAudioService.swift
+++ b/Signal/src/call/CallAudioService.swift
@@ -193,7 +193,7 @@ protocol CallAudioServiceDelegate: class {
             do {
                 try self.avAudioSession.overrideOutputAudioPort( isEnabled ? .speaker : .none )
             } catch {
-                owsFail("\(self.logTag) failed to set \(#function) = \(isEnabled) with error: \(error)")
+                owsFail("failed to set \(#function) = \(isEnabled) with error: \(error)")
             }
         }
     }
@@ -255,19 +255,19 @@ protocol CallAudioServiceDelegate: class {
             // because some sources are only valid for certain category/option combinations.
             let existingPreferredInput = avAudioSession.preferredInput
             if  existingPreferredInput != call.audioSource?.portDescription {
-                Logger.info("\(self.logTag) changing preferred input: \(String(describing: existingPreferredInput)) -> \(String(describing: call.audioSource?.portDescription))")
+                Logger.info("changing preferred input: \(String(describing: existingPreferredInput)) -> \(String(describing: call.audioSource?.portDescription))")
                 try avAudioSession.setPreferredInput(call.audioSource?.portDescription)
             }
 
         } catch {
-            owsFail("\(self.logTag) failed setting audio source with error: \(error) isSpeakerPhoneEnabled: \(call.isSpeakerphoneEnabled)")
+            owsFail("failed setting audio source with error: \(error) isSpeakerPhoneEnabled: \(call.isSpeakerphoneEnabled)")
         }
     }
 
     // MARK: - Service action handlers
 
     public func didUpdateVideoTracks(call: SignalCall?) {
-        Logger.verbose("\(self.logTag) in \(#function)")
+        Logger.verbose("")
 
         self.ensureProperAudioSession(call: call)
     }
@@ -275,7 +275,7 @@ protocol CallAudioServiceDelegate: class {
     public func handleState(call: SignalCall) {
         assert(Thread.isMainThread)
 
-        Logger.verbose("\(self.logTag) in \(#function) new state: \(call.state)")
+        Logger.verbose("new state: \(call.state)")
 
         // Stop playing sounds while switching audio session so we don't 
         // get any blips across a temporary unintended route.
@@ -298,12 +298,12 @@ protocol CallAudioServiceDelegate: class {
     }
 
     private func handleIdle(call: SignalCall) {
-        Logger.debug("\(self.logTag) \(#function)")
+        Logger.debug("")
     }
 
     private func handleDialing(call: SignalCall) {
-        Logger.debug("\(self.logTag) \(#function)")
         AssertIsOnMainThread()
+        Logger.debug("")
 
         // HACK: Without this async, dialing sound only plays once. I don't really understand why. Does the audioSession
         // need some time to settle? Is somethign else interrupting our session?
@@ -313,52 +313,52 @@ protocol CallAudioServiceDelegate: class {
     }
 
     private func handleAnswering(call: SignalCall) {
-        Logger.debug("\(self.logTag) \(#function)")
         AssertIsOnMainThread()
+        Logger.debug("")
     }
 
     private func handleRemoteRinging(call: SignalCall) {
-        Logger.debug("\(self.logTag) \(#function)")
         AssertIsOnMainThread()
+        Logger.debug("")
 
         self.play(sound: OWSSound.callOutboundRinging)
     }
 
     private func handleLocalRinging(call: SignalCall) {
-        Logger.debug("\(self.logTag) in \(#function)")
         AssertIsOnMainThread()
+        Logger.debug("")
 
         startRinging(call: call)
     }
 
     private func handleConnected(call: SignalCall) {
-        Logger.debug("\(self.logTag) \(#function)")
         AssertIsOnMainThread()
+        Logger.debug("")
     }
 
     private func handleReconnecting(call: SignalCall) {
-        Logger.debug("\(self.logTag) \(#function)")
         AssertIsOnMainThread()
+        Logger.debug("")
     }
 
     private func handleLocalFailure(call: SignalCall) {
-        Logger.debug("\(self.logTag) \(#function)")
         AssertIsOnMainThread()
+        Logger.debug("")
 
         play(sound: OWSSound.callFailure)
         handleCallEnded(call: call)
     }
 
     private func handleLocalHangup(call: SignalCall) {
-        Logger.debug("\(self.logTag) \(#function)")
         AssertIsOnMainThread()
+        Logger.debug("")
 
         handleCallEnded(call: call)
     }
 
     private func handleRemoteHangup(call: SignalCall) {
-        Logger.debug("\(self.logTag) \(#function)")
         AssertIsOnMainThread()
+        Logger.debug("")
 
         vibrate()
 
@@ -366,8 +366,8 @@ protocol CallAudioServiceDelegate: class {
     }
 
     private func handleBusy(call: SignalCall) {
-        Logger.debug("\(self.logTag) \(#function)")
         AssertIsOnMainThread()
+        Logger.debug("")
 
         play(sound: OWSSound.callBusy)
 
@@ -378,8 +378,8 @@ protocol CallAudioServiceDelegate: class {
     }
 
     private func handleCallEnded(call: SignalCall) {
-        Logger.debug("\(self.logTag) \(#function)")
         AssertIsOnMainThread()
+        Logger.debug("")
 
         // Stop solo audio, revert to default.
         isSpeakerphoneEnabled = false
@@ -397,10 +397,10 @@ protocol CallAudioServiceDelegate: class {
 
     private func play(sound: OWSSound) {
         guard let newPlayer = OWSSounds.audioPlayer(for: sound) else {
-            owsFail("\(self.logTag) unable to build player for sound: \(OWSSounds.displayName(for: sound))")
+            owsFail("unable to build player for sound: \(OWSSounds.displayName(for: sound))")
             return
         }
-        Logger.info("\(self.logTag) playing sound: \(OWSSounds.displayName(for: sound))")
+        Logger.info("playing sound: \(OWSSounds.displayName(for: sound))")
 
         // It's important to stop the current player **before** starting the new player. In the case that 
         // we're playing the same sound, since the player is memoized on the sound instance, we'd otherwise 
@@ -414,7 +414,7 @@ protocol CallAudioServiceDelegate: class {
 
     private func startRinging(call: SignalCall) {
         guard handleRinging else {
-            Logger.debug("\(self.logTag) ignoring \(#function) since CallKit handles it's own ringing state")
+            Logger.debug("ignoring \(#function) since CallKit handles it's own ringing state")
             return
         }
 
@@ -427,10 +427,10 @@ protocol CallAudioServiceDelegate: class {
 
     private func stopAnyRingingVibration() {
         guard handleRinging else {
-            Logger.debug("\(self.logTag) ignoring \(#function) since CallKit handles it's own ringing state")
+            Logger.debug("ignoring \(#function) since CallKit handles it's own ringing state")
             return
         }
-        Logger.debug("\(self.logTag) in \(#function)")
+        Logger.debug("")
 
         // Stop vibrating
         vibrateTimer?.invalidate()
@@ -452,7 +452,7 @@ protocol CallAudioServiceDelegate: class {
         AudioServicesPlaySystemSound(kSystemSoundID_Vibrate)
     }
 
-    // MARK - AudioSession MGMT
+    // MARK: - AudioSession MGMT
     // TODO move this to CallAudioSession?
 
     // Note this method is sensitive to the current audio session configuration.
@@ -465,7 +465,7 @@ protocol CallAudioServiceDelegate: class {
             return [AudioSource.builtInSpeaker]
         }
 
-        Logger.info("\(self.logTag) in \(#function) availableInputs: \(availableInputs)")
+        Logger.info("availableInputs: \(availableInputs)")
         return [AudioSource.builtInSpeaker] + availableInputs.map { portDescription in
             return AudioSource(portDescription: portDescription)
         }
@@ -507,13 +507,13 @@ protocol CallAudioServiceDelegate: class {
                 audioSessionChanged = true
 
                 if oldCategory != category {
-                    Logger.debug("\(self.logTag) audio session changed category: \(oldCategory) -> \(category) ")
+                    Logger.debug("audio session changed category: \(oldCategory) -> \(category) ")
                 }
                 if oldMode != mode {
-                    Logger.debug("\(self.logTag) audio session changed mode: \(oldMode) -> \(mode) ")
+                    Logger.debug("audio session changed mode: \(oldMode) -> \(mode) ")
                 }
                 if oldOptions != options {
-                    Logger.debug("\(self.logTag) audio session changed options: \(oldOptions) -> \(options) ")
+                    Logger.debug("audio session changed options: \(oldOptions) -> \(options) ")
                 }
                 try avAudioSession.setCategory(category, mode: mode, options: options)
 
@@ -528,21 +528,21 @@ protocol CallAudioServiceDelegate: class {
                 audioSessionChanged = true
 
                 if oldCategory != category {
-                    Logger.debug("\(self.logTag) audio session changed category: \(oldCategory) -> \(category) ")
+                    Logger.debug("audio session changed category: \(oldCategory) -> \(category) ")
                 }
                 if oldOptions != options {
-                    Logger.debug("\(self.logTag) audio session changed options: \(oldOptions) -> \(options) ")
+                    Logger.debug("audio session changed options: \(oldOptions) -> \(options) ")
                 }
                 try avAudioSession.setCategory(category, with: options)
 
             }
         } catch {
-            let message = "\(self.logTag) in \(#function) failed to set category: \(category) mode: \(String(describing: mode)), options: \(options) with error: \(error)"
+            let message = "failed to set category: \(category) mode: \(String(describing: mode)), options: \(options) with error: \(error)"
             owsFail(message)
         }
 
         if audioSessionChanged {
-            Logger.info("\(self.logTag) in \(#function)")
+            Logger.info("")
             self.delegate?.callAudioServiceDidChangeAudioSession(self)
         }
     }

--- a/Signal/src/call/CallService.swift
+++ b/Signal/src/call/CallService.swift
@@ -146,7 +146,7 @@ private class SignalCallData: NSObject {
         didSet {
             AssertIsOnMainThread()
 
-            Logger.debug(".peerConnectionClient setter: \(oldValue != nil) -> \(peerConnectionClient != nil) \(String(describing: peerConnectionClient))")
+            Logger.debug(".peerConnectionClient setter: \(oldValue != nil) -> \(self.peerConnectionClient != nil) \(String(describing: self.peerConnectionClient))")
         }
     }
 
@@ -253,7 +253,7 @@ private class SignalCallData: NSObject {
                 }
             }
 
-            Logger.debug(".callData setter: \(oldValue?.call.identifiersForLogs as Optional) -> \(callData?.call.identifiersForLogs as Optional)")
+            Logger.debug(".callData setter: \(oldValue?.call.identifiersForLogs as Optional) -> \(self.callData?.call.identifiersForLogs as Optional)")
 
             for observer in observers {
                 observer.value?.didUpdateCall(call: callData?.call)

--- a/Signal/src/call/CallService.swift
+++ b/Signal/src/call/CallService.swift
@@ -138,7 +138,7 @@ private class SignalCallData: NSObject {
         didSet {
             AssertIsOnMainThread()
 
-            Logger.info("\(isRemoteVideoEnabled)")
+            Logger.info("\(self.isRemoteVideoEnabled)")
         }
     }
 

--- a/Signal/src/call/CallService.swift
+++ b/Signal/src/call/CallService.swift
@@ -138,7 +138,7 @@ private class SignalCallData: NSObject {
         didSet {
             AssertIsOnMainThread()
 
-            Logger.info("\(self.isRemoteVideoEnabled)")
+            Logger.info("\(isRemoteVideoEnabled)")
         }
     }
 
@@ -146,7 +146,7 @@ private class SignalCallData: NSObject {
         didSet {
             AssertIsOnMainThread()
 
-            Logger.debug(".peerConnectionClient setter: \(oldValue != nil) -> \(self.peerConnectionClient != nil) \(String(describing: self.peerConnectionClient))")
+            Logger.debug(".peerConnectionClient setter: \(oldValue != nil) -> \(peerConnectionClient != nil) \(String(describing: peerConnectionClient))")
         }
     }
 
@@ -253,7 +253,7 @@ private class SignalCallData: NSObject {
                 }
             }
 
-            Logger.debug(".callData setter: \(oldValue?.call.identifiersForLogs as Optional) -> \(self.callData?.call.identifiersForLogs as Optional)")
+            Logger.debug(".callData setter: \(oldValue?.call.identifiersForLogs as Optional) -> \(callData?.call.identifiersForLogs as Optional)")
 
             for observer in observers {
                 observer.value?.didUpdateCall(call: callData?.call)

--- a/Signal/src/call/NonCallKitCallUIAdaptee.swift
+++ b/Signal/src/call/NonCallKitCallUIAdaptee.swift
@@ -35,9 +35,9 @@ class NonCallKitCallUIAdaptee: NSObject, CallUIAdaptee {
         OWSAudioSession.shared.startAudioActivity(call.audioActivity)
 
         self.callService.handleOutgoingCall(call).then {
-            Logger.debug("\(self.logTag) handleOutgoingCall succeeded")
+            Logger.debug("handleOutgoingCall succeeded")
         }.catch { error in
-            Logger.error("\(self.logTag) handleOutgoingCall failed with error: \(error)")
+            Logger.error("handleOutgoingCall failed with error: \(error)")
         }.retainUntilComplete()
 
         return call
@@ -46,13 +46,13 @@ class NonCallKitCallUIAdaptee: NSObject, CallUIAdaptee {
     func reportIncomingCall(_ call: SignalCall, callerName: String) {
         AssertIsOnMainThread()
 
-        Logger.debug("\(logTag) \(#function)")
+        Logger.debug("")
 
         self.showCall(call)
 
         // present lock screen notification
         if UIApplication.shared.applicationState == .active {
-            Logger.debug("\(logTag) skipping notification since app is already active.")
+            Logger.debug("skipping notification since app is already active.")
         } else {
             notificationsAdapter.presentIncomingCall(call, callerName: callerName)
         }
@@ -68,12 +68,12 @@ class NonCallKitCallUIAdaptee: NSObject, CallUIAdaptee {
         AssertIsOnMainThread()
 
         guard let call = self.callService.call else {
-            owsFail("\(self.logTag) in \(#function) No current call.")
+            owsFail("No current call.")
             return
         }
 
         guard call.localId == localId else {
-            owsFail("\(self.logTag) in \(#function) localId does not match current call")
+            owsFail("localId does not match current call")
             return
         }
 
@@ -84,7 +84,7 @@ class NonCallKitCallUIAdaptee: NSObject, CallUIAdaptee {
         AssertIsOnMainThread()
 
         guard call.localId == self.callService.call?.localId else {
-            owsFail("\(self.logTag) in \(#function) localId does not match current call")
+            owsFail("localId does not match current call")
             return
         }
 
@@ -96,12 +96,12 @@ class NonCallKitCallUIAdaptee: NSObject, CallUIAdaptee {
         AssertIsOnMainThread()
 
         guard let call = self.callService.call else {
-            owsFail("\(self.logTag) in \(#function) No current call.")
+            owsFail("No current call.")
             return
         }
 
         guard call.localId == localId else {
-            owsFail("\(self.logTag) in \(#function) localId does not match current call")
+            owsFail("localId does not match current call")
             return
         }
 
@@ -112,7 +112,7 @@ class NonCallKitCallUIAdaptee: NSObject, CallUIAdaptee {
         AssertIsOnMainThread()
 
         guard call.localId == self.callService.call?.localId else {
-            owsFail("\(self.logTag) in \(#function) localId does not match current call")
+            owsFail("localId does not match current call")
             return
         }
 
@@ -131,7 +131,7 @@ class NonCallKitCallUIAdaptee: NSObject, CallUIAdaptee {
         // If both parties hang up at the same moment,
         // call might already be nil.
         guard self.callService.call == nil || call.localId == self.callService.call?.localId else {
-            owsFail("\(self.logTag) in \(#function) localId does not match current call")
+            owsFail("localId does not match current call")
             return
         }
 
@@ -141,26 +141,26 @@ class NonCallKitCallUIAdaptee: NSObject, CallUIAdaptee {
     internal func remoteDidHangupCall(_ call: SignalCall) {
         AssertIsOnMainThread()
 
-        Logger.debug("\(logTag) in \(#function) is no-op")
+        Logger.debug("is no-op")
     }
 
     internal func remoteBusy(_ call: SignalCall) {
         AssertIsOnMainThread()
 
-        Logger.debug("\(logTag) in \(#function) is no-op")
+        Logger.debug("is no-op")
     }
 
     internal func failCall(_ call: SignalCall, error: CallError) {
         AssertIsOnMainThread()
 
-        Logger.debug("\(logTag) in \(#function) is no-op")
+        Logger.debug("is no-op")
     }
 
     func setIsMuted(call: SignalCall, isMuted: Bool) {
         AssertIsOnMainThread()
 
         guard call.localId == self.callService.call?.localId else {
-            owsFail("\(self.logTag) in \(#function) localId does not match current call")
+            owsFail("localId does not match current call")
             return
         }
 
@@ -171,7 +171,7 @@ class NonCallKitCallUIAdaptee: NSObject, CallUIAdaptee {
         AssertIsOnMainThread()
 
         guard call.localId == self.callService.call?.localId else {
-            owsFail("\(self.logTag) in \(#function) localId does not match current call")
+            owsFail("localId does not match current call")
             return
         }
 

--- a/Signal/src/call/OutboundCallInitiator.swift
+++ b/Signal/src/call/OutboundCallInitiator.swift
@@ -27,10 +27,10 @@ import SignalMessaging
      * |handle| is a user formatted phone number, e.g. from a system contacts entry
      */
     @discardableResult @objc public func initiateCall(handle: String) -> Bool {
-        Logger.info("\(logTag) in \(#function) with handle: \(handle)")
+        Logger.info("with handle: \(handle)")
 
         guard let recipientId = PhoneNumber(fromE164: handle)?.toE164() else {
-            Logger.warn("\(logTag) unable to parse signalId from phone number: \(handle)")
+            Logger.warn("unable to parse signalId from phone number: \(handle)")
             return false
         }
 
@@ -46,7 +46,7 @@ import SignalMessaging
         // because it can change after app launch due to user settings
         let callUIAdapter = SignalApp.shared().callUIAdapter
         guard let frontmostViewController = UIApplication.shared.frontmostViewController else {
-            owsFail("\(logTag) could not identify frontmostViewController in \(#function)")
+            owsFail("could not identify frontmostViewController")
             return false
         }
 
@@ -74,7 +74,7 @@ import SignalMessaging
 
             // Here the permissions are either granted or denied
             guard granted == true else {
-                Logger.warn("\(strongSelf.logTag) aborting due to missing microphone permissions.")
+                Logger.warn("aborting due to missing microphone permissions.")
                 OWSAlerts.showNoMicrophonePermissionAlert()
                 return
             }

--- a/Signal/src/call/PeerConnectionClient.swift
+++ b/Signal/src/call/PeerConnectionClient.swift
@@ -119,14 +119,14 @@ class PeerConnectionProxy: NSObject, RTCPeerConnectionDelegate, RTCDataChannelDe
         if result == nil {
             // Every time this method returns nil is a
             // possible crash avoided.
-            Logger.verbose("\(logTag) cleared get.")
+            Logger.verbose("cleared get.")
         }
 
         return result
     }
 
     func clear() {
-        Logger.info("\(logTag) \(#function)")
+        Logger.info("")
 
         objc_sync_enter(self)
         value = nil
@@ -259,10 +259,10 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
         configuration.bundlePolicy = .maxBundle
         configuration.rtcpMuxPolicy = .require
         if useTurnOnly {
-            Logger.debug("\(PeerConnectionClient.logTag()) using iceTransportPolicy: relay")
+            Logger.debug("using iceTransportPolicy: relay")
             configuration.iceTransportPolicy = .relay
         } else {
-            Logger.debug("\(PeerConnectionClient.logTag()) using iceTransportPolicy: default")
+            Logger.debug("using iceTransportPolicy: default")
         }
 
         let connectionConstraintsDict = ["DtlsSrtpKeyAgreement": "true"]
@@ -299,7 +299,7 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
     private func createSignalingDataChannel() {
         AssertIsOnMainThread()
         guard let peerConnection = peerConnection else {
-            Logger.debug("\(logTag) \(#function) Ignoring obsolete event in terminated client")
+            Logger.debug("Ignoring obsolete event in terminated client")
             return
         }
 
@@ -324,15 +324,15 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
 
     fileprivate func createVideoSender() {
         AssertIsOnMainThread()
-        Logger.debug("\(logTag) in \(#function)")
+        Logger.debug("")
         assert(self.videoSender == nil, "\(#function) should only be called once.")
 
         guard !Platform.isSimulator else {
-            Logger.warn("\(logTag) Refusing to create local video track on simulator which has no capture device.")
+            Logger.warn("Refusing to create local video track on simulator which has no capture device.")
             return
         }
         guard let peerConnection = peerConnection else {
-            Logger.debug("\(logTag) \(#function) Ignoring obsolete event in terminated client")
+            Logger.debug("Ignoring obsolete event in terminated client")
             return
         }
 
@@ -362,7 +362,7 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
             guard let strongSelf = proxyCopy.get() else { return }
 
             guard let captureController = strongSelf.videoCaptureController else {
-                owsFail("\(self.logTag) in \(#function) captureController was unexpectedly nil")
+                owsFail("captureController was unexpectedly nil")
                 return
             }
 
@@ -383,7 +383,7 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
                 }
 
                 guard let captureController = strongSelf.videoCaptureController else {
-                    owsFail("\(self.logTag) in \(#function) videoCaptureController was unexpectedly nil")
+                    owsFail("videoCaptureController was unexpectedly nil")
                     return nil
                 }
 
@@ -396,26 +396,26 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
         PeerConnectionClient.signalingQueue.async {
             guard let strongSelf = proxyCopy.get() else { return }
             guard strongSelf.peerConnection != nil else {
-                Logger.debug("\(strongSelf.logTag) \(#function) Ignoring obsolete event in terminated client")
+                Logger.debug("Ignoring obsolete event in terminated client")
                 return
             }
 
             guard let videoCaptureController = strongSelf.videoCaptureController else {
-                Logger.debug("\(strongSelf.logTag) \(#function) Ignoring obsolete event in terminated client")
+                Logger.debug("Ignoring obsolete event in terminated client")
                 return
             }
 
             guard let localVideoTrack = strongSelf.localVideoTrack else {
-                Logger.debug("\(strongSelf.logTag) \(#function) Ignoring obsolete event in terminated client")
+                Logger.debug("Ignoring obsolete event in terminated client")
                 return
             }
             localVideoTrack.isEnabled = enabled
 
             if enabled {
-                Logger.debug("\(strongSelf.logTag) in \(#function) starting video capture")
+                Logger.debug("starting video capture")
                 videoCaptureController.startCapture()
             } else {
-                Logger.debug("\(strongSelf.logTag) in \(#function) stopping video capture")
+                Logger.debug("stopping video capture")
                 videoCaptureController.stopCapture()
             }
 
@@ -437,11 +437,11 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
 
     fileprivate func createAudioSender() {
         AssertIsOnMainThread()
-        Logger.debug("\(logTag) in \(#function)")
+        Logger.debug("")
         assert(self.audioSender == nil, "\(#function) should only be called once.")
 
         guard let peerConnection = peerConnection else {
-            Logger.debug("\(logTag) \(#function) Ignoring obsolete event in terminated client")
+            Logger.debug("Ignoring obsolete event in terminated client")
             return
         }
 
@@ -467,11 +467,11 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
         PeerConnectionClient.signalingQueue.async {
             guard let strongSelf = proxyCopy.get() else { return }
             guard strongSelf.peerConnection != nil else {
-                Logger.debug("\(strongSelf.logTag) \(#function) Ignoring obsolete event in terminated client")
+                Logger.debug("Ignoring obsolete event in terminated client")
                 return
             }
             guard let audioTrack = strongSelf.audioTrack else {
-                Logger.debug("\(strongSelf.logTag) \(#function) Ignoring obsolete event in terminated client")
+                Logger.debug("Ignoring obsolete event in terminated client")
                 return
             }
 
@@ -500,7 +500,7 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
             }
             strongSelf.assertOnSignalingQueue()
             guard strongSelf.peerConnection != nil else {
-                Logger.debug("\(strongSelf.logTag) \(#function) Ignoring obsolete event in terminated client")
+                Logger.debug("Ignoring obsolete event in terminated client")
                 reject(NSError(domain: "Obsolete client", code: 0, userInfo: nil))
                 return
             }
@@ -510,7 +510,7 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
             }
 
             guard let sessionDescription = sdp else {
-                Logger.error("\(strongSelf.logTag) No session description was obtained, even though there was no error reported.")
+                Logger.error("No session description was obtained, even though there was no error reported.")
                 let error = OWSErrorMakeUnableToProcessServerResponseError()
                 reject(error)
                 return
@@ -526,7 +526,7 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
             }
             strongSelf.assertOnSignalingQueue()
             guard let peerConnection = strongSelf.peerConnection else {
-                Logger.debug("\(strongSelf.logTag) \(#function) Ignoring obsolete event in terminated client")
+                Logger.debug("Ignoring obsolete event in terminated client")
                 reject(NSError(domain: "Obsolete client", code: 0, userInfo: nil))
                 return
             }
@@ -552,12 +552,12 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
             strongSelf.assertOnSignalingQueue()
 
             guard let peerConnection = strongSelf.peerConnection else {
-                Logger.debug("\(strongSelf.logTag) \(#function) Ignoring obsolete event in terminated client")
+                Logger.debug("Ignoring obsolete event in terminated client")
                 reject(NSError(domain: "Obsolete client", code: 0, userInfo: nil))
                 return
             }
 
-            Logger.verbose("\(strongSelf.logTag) setting local session description: \(sessionDescription)")
+            Logger.verbose("setting local session description: \(sessionDescription)")
             peerConnection.setLocalDescription(sessionDescription.rtcSessionDescription, completionHandler: { (error) in
                 if let error = error {
                     reject(error)
@@ -580,12 +580,12 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
             }
             strongSelf.assertOnSignalingQueue()
             guard let peerConnection = strongSelf.peerConnection else {
-                Logger.debug("\(strongSelf.logTag) \(#function) Ignoring obsolete event in terminated client")
+                Logger.debug("Ignoring obsolete event in terminated client")
                 reject(NSError(domain: "Obsolete client", code: 0, userInfo: nil))
                 return
             }
 
-            Logger.verbose("\(strongSelf.logTag) setting local session description: \(sessionDescription)")
+            Logger.verbose("setting local session description: \(sessionDescription)")
             peerConnection.setLocalDescription(sessionDescription.rtcSessionDescription,
                                                completionHandler: { error in
                                                 if let error = error {
@@ -622,11 +622,11 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
             }
             strongSelf.assertOnSignalingQueue()
             guard let peerConnection = strongSelf.peerConnection else {
-                Logger.debug("\(strongSelf.logTag) \(#function) Ignoring obsolete event in terminated client")
+                Logger.debug("Ignoring obsolete event in terminated client")
                 reject(NSError(domain: "Obsolete client", code: 0, userInfo: nil))
                 return
             }
-            Logger.verbose("\(strongSelf.logTag) setting remote description: \(sessionDescription)")
+            Logger.verbose("setting remote description: \(sessionDescription)")
             peerConnection.setRemoteDescription(sessionDescription,
                                                 completionHandler: { error in
                                                     if let error = error {
@@ -650,7 +650,7 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
             }
             strongSelf.assertOnSignalingQueue()
             guard strongSelf.peerConnection != nil else {
-                Logger.debug("\(strongSelf.logTag) \(#function) Ignoring obsolete event in terminated client")
+                Logger.debug("Ignoring obsolete event in terminated client")
                 reject(NSError(domain: "Obsolete client", code: 0, userInfo: nil))
                 return
             }
@@ -660,7 +660,7 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
             }
 
             guard let sessionDescription = sdp else {
-                Logger.error("\(strongSelf.logTag) unexpected empty session description, even though no error was reported.")
+                Logger.error("unexpected empty session description, even though no error was reported.")
                 let error = OWSErrorMakeUnableToProcessServerResponseError()
                 reject(error)
                 return
@@ -684,12 +684,12 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
             strongSelf.assertOnSignalingQueue()
 
             guard let peerConnection = strongSelf.peerConnection else {
-                Logger.debug("\(strongSelf.logTag) \(#function) Ignoring obsolete event in terminated client")
+                Logger.debug("Ignoring obsolete event in terminated client")
                 reject(NSError(domain: "Obsolete client", code: 0, userInfo: nil))
                 return
             }
 
-            Logger.debug("\(strongSelf.logTag) negotiating answer session.")
+            Logger.debug("negotiating answer session.")
 
             peerConnection.answer(for: constraints, completionHandler: { (sdp: RTCSessionDescription?, error: Error?) in
                 PeerConnectionClient.signalingQueue.async {
@@ -705,17 +705,17 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
         PeerConnectionClient.signalingQueue.async {
             guard let strongSelf = proxyCopy.get() else { return }
             guard let peerConnection = strongSelf.peerConnection else {
-                Logger.debug("\(strongSelf.logTag) \(#function) Ignoring obsolete event in terminated client")
+                Logger.debug("Ignoring obsolete event in terminated client")
                 return
             }
-            Logger.info("\(strongSelf.logTag) adding remote ICE candidate: \(candidate.sdp)")
+            Logger.info("adding remote ICE candidate: \(candidate.sdp)")
             peerConnection.add(candidate)
         }
     }
 
     public func terminate() {
         AssertIsOnMainThread()
-        Logger.debug("\(logTag) in \(#function)")
+        Logger.debug("")
 
         // Clear the delegate immediately so that we can guarantee that
         // no delegate methods are called after terminate() returns.
@@ -734,7 +734,7 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
 
     private func terminateInternal() {
         assertOnSignalingQueue()
-        Logger.debug("\(logTag) in \(#function)")
+        Logger.debug("")
 
         //        Some notes on preventing crashes while disposing of peerConnection for video calls
         //        from: https://groups.google.com/forum/#!searchin/discuss-webrtc/objc$20crash$20dealloc%7Csort:relevance/discuss-webrtc/7D-vk5yLjn8/rBW2D6EW4GYJ
@@ -788,29 +788,29 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
             guard let strongSelf = proxyCopy.get() else { return }
 
             guard strongSelf.peerConnection != nil else {
-                Logger.debug("\(strongSelf.logTag) \(#function) Ignoring obsolete event in terminated client: \(description)")
+                Logger.debug("Ignoring obsolete event in terminated client: \(description)")
                 return
             }
 
             guard let dataChannel = strongSelf.dataChannel else {
                 if isCritical {
-                    Logger.info("\(strongSelf.logTag) in \(#function) enqueuing critical data channel message for after we have a dataChannel: \(description)")
+                    Logger.info("enqueuing critical data channel message for after we have a dataChannel: \(description)")
                     strongSelf.pendingDataChannelMessages.append(PendingDataChannelMessage(data: data, description: description, isCritical: isCritical))
                 } else {
-                    Logger.error("\(strongSelf.logTag) in \(#function) ignoring sending \(data) for nil dataChannel: \(description)")
+                    Logger.error("ignoring sending \(data) for nil dataChannel: \(description)")
                 }
                 return
             }
 
-            Logger.debug("\(strongSelf.logTag) sendDataChannelMessage trying: \(description)")
+            Logger.debug("sendDataChannelMessage trying: \(description)")
 
             let buffer = RTCDataBuffer(data: data, isBinary: false)
             let result = dataChannel.sendData(buffer)
 
             if result {
-                Logger.debug("\(strongSelf.logTag) sendDataChannelMessage succeeded: \(description)")
+                Logger.debug("sendDataChannelMessage succeeded: \(description)")
             } else {
-                Logger.warn("\(strongSelf.logTag) sendDataChannelMessage failed: \(description)")
+                Logger.warn("sendDataChannelMessage failed: \(description)")
                 if isCritical {
                     OWSProdError(OWSAnalyticsEvents.peerConnectionClientErrorSendDataChannelMessageFailed(), file: #file, function: #function, line: #line)
                 }
@@ -822,7 +822,7 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
 
     /** The data channel state changed. */
     internal func dataChannelDidChangeState(_ dataChannel: RTCDataChannel) {
-        Logger.debug("\(logTag) dataChannelDidChangeState: \(dataChannel)")
+        Logger.debug("dataChannelDidChangeState: \(dataChannel)")
     }
 
     /** The data channel successfully received a data buffer. */
@@ -838,16 +838,16 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
         PeerConnectionClient.signalingQueue.async {
             guard let strongSelf = proxyCopy.get() else { return }
             guard strongSelf.peerConnection != nil else {
-                Logger.debug("\(strongSelf.logTag) \(#function) Ignoring obsolete event in terminated client")
+                Logger.debug("Ignoring obsolete event in terminated client")
                 return
             }
-            Logger.debug("\(strongSelf.logTag) dataChannel didReceiveMessageWith buffer:\(buffer)")
+            Logger.debug("dataChannel didReceiveMessageWith buffer:\(buffer)")
 
             var dataChannelMessage: WebRTCProtoData
             do {
                 dataChannelMessage = try WebRTCProtoData.parseData(buffer.data)
             } catch {
-                Logger.error("\(strongSelf.logTag) failed to parse dataProto")
+                Logger.error("failed to parse dataProto")
                 return
             }
 
@@ -859,14 +859,14 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
 
     /** The data channel's |bufferedAmount| changed. */
     internal func dataChannel(_ dataChannel: RTCDataChannel, didChangeBufferedAmount amount: UInt64) {
-        Logger.debug("\(logTag) didChangeBufferedAmount: \(amount)")
+        Logger.debug("didChangeBufferedAmount: \(amount)")
     }
 
     // MARK: - RTCPeerConnectionDelegate
 
     /** Called when the SignalingState changed. */
     internal func peerConnection(_ peerConnectionParam: RTCPeerConnection, didChange stateChanged: RTCSignalingState) {
-        Logger.debug("\(logTag) didChange signalingState:\(stateChanged.debugDescription)")
+        Logger.debug("didChange signalingState:\(stateChanged.debugDescription)")
     }
 
     /** Called when media is received on a new stream from remote peer. */
@@ -885,19 +885,19 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
         PeerConnectionClient.signalingQueue.async {
             guard let strongSelf = proxyCopy.get() else { return }
             guard let peerConnection = strongSelf.peerConnection else {
-                Logger.debug("\(strongSelf.logTag) \(#function) Ignoring obsolete event in terminated client")
+                Logger.debug("Ignoring obsolete event in terminated client")
                 return
             }
             guard peerConnection == peerConnectionParam else {
-                owsFail("\(strongSelf.logTag) in \(#function) mismatched peerConnection callback.")
+                owsFail("mismatched peerConnection callback.")
                 return
             }
             guard stream.videoTracks.count > 0 else {
-                owsFail("\(strongSelf.logTag) in \(#function) didAdd stream missing stream.")
+                owsFail("didAdd stream missing stream.")
                 return
             }
             let remoteVideoTrack = stream.videoTracks[0]
-            Logger.debug("\(strongSelf.logTag) didAdd stream:\(stream) video tracks: \(stream.videoTracks.count) audio tracks: \(stream.audioTracks.count)")
+            Logger.debug("didAdd stream:\(stream) video tracks: \(stream.videoTracks.count) audio tracks: \(stream.audioTracks.count)")
 
             strongSelf.remoteVideoTrack = remoteVideoTrack
 
@@ -909,12 +909,12 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
 
     /** Called when a remote peer closes a stream. */
     internal func peerConnection(_ peerConnectionParam: RTCPeerConnection, didRemove stream: RTCMediaStream) {
-        Logger.debug("\(logTag) didRemove Stream:\(stream)")
+        Logger.debug("didRemove Stream:\(stream)")
     }
 
     /** Called when negotiation is needed, for example ICE has restarted. */
     internal func peerConnectionShouldNegotiate(_ peerConnectionParam: RTCPeerConnection) {
-        Logger.debug("\(logTag) shouldNegotiate")
+        Logger.debug("shouldNegotiate")
     }
 
     /** Called any time the IceConnectionState changes. */
@@ -942,33 +942,33 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
         PeerConnectionClient.signalingQueue.async {
             guard let strongSelf = proxyCopy.get() else { return }
             guard let peerConnection = strongSelf.peerConnection else {
-                Logger.debug("\(strongSelf.logTag) \(#function) Ignoring obsolete event in terminated client")
+                Logger.debug("Ignoring obsolete event in terminated client")
                 return
             }
             guard peerConnection == peerConnectionParam else {
-                owsFail("\(strongSelf.logTag) in \(#function) mismatched peerConnection callback.")
+                owsFail("mismatched peerConnection callback.")
                 return
             }
 
-            Logger.info("\(strongSelf.logTag) didChange IceConnectionState:\(newState.debugDescription)")
+            Logger.info("didChange IceConnectionState:\(newState.debugDescription)")
             switch newState {
             case .connected, .completed:
                 DispatchQueue.main.async(execute: connectedCompletion)
             case .failed:
-                Logger.warn("\(strongSelf.logTag) RTCIceConnection failed.")
+                Logger.warn("RTCIceConnection failed.")
                 DispatchQueue.main.async(execute: failedCompletion)
             case .disconnected:
-                Logger.warn("\(strongSelf.logTag) RTCIceConnection disconnected.")
+                Logger.warn("RTCIceConnection disconnected.")
                 DispatchQueue.main.async(execute: disconnectedCompletion)
             default:
-                Logger.debug("\(strongSelf.logTag) ignoring change IceConnectionState:\(newState.debugDescription)")
+                Logger.debug("ignoring change IceConnectionState:\(newState.debugDescription)")
             }
         }
     }
 
     /** Called any time the IceGatheringState changes. */
     internal func peerConnection(_ peerConnectionParam: RTCPeerConnection, didChange newState: RTCIceGatheringState) {
-        Logger.info("\(logTag) didChange IceGatheringState:\(newState.debugDescription)")
+        Logger.info("didChange IceGatheringState:\(newState.debugDescription)")
     }
 
     /** New ice candidate has been found. */
@@ -984,14 +984,14 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
         PeerConnectionClient.signalingQueue.async {
             guard let strongSelf = proxyCopy.get() else { return }
             guard let peerConnection = strongSelf.peerConnection else {
-                Logger.debug("\(strongSelf.logTag) \(#function) Ignoring obsolete event in terminated client")
+                Logger.debug("Ignoring obsolete event in terminated client")
                 return
             }
             guard peerConnection == peerConnectionParam else {
-                owsFail("\(strongSelf.logTag) in \(#function) mismatched peerConnection callback.")
+                owsFail("mismatched peerConnection callback.")
                 return
             }
-            Logger.info("\(strongSelf.logTag) adding local ICE candidate:\(candidate.sdp)")
+            Logger.info("adding local ICE candidate:\(candidate.sdp)")
             DispatchQueue.main.async {
                 completion(candidate)
             }
@@ -1000,7 +1000,7 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
 
     /** Called when a group of local Ice candidates have been removed. */
     internal func peerConnection(_ peerConnectionParam: RTCPeerConnection, didRemove candidates: [RTCIceCandidate]) {
-        Logger.debug("\(logTag) didRemove IceCandidates:\(candidates)")
+        Logger.debug("didRemove IceCandidates:\(candidates)")
     }
 
     /** New data channel has been opened. */
@@ -1017,16 +1017,16 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
         PeerConnectionClient.signalingQueue.async {
             guard let strongSelf = proxyCopy.get() else { return }
             guard let peerConnection = strongSelf.peerConnection else {
-                Logger.debug("\(strongSelf.logTag) \(#function) Ignoring obsolete event in terminated client")
+                Logger.debug("Ignoring obsolete event in terminated client")
                 return
             }
             guard peerConnection == peerConnectionParam else {
-                owsFail("\(strongSelf.logTag) in \(#function) mismatched peerConnection callback.")
+                owsFail("mismatched peerConnection callback.")
                 return
             }
-            Logger.info("\(strongSelf.logTag) didOpen dataChannel:\(dataChannel)")
+            Logger.info("didOpen dataChannel:\(dataChannel)")
             if strongSelf.dataChannel != nil {
-                owsFail("\(strongSelf.logTag) in \(#function) dataChannel unexpectedly set twice.")
+                owsFail("dataChannel unexpectedly set twice.")
             }
             strongSelf.dataChannel = dataChannel
             dataChannel.delegate = strongSelf.proxy
@@ -1056,7 +1056,7 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
         var result: RTCPeerConnection?
         PeerConnectionClient.signalingQueue.sync {
             result = peerConnection
-            Logger.info("\(self.logTag) called \(#function)")
+            Logger.info("")
         }
         return result!
     }
@@ -1067,7 +1067,7 @@ class PeerConnectionClient: NSObject, RTCPeerConnectionDelegate, RTCDataChannelD
         var result: RTCDataChannel?
         PeerConnectionClient.signalingQueue.sync {
             result = dataChannel
-            Logger.info("\(self.logTag) called \(#function)")
+            Logger.info("")
         }
         return result!
     }
@@ -1216,7 +1216,7 @@ class VideoCaptureController {
 
         if _isDebugAssertConfiguration(), let selectedFormat = selectedFormat {
             let dimension = CMVideoFormatDescriptionGetDimensions(selectedFormat.formatDescription)
-            Logger.debug("in \(#function) selected format width: \(dimension.width) height: \(dimension.height)")
+            Logger.debug("selected format width: \(dimension.width) height: \(dimension.height)")
         }
 
         assert(selectedFormat != nil)

--- a/Signal/src/call/SignalCall.swift
+++ b/Signal/src/call/SignalCall.swift
@@ -86,7 +86,7 @@ protocol CallObserver: class {
     var state: CallState {
         didSet {
             AssertIsOnMainThread()
-            Logger.debug("\(logTag) state changed: \(oldValue) -> \(self.state) for call: \(self.identifiersForLogs)")
+            Logger.debug("state changed: \(oldValue) -> \(self.state) for call: \(self.identifiersForLogs)")
 
             // Update connectedDate
             if case .connected = self.state {
@@ -108,7 +108,7 @@ protocol CallObserver: class {
         didSet {
             AssertIsOnMainThread()
 
-            Logger.debug("\(logTag) muted changed: \(oldValue) -> \(self.isMuted)")
+            Logger.debug("muted changed: \(oldValue) -> \(self.isMuted)")
 
             for observer in observers {
                 observer.value?.muteDidChange(call: self, isMuted: isMuted)
@@ -121,7 +121,7 @@ protocol CallObserver: class {
     var audioSource: AudioSource? = nil {
         didSet {
             AssertIsOnMainThread()
-            Logger.debug("\(logTag) audioSource changed: \(String(describing: oldValue)) -> \(String(describing: audioSource))")
+            Logger.debug("audioSource changed: \(String(describing: oldValue)) -> \(String(describing: audioSource))")
 
             for observer in observers {
                 observer.value?.audioSourceDidChange(call: self, audioSource: audioSource)
@@ -140,7 +140,7 @@ protocol CallObserver: class {
     var isOnHold = false {
         didSet {
             AssertIsOnMainThread()
-            Logger.debug("\(logTag) isOnHold changed: \(oldValue) -> \(self.isOnHold)")
+            Logger.debug("isOnHold changed: \(oldValue) -> \(self.isOnHold)")
 
             for observer in observers {
                 observer.value?.holdDidChange(call: self, isOnHold: isOnHold)

--- a/Signal/src/call/SignalCall.swift
+++ b/Signal/src/call/SignalCall.swift
@@ -121,7 +121,7 @@ protocol CallObserver: class {
     var audioSource: AudioSource? = nil {
         didSet {
             AssertIsOnMainThread()
-            Logger.debug("audioSource changed: \(String(describing: oldValue)) -> \(String(describing: audioSource))")
+            Logger.debug("audioSource changed: \(String(describing: oldValue)) -> \(String(describing: self.audioSource))")
 
             for observer in observers {
                 observer.value?.audioSourceDidChange(call: self, audioSource: audioSource)

--- a/Signal/src/call/SignalCall.swift
+++ b/Signal/src/call/SignalCall.swift
@@ -121,7 +121,7 @@ protocol CallObserver: class {
     var audioSource: AudioSource? = nil {
         didSet {
             AssertIsOnMainThread()
-            Logger.debug("audioSource changed: \(String(describing: oldValue)) -> \(String(describing: self.audioSource))")
+            Logger.debug("audioSource changed: \(String(describing: oldValue)) -> \(String(describing: audioSource))")
 
             for observer in observers {
                 observer.value?.audioSourceDidChange(call: self, audioSource: audioSource)

--- a/Signal/src/call/Speakerbox/CallKitCallManager.swift
+++ b/Signal/src/call/Speakerbox/CallKitCallManager.swift
@@ -90,9 +90,9 @@ final class CallKitCallManager: NSObject {
     private func requestTransaction(_ transaction: CXTransaction) {
         callController.request(transaction) { error in
             if let error = error {
-                Logger.error("\(self.logTag) Error requesting transaction: \(error)")
+                Logger.error("Error requesting transaction: \(error)")
             } else {
-                Logger.debug("\(self.logTag) Requested transaction successfully")
+                Logger.debug("Requested transaction successfully")
             }
         }
     }

--- a/Signal/src/call/Speakerbox/CallKitCallUIAdaptee.swift
+++ b/Signal/src/call/Speakerbox/CallKitCallUIAdaptee.swift
@@ -79,7 +79,7 @@ final class CallKitCallUIAdaptee: NSObject, CallUIAdaptee, CXProviderDelegate {
     init(callService: CallService, contactsManager: OWSContactsManager, notificationsAdapter: CallNotificationsAdapter, showNamesOnCallScreen: Bool, useSystemCallLog: Bool) {
         AssertIsOnMainThread()
 
-        Logger.debug("\(CallKitCallUIAdaptee.logTag()) \(#function)")
+        Logger.debug("")
 
         self.callManager = CallKitCallManager(showNamesOnCallScreen: showNamesOnCallScreen)
         self.callService = callService
@@ -102,7 +102,7 @@ final class CallKitCallUIAdaptee: NSObject, CallUIAdaptee, CXProviderDelegate {
 
     func startOutgoingCall(handle: String) -> SignalCall {
         AssertIsOnMainThread()
-        Logger.info("\(self.logTag) \(#function)")
+        Logger.info("")
 
         let call = SignalCall.outgoingCall(localId: UUID(), remotePhoneNumber: handle)
 
@@ -120,7 +120,7 @@ final class CallKitCallUIAdaptee: NSObject, CallUIAdaptee, CXProviderDelegate {
     // Called from CallService after call has ended to clean up any remaining CallKit call state.
     func failCall(_ call: SignalCall, error: CallError) {
         AssertIsOnMainThread()
-        Logger.info("\(self.logTag) \(#function)")
+        Logger.info("")
 
         switch error {
         case .timeout(description: _):
@@ -134,7 +134,7 @@ final class CallKitCallUIAdaptee: NSObject, CallUIAdaptee, CXProviderDelegate {
 
     func reportIncomingCall(_ call: SignalCall, callerName: String) {
         AssertIsOnMainThread()
-        Logger.info("\(self.logTag) \(#function)")
+        Logger.info("")
 
         // Construct a CXCallUpdate describing the incoming call, including the caller.
         let update = CXCallUpdate()
@@ -160,7 +160,7 @@ final class CallKitCallUIAdaptee: NSObject, CallUIAdaptee, CXProviderDelegate {
              since calls may be "denied" for various legitimate reasons. See CXErrorCodeIncomingCallError.
              */
             guard error == nil else {
-                Logger.error("\(self.logTag) failed to report new incoming call")
+                Logger.error("failed to report new incoming call")
                 return
             }
 
@@ -170,14 +170,14 @@ final class CallKitCallUIAdaptee: NSObject, CallUIAdaptee, CXProviderDelegate {
 
     func answerCall(localId: UUID) {
         AssertIsOnMainThread()
-        Logger.info("\(self.logTag) \(#function)")
+        Logger.info("")
 
-        owsFail("\(self.logTag) \(#function) CallKit should answer calls via system call screen, not via notifications.")
+        owsFail("CallKit should answer calls via system call screen, not via notifications.")
     }
 
     func answerCall(_ call: SignalCall) {
         AssertIsOnMainThread()
-        Logger.info("\(self.logTag) \(#function)")
+        Logger.info("")
 
         callManager.answer(call: call)
     }
@@ -185,19 +185,19 @@ final class CallKitCallUIAdaptee: NSObject, CallUIAdaptee, CXProviderDelegate {
     func declineCall(localId: UUID) {
         AssertIsOnMainThread()
 
-        owsFail("\(self.logTag) \(#function) CallKit should decline calls via system call screen, not via notifications.")
+        owsFail("CallKit should decline calls via system call screen, not via notifications.")
     }
 
     func declineCall(_ call: SignalCall) {
         AssertIsOnMainThread()
-        Logger.info("\(self.logTag) \(#function)")
+        Logger.info("")
 
         callManager.localHangup(call: call)
     }
 
     func recipientAcceptedCall(_ call: SignalCall) {
         AssertIsOnMainThread()
-        Logger.info("\(self.logTag) \(#function)")
+        Logger.info("")
 
         self.provider.reportOutgoingCall(with: call.localId, connectedAt: nil)
 
@@ -209,35 +209,35 @@ final class CallKitCallUIAdaptee: NSObject, CallUIAdaptee, CXProviderDelegate {
 
     func localHangupCall(_ call: SignalCall) {
         AssertIsOnMainThread()
-        Logger.info("\(self.logTag) \(#function)")
+        Logger.info("")
 
         callManager.localHangup(call: call)
     }
 
     func remoteDidHangupCall(_ call: SignalCall) {
         AssertIsOnMainThread()
-        Logger.info("\(self.logTag) \(#function)")
+        Logger.info("")
 
         provider.reportCall(with: call.localId, endedAt: nil, reason: CXCallEndedReason.remoteEnded)
     }
 
     func remoteBusy(_ call: SignalCall) {
         AssertIsOnMainThread()
-        Logger.info("\(self.logTag) \(#function)")
+        Logger.info("")
 
         provider.reportCall(with: call.localId, endedAt: nil, reason: CXCallEndedReason.unanswered)
     }
 
     func setIsMuted(call: SignalCall, isMuted: Bool) {
         AssertIsOnMainThread()
-        Logger.info("\(self.logTag) \(#function)")
+        Logger.info("")
 
         callManager.setIsMuted(call: call, isMuted: isMuted)
     }
 
     func setHasLocalVideo(call: SignalCall, hasLocalVideo: Bool) {
         AssertIsOnMainThread()
-        Logger.debug("\(self.logTag) \(#function)")
+        Logger.debug("")
 
         let update = CXCallUpdate()
         update.hasVideo = hasLocalVideo
@@ -252,7 +252,7 @@ final class CallKitCallUIAdaptee: NSObject, CallUIAdaptee, CXProviderDelegate {
 
     func providerDidReset(_ provider: CXProvider) {
         AssertIsOnMainThread()
-        Logger.info("\(self.logTag) \(#function)")
+        Logger.info("")
 
         // End any ongoing calls if the provider resets, and remove them from the app's list of calls,
         // since they are no longer valid.
@@ -265,10 +265,10 @@ final class CallKitCallUIAdaptee: NSObject, CallUIAdaptee, CXProviderDelegate {
     func provider(_ provider: CXProvider, perform action: CXStartCallAction) {
         AssertIsOnMainThread()
 
-        Logger.info("\(logTag) in \(#function) CXStartCallAction")
+        Logger.info("CXStartCallAction")
 
         guard let call = callManager.callWithLocalId(action.callUUID) else {
-            Logger.error("\(logTag) unable to find call in \(#function)")
+            Logger.error("unable to find call")
             return
         }
 
@@ -294,7 +294,7 @@ final class CallKitCallUIAdaptee: NSObject, CallUIAdaptee, CXProviderDelegate {
     func provider(_ provider: CXProvider, perform action: CXAnswerCallAction) {
         AssertIsOnMainThread()
 
-        Logger.info("\(logTag) Received \(#function) CXAnswerCallAction")
+        Logger.info("Received \(#function) CXAnswerCallAction")
         // Retrieve the instance corresponding to the action's call UUID
         guard let call = callManager.callWithLocalId(action.callUUID) else {
             action.fail()
@@ -309,9 +309,9 @@ final class CallKitCallUIAdaptee: NSObject, CallUIAdaptee, CXProviderDelegate {
     public func provider(_ provider: CXProvider, perform action: CXEndCallAction) {
         AssertIsOnMainThread()
 
-        Logger.info("\(logTag) Received \(#function) CXEndCallAction")
+        Logger.info("Received \(#function) CXEndCallAction")
         guard let call = callManager.callWithLocalId(action.callUUID) else {
-            Logger.error("\(self.logTag) in \(#function) trying to end unknown call with localId: \(action.callUUID)")
+            Logger.error("trying to end unknown call with localId: \(action.callUUID)")
             action.fail()
             return
         }
@@ -328,7 +328,7 @@ final class CallKitCallUIAdaptee: NSObject, CallUIAdaptee, CXProviderDelegate {
     public func provider(_ provider: CXProvider, perform action: CXSetHeldCallAction) {
         AssertIsOnMainThread()
 
-        Logger.info("\(logTag) Received \(#function) CXSetHeldCallAction")
+        Logger.info("Received \(#function) CXSetHeldCallAction")
         guard let call = callManager.callWithLocalId(action.callUUID) else {
             action.fail()
             return
@@ -344,9 +344,9 @@ final class CallKitCallUIAdaptee: NSObject, CallUIAdaptee, CXProviderDelegate {
     public func provider(_ provider: CXProvider, perform action: CXSetMutedCallAction) {
         AssertIsOnMainThread()
 
-        Logger.info("\(logTag) Received \(#function) CXSetMutedCallAction")
+        Logger.info("Received \(#function) CXSetMutedCallAction")
         guard let call = callManager.callWithLocalId(action.callUUID) else {
-            Logger.error("\(logTag) Failing CXSetMutedCallAction for unknown call: \(action.callUUID)")
+            Logger.error("Failing CXSetMutedCallAction for unknown call: \(action.callUUID)")
             action.fail()
             return
         }
@@ -358,19 +358,19 @@ final class CallKitCallUIAdaptee: NSObject, CallUIAdaptee, CXProviderDelegate {
     public func provider(_ provider: CXProvider, perform action: CXSetGroupCallAction) {
         AssertIsOnMainThread()
 
-        Logger.warn("\(logTag) unimplemented \(#function) for CXSetGroupCallAction")
+        Logger.warn("unimplemented \(#function) for CXSetGroupCallAction")
     }
 
     public func provider(_ provider: CXProvider, perform action: CXPlayDTMFCallAction) {
         AssertIsOnMainThread()
 
-        Logger.warn("\(logTag) unimplemented \(#function) for CXPlayDTMFCallAction")
+        Logger.warn("unimplemented \(#function) for CXPlayDTMFCallAction")
     }
 
     func provider(_ provider: CXProvider, timedOutPerforming action: CXAction) {
         AssertIsOnMainThread()
 
-        owsFail("\(logTag) Timed out \(#function) while performing \(action)")
+        owsFail("Timed out while performing \(action)")
 
         // React to the action timeout if necessary, such as showing an error UI.
     }
@@ -378,7 +378,7 @@ final class CallKitCallUIAdaptee: NSObject, CallUIAdaptee, CXProviderDelegate {
     func provider(_ provider: CXProvider, didActivate audioSession: AVAudioSession) {
         AssertIsOnMainThread()
 
-        Logger.debug("\(logTag) Received \(#function)")
+        Logger.debug("Received")
 
         OWSAudioSession.shared.startAudioActivity(self.audioActivity)
         OWSAudioSession.shared.isRTCAudioEnabled = true
@@ -387,7 +387,7 @@ final class CallKitCallUIAdaptee: NSObject, CallUIAdaptee, CXProviderDelegate {
     func provider(_ provider: CXProvider, didDeactivate audioSession: AVAudioSession) {
         AssertIsOnMainThread()
 
-        Logger.debug("\(logTag) Received \(#function)")
+        Logger.debug("Received")
         OWSAudioSession.shared.isRTCAudioEnabled = false
         OWSAudioSession.shared.endAudioActivity(self.audioActivity)
     }

--- a/Signal/src/call/UserInterface/CallUIAdapter.swift
+++ b/Signal/src/call/UserInterface/CallUIAdapter.swift
@@ -43,7 +43,7 @@ extension CallUIAdaptee {
             OWSWindowManager.shared().startCall(callViewController)
         } else {
             guard let presentingViewController = UIApplication.shared.frontmostViewControllerIgnoringAlerts else {
-                owsFail("in \(#function) view controller unexpectedly nil")
+                owsFail("view controller unexpectedly nil")
                 return
             }
 
@@ -98,16 +98,16 @@ extension CallUIAdaptee {
             // CallKit doesn't seem entirely supported in simulator.
             // e.g. you can't receive calls in the call screen.
             // So we use the non-CallKit call UI.
-            Logger.info("\(CallUIAdapter.logTag()) choosing non-callkit adaptee for simulator.")
+            Logger.info("choosing non-callkit adaptee for simulator.")
             adaptee = NonCallKitCallUIAdaptee(callService: callService, notificationsAdapter: notificationsAdapter)
         } else if #available(iOS 11, *) {
-            Logger.info("\(CallUIAdapter.logTag()) choosing callkit adaptee for iOS11+")
+            Logger.info("choosing callkit adaptee for iOS11+")
             let showNames = Environment.preferences().notificationPreviewType() != .noNameNoPreview
             let useSystemCallLog = Environment.preferences().isSystemCallLogEnabled()
 
             adaptee = CallKitCallUIAdaptee(callService: callService, contactsManager: contactsManager, notificationsAdapter: notificationsAdapter, showNamesOnCallScreen: showNames, useSystemCallLog: useSystemCallLog)
         } else if #available(iOS 10.0, *), Environment.current().preferences.isCallKitEnabled() {
-            Logger.info("\(CallUIAdapter.logTag()) choosing callkit adaptee for iOS10")
+            Logger.info("choosing callkit adaptee for iOS10")
             let hideNames = Environment.preferences().isCallKitPrivacyEnabled() || Environment.preferences().notificationPreviewType() == .noNameNoPreview
             let showNames = !hideNames
 
@@ -116,7 +116,7 @@ extension CallUIAdaptee {
 
             adaptee = CallKitCallUIAdaptee(callService: callService, contactsManager: contactsManager, notificationsAdapter: notificationsAdapter, showNamesOnCallScreen: showNames, useSystemCallLog: useSystemCallLog)
         } else {
-            Logger.info("\(CallUIAdapter.logTag()) choosing non-callkit adaptee")
+            Logger.info("choosing non-callkit adaptee")
             adaptee = NonCallKitCallUIAdaptee(callService: callService, notificationsAdapter: notificationsAdapter)
         }
 

--- a/Signal/src/environment/ExperienceUpgrades/ExperienceUpgradeFinder.swift
+++ b/Signal/src/environment/ExperienceUpgrades/ExperienceUpgradeFinder.swift
@@ -15,7 +15,7 @@ enum ExperienceUpgradeId: String {
 
 @objc public class ExperienceUpgradeFinder: NSObject {
 
-    // MARK - Singleton class
+    // MARK: - Singleton class
 
     @objc(sharedManager)
     public static let shared = ExperienceUpgradeFinder()
@@ -84,7 +84,7 @@ enum ExperienceUpgradeId: String {
     }
 
     @objc public func markAllAsSeen(transaction: YapDatabaseReadWriteTransaction) {
-        Logger.info("\(logTag) marking experience upgrades as seen")
+        Logger.info("marking experience upgrades as seen")
         allExperienceUpgrades.forEach { $0.save(with: transaction) }
     }
 }

--- a/Signal/src/network/GiphyAPI.swift
+++ b/Signal/src/network/GiphyAPI.swift
@@ -297,7 +297,7 @@ extension GiphyError: LocalizedError {
 
     private func giphyAPISessionManager() -> AFHTTPSessionManager? {
         guard let baseUrl = NSURL(string: kGiphyBaseURL) else {
-            Logger.error("\(logTag) Invalid base URL.")
+            Logger.error("Invalid base URL.")
             return nil
         }
         let sessionManager = AFHTTPSessionManager(baseURL: baseUrl as URL,
@@ -312,12 +312,12 @@ extension GiphyError: LocalizedError {
 
     public func search(query: String, success: @escaping (([GiphyImageInfo]) -> Void), failure: @escaping ((NSError?) -> Void)) {
         guard let sessionManager = giphyAPISessionManager() else {
-            Logger.error("\(logTag) Couldn't create session manager.")
+            Logger.error("Couldn't create session manager.")
             failure(nil)
             return
         }
         guard NSURL(string: kGiphyBaseURL) != nil else {
-            Logger.error("\(logTag) Invalid base URL.")
+            Logger.error("Invalid base URL.")
             failure(nil)
             return
         }
@@ -327,7 +327,7 @@ extension GiphyError: LocalizedError {
         let kGiphyPageSize = 100
         let kGiphyPageOffset = 0
         guard let queryEncoded = query.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else {
-            Logger.error("\(logTag) Could not URL encode query: \(query).")
+            Logger.error("Could not URL encode query: \(query).")
             failure(nil)
             return
         }
@@ -337,7 +337,7 @@ extension GiphyError: LocalizedError {
                            parameters: {},
                            progress: nil,
                            success: { _, value in
-                            Logger.error("\(GiphyAPI.logTag()) search request succeeded")
+                            Logger.error("search request succeeded")
                             guard let imageInfos = self.parseGiphyImages(responseJson: value) else {
                                 failure(nil)
                                 return
@@ -345,7 +345,7 @@ extension GiphyError: LocalizedError {
                             success(imageInfos)
         },
                            failure: { _, error in
-                            Logger.error("\(GiphyAPI.logTag()) search request failed: \(error)")
+                            Logger.error("search request failed: \(error)")
                             failure(error as NSError)
         })
     }
@@ -354,15 +354,15 @@ extension GiphyError: LocalizedError {
 
     private func parseGiphyImages(responseJson: Any?) -> [GiphyImageInfo]? {
         guard let responseJson = responseJson else {
-            Logger.error("\(logTag) Missing response.")
+            Logger.error("Missing response.")
             return nil
         }
         guard let responseDict = responseJson as? [String: Any] else {
-            Logger.error("\(logTag) Invalid response.")
+            Logger.error("Invalid response.")
             return nil
         }
         guard let imageDicts = responseDict["data"] as? [[String: Any]] else {
-            Logger.error("\(logTag) Invalid response data.")
+            Logger.error("Invalid response data.")
             return nil
         }
         return imageDicts.compactMap { imageDict in
@@ -373,21 +373,21 @@ extension GiphyError: LocalizedError {
     // Giphy API results are often incomplete or malformed, so we need to be defensive.
     private func parseGiphyImage(imageDict: [String: Any]) -> GiphyImageInfo? {
         guard let giphyId = imageDict["id"] as? String else {
-            Logger.warn("\(logTag) Image dict missing id.")
+            Logger.warn("Image dict missing id.")
             return nil
         }
         guard giphyId.count > 0 else {
-            Logger.warn("\(logTag) Image dict has invalid id.")
+            Logger.warn("Image dict has invalid id.")
             return nil
         }
         guard let renditionDicts = imageDict["images"] as? [String: Any] else {
-            Logger.warn("\(logTag) Image dict missing renditions.")
+            Logger.warn("Image dict missing renditions.")
             return nil
         }
         var renditions = [GiphyRendition]()
         for (renditionName, renditionDict) in renditionDicts {
             guard let renditionDict = renditionDict as? [String: Any] else {
-                Logger.warn("\(logTag) Invalid rendition dict.")
+                Logger.warn("Invalid rendition dict.")
                 continue
             }
             guard let rendition = parseGiphyRendition(renditionName: renditionName,
@@ -397,12 +397,12 @@ extension GiphyError: LocalizedError {
             renditions.append(rendition)
         }
         guard renditions.count > 0 else {
-            Logger.warn("\(logTag) Image has no valid renditions.")
+            Logger.warn("Image has no valid renditions.")
             return nil
         }
 
         guard let originalRendition = findOriginalRendition(renditions: renditions) else {
-            Logger.warn("\(logTag) Image has no original rendition.")
+            Logger.warn("Image has no original rendition.")
             return nil
         }
 
@@ -435,15 +435,15 @@ extension GiphyError: LocalizedError {
             return nil
         }
         guard urlString.count > 0 else {
-            Logger.warn("\(logTag) Rendition has invalid url.")
+            Logger.warn("Rendition has invalid url.")
             return nil
         }
         guard let url = NSURL(string: urlString) else {
-            Logger.warn("\(logTag) Rendition url could not be parsed.")
+            Logger.warn("Rendition url could not be parsed.")
             return nil
         }
         guard let fileExtension = url.pathExtension?.lowercased() else {
-            Logger.warn("\(logTag) Rendition url missing file extension.")
+            Logger.warn("Rendition url missing file extension.")
             return nil
         }
         var format = GiphyFormat.gif
@@ -456,7 +456,7 @@ extension GiphyError: LocalizedError {
         } else if fileExtension == "webp" {
             return nil
         } else {
-            Logger.warn("\(logTag) Invalid file extension: \(fileExtension).")
+            Logger.warn("Invalid file extension: \(fileExtension).")
             return nil
         }
 
@@ -481,7 +481,7 @@ extension GiphyError: LocalizedError {
             return nil
         }
         guard parsedValue > 0 else {
-            Logger.verbose("\(logTag) \(typeName) has non-positive \(key): \(parsedValue).")
+            Logger.verbose("\(typeName) has non-positive \(key): \(parsedValue).")
             return nil
         }
         return parsedValue

--- a/Signal/src/network/GiphyAPI.swift
+++ b/Signal/src/network/GiphyAPI.swift
@@ -82,7 +82,7 @@ extension GiphyError: LocalizedError {
     }
 
     public func log() {
-        Logger.verbose("\t \(format), \(name), \(width), \(height), \(fileSize)")
+        Logger.verbose("\t \(self.format), \(self.name), \(self.width), \(self.height), \(self.fileSize)")
     }
 }
 
@@ -114,7 +114,7 @@ extension GiphyError: LocalizedError {
     }
 
     public func log() {
-        Logger.verbose("giphyId: \(giphyId), \(renditions.count)")
+        Logger.verbose("giphyId: \(self.giphyId), \(self.renditions.count)")
         for rendition in renditions {
             rendition.log()
         }

--- a/Signal/src/network/GiphyAPI.swift
+++ b/Signal/src/network/GiphyAPI.swift
@@ -82,7 +82,7 @@ extension GiphyError: LocalizedError {
     }
 
     public func log() {
-        Logger.verbose("\t \(self.format), \(self.name), \(self.width), \(self.height), \(self.fileSize)")
+        Logger.verbose("\t \(format), \(name), \(width), \(height), \(fileSize)")
     }
 }
 
@@ -114,7 +114,7 @@ extension GiphyError: LocalizedError {
     }
 
     public func log() {
-        Logger.verbose("giphyId: \(self.giphyId), \(self.renditions.count)")
+        Logger.verbose("giphyId: \(giphyId), \(renditions.count)")
         for rendition in renditions {
             rendition.log()
         }

--- a/Signal/src/util/AppUpdateNag.swift
+++ b/Signal/src/util/AppUpdateNag.swift
@@ -21,17 +21,17 @@ class AppUpdateNag: NSObject {
     public func showAppUpgradeNagIfNecessary() {
 
         guard let currentVersion = self.currentVersion else {
-            owsFail("\(self.logTag) in \(#function) currentVersion was unexpectedly nil")
+            owsFail("currentVersion was unexpectedly nil")
             return
         }
 
         guard let bundleIdentifier = self.bundleIdentifier else {
-            owsFail("\(self.logTag) in \(#function) bundleIdentifier was unexpectedly nil")
+            owsFail("bundleIdentifier was unexpectedly nil")
             return
         }
 
         guard let lookupURL = lookupURL(bundleIdentifier: bundleIdentifier) else {
-            owsFail("\(self.logTag) in \(#function) appStoreURL was unexpectedly nil")
+            owsFail("appStoreURL was unexpectedly nil")
             return
         }
 
@@ -39,14 +39,14 @@ class AppUpdateNag: NSObject {
             self.versionService.fetchLatestVersion(lookupURL: lookupURL)
         }.then { appStoreRecord -> Void in
             guard appStoreRecord.version.compare(currentVersion, options: .numeric) == ComparisonResult.orderedDescending else {
-                Logger.debug("\(self.logTag) remote version: \(appStoreRecord) is not newer than currentVersion: \(currentVersion)")
+                Logger.debug("remote version: \(appStoreRecord) is not newer than currentVersion: \(currentVersion)")
                 return
             }
 
-            Logger.info("\(self.logTag) new version available: \(appStoreRecord)")
+            Logger.info("new version available: \(appStoreRecord)")
             self.showUpdateNagIfEnoughTimeHasPassed(appStoreRecord: appStoreRecord)
         }.catch { error in
-            Logger.error("\(self.logTag) in \(#function) failed with error: \(error)")
+            Logger.error("failed with error: \(error)")
         }.retainUntilComplete()
     }
 
@@ -95,14 +95,14 @@ class AppUpdateNag: NSObject {
 
         let intervalBeforeNag = 7 * kDayInterval
         guard Date() > Date.init(timeInterval: intervalBeforeNag, since: firstHeardOfNewVersionDate) else {
-            Logger.info("\(logTag) in \(#function) firstHeardOfNewVersionDate: \(firstHeardOfNewVersionDate) not nagging for new release yet.")
+            Logger.info("firstHeardOfNewVersionDate: \(firstHeardOfNewVersionDate) not nagging for new release yet.")
             return
         }
 
         if let lastNagDate = self.lastNagDate {
             let intervalBetweenNags = 14 * kDayInterval
             guard Date() > Date.init(timeInterval: intervalBetweenNags, since: lastNagDate) else {
-                Logger.info("\(logTag) in \(#function) lastNagDate: \(lastNagDate) not nagging again so soon.")
+                Logger.info("lastNagDate: \(lastNagDate) not nagging again so soon.")
                 return
             }
         }
@@ -110,7 +110,7 @@ class AppUpdateNag: NSObject {
         // Only show nag if we are "at rest" in the home view or registration view without any
         // alerts or dialogs showing.
         guard let frontmostViewController = UIApplication.shared.frontmostViewController else {
-            owsFail("\(self.logTag) in \(#function) frontmostViewController was unexpectedly nil")
+            owsFail("frontmostViewController was unexpectedly nil")
             return
         }
 
@@ -120,7 +120,7 @@ class AppUpdateNag: NSObject {
             self.clearFirstHeardOfNewVersionDate()
             presentUpgradeNag(appStoreRecord: appStoreRecord)
         default:
-            Logger.debug("\(logTag) in \(#function) not presenting alert due to frontmostViewController: \(frontmostViewController)")
+            Logger.debug("not presenting alert due to frontmostViewController: \(frontmostViewController)")
             break
         }
     }
@@ -150,7 +150,7 @@ class AppUpdateNag: NSObject {
     }
 
     func showAppStore(appStoreURL: URL) {
-        Logger.debug("\(logTag) in \(#function)")
+        Logger.debug("")
         UIApplication.shared.openURL(appStoreURL)
     }
 
@@ -199,13 +199,13 @@ class AppStoreVersionService: NSObject {
     // MARK: 
 
     func fetchLatestVersion(lookupURL: URL) -> Promise<AppStoreRecord> {
-        Logger.debug("\(logTag) in \(#function) lookupURL:\(lookupURL)")
+        Logger.debug("lookupURL:\(lookupURL)")
 
         let (promise, fulfill, reject) = Promise<AppStoreRecord>.pending()
 
         let task = URLSession.ephemeral.dataTask(with: lookupURL) { (data, _, error) in
             guard let data = data else {
-                Logger.warn("\(self.logTag) in \(#function) data was unexpectedly nil")
+                Logger.warn("data was unexpectedly nil")
                 reject(OWSErrorMakeUnableToProcessServerResponseError())
                 return
             }
@@ -214,7 +214,7 @@ class AppStoreVersionService: NSObject {
                 let decoder = JSONDecoder()
                 let resultSet = try decoder.decode(AppStoreLookupResultSet.self, from: data)
                 guard let appStoreRecord = resultSet.results.first else {
-                    Logger.warn("\(self.logTag) in \(#function) record was unexpectedly nil")
+                    Logger.warn("record was unexpectedly nil")
                     reject(OWSErrorMakeUnableToProcessServerResponseError())
                     return
                 }

--- a/Signal/src/util/OWSBackupAPI.swift
+++ b/Signal/src/util/OWSBackupAPI.swift
@@ -160,7 +160,7 @@ import CloudKit
                                       failure: failure)
                 }
             case .unknownItem:
-                owsFail("\(self.logTag) unexpected CloudKit response.")
+                owsFail("unexpected CloudKit response.")
                 failure(invalidServiceResponseError())
             }
         }
@@ -221,7 +221,7 @@ import CloudKit
                                 } else {
                                     // No record found, saving new record.
                                     guard let fileUrl = fileUrlBlock() else {
-                                        Logger.error("\(self.logTag) error preparing file for upload.")
+                                        Logger.error("error preparing file for upload.")
                                         failure(OWSErrorWithCodeDescription(.exportBackupError,
                                                                             NSLocalizedString("BACKUP_EXPORT_ERROR_SAVE_FILE_TO_CLOUD_FAILED",
                                                                                               comment: "Error indicating the backup export failed to save a file to the cloud.")))
@@ -282,7 +282,7 @@ import CloudKit
                                         failure: failure)
                 }
             case .unknownItem:
-                owsFail("\(self.logTag) unexpected CloudKit response.")
+                owsFail("unexpected CloudKit response.")
                 failure(invalidServiceResponseError())
             }
         }
@@ -308,7 +308,7 @@ import CloudKit
             switch outcome {
             case .success:
                 guard let record = record else {
-                    owsFail("\(self.logTag) missing fetching record.")
+                    owsFail("missing fetching record.")
                     failure(invalidServiceResponseError())
                     return
                 }
@@ -391,7 +391,7 @@ import CloudKit
             switch outcome {
             case .success:
                 if let cursor = cursor {
-                    Logger.verbose("\(self.logTag) fetching more record names \(allRecordNames.count).")
+                    Logger.verbose("fetching more record names \(allRecordNames.count).")
                     // There are more pages of results, continue fetching.
                     fetchAllRecordNamesStep(query: query,
                                             previousRecordNames: allRecordNames,
@@ -401,7 +401,7 @@ import CloudKit
                                             failure: failure)
                     return
                 }
-                Logger.info("\(self.logTag) fetched \(allRecordNames.count) record names.")
+                Logger.info("fetched \(allRecordNames.count) record names.")
                 success(allRecordNames)
             case .failureDoNotRetry(let outcomeError):
                 failure(outcomeError)
@@ -424,7 +424,7 @@ import CloudKit
                                             failure: failure)
                 }
             case .unknownItem:
-                owsFail("\(self.logTag) unexpected CloudKit response.")
+                owsFail("unexpected CloudKit response.")
                 failure(invalidServiceResponseError())
             }
         }
@@ -455,7 +455,7 @@ import CloudKit
                                     let data = try Data(contentsOf: asset.fileURL)
                                     success(data)
                                 } catch {
-                                    Logger.error("\(self.logTag) couldn't load asset file: \(error).")
+                                    Logger.error("couldn't load asset file: \(error).")
                                     failure(invalidServiceResponseError())
                                 }
                             }
@@ -477,7 +477,7 @@ import CloudKit
                                     try FileManager.default.copyItem(at: asset.fileURL, to: toFileUrl)
                                     success()
                                 } catch {
-                                    Logger.error("\(self.logTag) couldn't copy asset file: \(error).")
+                                    Logger.error("couldn't copy asset file: \(error).")
                                     failure(invalidServiceResponseError())
                                 }
                             }
@@ -506,12 +506,12 @@ import CloudKit
             switch outcome {
             case .success:
                 guard let record = record else {
-                    Logger.error("\(self.logTag) missing fetching record.")
+                    Logger.error("missing fetching record.")
                     failure(invalidServiceResponseError())
                     return
                 }
                 guard let asset = record[payloadKey] as? CKAsset else {
-                    Logger.error("\(self.logTag) record missing payload.")
+                    Logger.error("record missing payload.")
                     failure(invalidServiceResponseError())
                     return
                 }
@@ -533,7 +533,7 @@ import CloudKit
                                       failure: failure)
                 }
             case .unknownItem:
-                Logger.error("\(self.logTag) missing fetching record.")
+                Logger.error("missing fetching record.")
                 failure(invalidServiceResponseError())
             }
         }
@@ -548,15 +548,15 @@ import CloudKit
             DispatchQueue.main.async {
                 switch accountStatus {
                 case .couldNotDetermine:
-                    Logger.error("\(self.logTag) could not determine CloudKit account status:\(String(describing: error)).")
+                    Logger.error("could not determine CloudKit account status:\(String(describing: error)).")
                     OWSAlerts.showErrorAlert(message: NSLocalizedString("CLOUDKIT_STATUS_COULD_NOT_DETERMINE", comment: "Error indicating that the app could not determine that user's CloudKit account status"))
                     completion(false)
                 case .noAccount:
-                    Logger.error("\(self.logTag) no CloudKit account.")
+                    Logger.error("no CloudKit account.")
                     OWSAlerts.showErrorAlert(message: NSLocalizedString("CLOUDKIT_STATUS_NO_ACCOUNT", comment: "Error indicating that user does not have an iCloud account."))
                     completion(false)
                 case .restricted:
-                    Logger.error("\(self.logTag) restricted CloudKit account.")
+                    Logger.error("restricted CloudKit account.")
                     OWSAlerts.showErrorAlert(message: NSLocalizedString("CLOUDKIT_STATUS_RESTRICTED", comment: "Error indicating that the app was prevented from accessing the user's CloudKit account."))
                     completion(false)
                 case .available:
@@ -583,20 +583,20 @@ import CloudKit
         if let error = error as? CKError {
             if error.code == CKError.unknownItem {
                 // This is not always an error for our purposes.
-                Logger.verbose("\(self.logTag) \(label) unknown item.")
+                Logger.verbose("\(label) unknown item.")
                 return .unknownItem
             }
 
-            Logger.error("\(self.logTag) \(label) failed: \(error)")
+            Logger.error("\(label) failed: \(error)")
 
             if remainingRetries < 1 {
-                Logger.verbose("\(self.logTag) \(label) no more retries.")
+                Logger.verbose("\(label) no more retries.")
                 return .failureDoNotRetry(error:error)
             }
 
             if #available(iOS 11, *) {
                 if error.code == CKError.serverResponseLost {
-                    Logger.verbose("\(self.logTag) \(label) retry without delay.")
+                    Logger.verbose("\(label) retry without delay.")
                     return .failureRetryWithoutDelay
                 }
             }
@@ -604,25 +604,25 @@ import CloudKit
             switch error {
             case CKError.requestRateLimited, CKError.serviceUnavailable, CKError.zoneBusy:
                 let retryDelay = error.retryAfterSeconds ?? 3.0
-                Logger.verbose("\(self.logTag) \(label) retry with delay: \(retryDelay).")
+                Logger.verbose("\(label) retry with delay: \(retryDelay).")
                 return .failureRetryAfterDelay(retryDelay:retryDelay)
             case CKError.networkFailure:
-                Logger.verbose("\(self.logTag) \(label) retry without delay.")
+                Logger.verbose("\(label) retry without delay.")
                 return .failureRetryWithoutDelay
             default:
-                Logger.verbose("\(self.logTag) \(label) unknown CKError.")
+                Logger.verbose("\(label) unknown CKError.")
                 return .failureDoNotRetry(error:error)
             }
         } else if let error = error {
-            Logger.error("\(self.logTag) \(label) failed: \(error)")
+            Logger.error("\(label) failed: \(error)")
             if remainingRetries < 1 {
-                Logger.verbose("\(self.logTag) \(label) no more retries.")
+                Logger.verbose("\(label) no more retries.")
                 return .failureDoNotRetry(error:error)
             }
-            Logger.verbose("\(self.logTag) \(label) unknown error.")
+            Logger.verbose("\(label) unknown error.")
             return .failureDoNotRetry(error:error)
         } else {
-            Logger.info("\(self.logTag) \(label) succeeded.")
+            Logger.info("\(label) succeeded.")
             return .success
         }
     }

--- a/Signal/src/util/OWSBackupLazyRestoreJob.swift
+++ b/Signal/src/util/OWSBackupLazyRestoreJob.swift
@@ -43,7 +43,7 @@ public class OWSBackupLazyRestoreJob: NSObject {
         let jobTempDirPath = (temporaryDirectory as NSString).appendingPathComponent(NSUUID().uuidString)
 
         guard OWSFileSystem.ensureDirectoryExists(jobTempDirPath) else {
-            Logger.error("\(logTag) could not create temp directory.")
+            Logger.error("could not create temp directory.")
             return
         }
 
@@ -53,10 +53,10 @@ public class OWSBackupLazyRestoreJob: NSObject {
 
         let attachmentIds = OWSBackup.shared().attachmentIdsForLazyRestore()
         guard attachmentIds.count > 0 else {
-            Logger.info("\(logTag) No attachments need lazy restore.")
+            Logger.info("No attachments need lazy restore.")
             return
         }
-        Logger.info("\(logTag) Lazy restoring \(attachmentIds.count) attachments.")
+        Logger.info("Lazy restoring \(attachmentIds.count) attachments.")
         self.tryToRestoreNextAttachment(attachmentIds: attachmentIds, backupIO: backupIO)
     }
 
@@ -64,12 +64,12 @@ public class OWSBackupLazyRestoreJob: NSObject {
         var attachmentIdsCopy = attachmentIds
         guard let attachmentId = attachmentIdsCopy.last else {
             // This job is done.
-            Logger.verbose("\(logTag) job is done.")
+            Logger.verbose("job is done.")
             return
         }
         attachmentIdsCopy.removeLast()
         guard let attachment = TSAttachmentStream.fetch(uniqueId: attachmentId) else {
-            Logger.warn("\(logTag) could not load attachment.")
+            Logger.warn("could not load attachment.")
             // Not necessarily an error.
             // The attachment might have been deleted since the job began.
             // Continue trying to restore the other attachments.
@@ -80,9 +80,9 @@ public class OWSBackupLazyRestoreJob: NSObject {
                                                  backupIO: backupIO,
                                                  completion: { (success) in
                                                     if success {
-                                                        Logger.info("\(self.logTag) restored attachment.")
+                                                        Logger.info("restored attachment.")
                                                     } else {
-                                                        Logger.warn("\(self.logTag) could not restore attachment.")
+                                                        Logger.warn("could not restore attachment.")
                                                     }
                                                 // Continue trying to restore the other attachments.
                                                 self.tryToRestoreNextAttachment(attachmentIds: attachmentIdsCopy, backupIO: backupIO)

--- a/Signal/src/views/QuotedReplyPreview.swift
+++ b/Signal/src/views/QuotedReplyPreview.swift
@@ -81,7 +81,7 @@ class QuotedReplyPreview: UIView {
 
     func updateHeight() {
         guard let quotedMessageView = quotedMessageView else {
-            owsFail("\(logTag) missing quotedMessageView")
+            owsFail("missing quotedMessageView")
             return
         }
         let size = quotedMessageView.size(forMaxWidth: CGFloat.infinity)
@@ -89,7 +89,7 @@ class QuotedReplyPreview: UIView {
     }
 
     @objc func contentSizeCategoryDidChange(_ notification: Notification) {
-        Logger.debug("\(self.logTag) in \(#function)")
+        Logger.debug("")
 
         updateContents()
     }

--- a/Signal/src/views/ReminderView.swift
+++ b/Signal/src/views/ReminderView.swift
@@ -94,7 +94,7 @@ class ReminderView: UIView {
             // Icon
             let iconName = (CurrentAppContext().isRTL ? "system_disclosure_indicator_rtl" : "system_disclosure_indicator")
             guard let iconImage = UIImage(named: iconName) else {
-                owsFail("\(logTag) missing icon.")
+                owsFail("missing icon.")
                 return
             }
             let iconView = UIImageView(image: iconImage.withRenderingMode(.alwaysTemplate))

--- a/Signal/src/views/Toast.swift
+++ b/Signal/src/views/Toast.swift
@@ -93,7 +93,7 @@ class ToastController: NSObject, ToastViewDelegate {
 
     @objc
     func presentToastView(fromBottomOfView view: UIView, inset: CGFloat) {
-        Logger.debug("\(logTag) in \(#function)")
+        Logger.debug("")
         toastView.alpha = 0
         view.addSubview(toastView)
         toastView.setCompressionResistanceHigh()
@@ -121,19 +121,19 @@ class ToastController: NSObject, ToastViewDelegate {
     // MARK: ToastViewDelegate
 
     func didTapToastView(_ toastView: ToastView) {
-        Logger.debug("\(logTag) in \(#function)")
+        Logger.debug("")
         self.dismissToastView()
     }
 
     func didSwipeToastView(_ toastView: ToastView) {
-        Logger.debug("\(logTag) in \(#function)")
+        Logger.debug("")
         self.dismissToastView()
     }
 
     // MARK: Internal
 
     func dismissToastView() {
-        Logger.debug("\(logTag) in \(#function)")
+        Logger.debug("")
 
         guard !isDismissing else {
             return

--- a/SignalMessaging/ViewControllers/AttachmentApprovalViewController.swift
+++ b/SignalMessaging/ViewControllers/AttachmentApprovalViewController.swift
@@ -67,7 +67,7 @@ public class AttachmentApprovalViewController: OWSViewController, CaptioningTool
         let navController = OWSNavigationController(rootViewController: vc)
 
         guard let navigationBar = navController.navigationBar as? OWSNavigationBar else {
-            owsFail("\(self.logTag) in \(#function) navigationBar was nil or unexpected class")
+            owsFail("navigationBar was nil or unexpected class")
             return navController
         }
         navigationBar.makeClear()
@@ -76,7 +76,7 @@ public class AttachmentApprovalViewController: OWSViewController, CaptioningTool
     }
 
     override public func viewWillLayoutSubviews() {
-        Logger.debug("\(logTag) in \(#function)")
+        Logger.debug("")
         super.viewWillLayoutSubviews()
 
         // e.g. if flipping to/from landscape
@@ -84,22 +84,20 @@ public class AttachmentApprovalViewController: OWSViewController, CaptioningTool
     }
 
     override public func viewWillAppear(_ animated: Bool) {
-        Logger.debug("\(logTag) in \(#function)")
+        Logger.debug("")
         super.viewWillAppear(animated)
 
         CurrentAppContext().setStatusBarHidden(true, animated: animated)
     }
 
     override public func viewDidAppear(_ animated: Bool) {
-        Logger.debug("\(logTag) in \(#function)")
-        DispatchQueue.global().async {
-            AssertIsOnMainThread()
-        }
+        Logger.debug("")
+
         super.viewDidAppear(animated)
     }
 
     override public func viewWillDisappear(_ animated: Bool) {
-        Logger.debug("\(logTag) in \(#function)")
+        Logger.debug("")
         super.viewWillDisappear(animated)
 
         // Since this VC is being dismissed, the "show status bar" animation would feel like
@@ -273,15 +271,15 @@ public class AttachmentApprovalViewController: OWSViewController, CaptioningTool
     // MARK: Video
 
     private func playVideo() {
-        Logger.info("\(logTag) in \(#function)")
+        Logger.info("")
 
         guard let videoPlayer = self.videoPlayer else {
-            owsFail("\(logTag) video player was unexpectedly nil")
+            owsFail("video player was unexpectedly nil")
             return
         }
 
         guard let playVideoButton = self.playVideoButton else {
-            owsFail("\(logTag) playVideoButton was unexpectedly nil")
+            owsFail("playVideoButton was unexpectedly nil")
             return
         }
         UIView.animate(withDuration: 0.1) {
@@ -292,13 +290,13 @@ public class AttachmentApprovalViewController: OWSViewController, CaptioningTool
 
     private func pauseVideo() {
         guard let videoPlayer = self.videoPlayer else {
-            owsFail("\(logTag) video player was unexpectedly nil")
+            owsFail("video player was unexpectedly nil")
             return
         }
 
         videoPlayer.pause()
         guard let playVideoButton = self.playVideoButton else {
-            owsFail("\(logTag) playVideoButton was unexpectedly nil")
+            owsFail("playVideoButton was unexpectedly nil")
             return
         }
         UIView.animate(withDuration: 0.1) {
@@ -309,7 +307,7 @@ public class AttachmentApprovalViewController: OWSViewController, CaptioningTool
     @objc
     public func videoPlayerDidPlayToCompletion(_ videoPlayer: OWSVideoPlayer) {
         guard let playVideoButton = self.playVideoButton else {
-            owsFail("\(logTag) playVideoButton was unexpectedly nil")
+            owsFail("playVideoButton was unexpectedly nil")
             return
         }
 
@@ -320,7 +318,7 @@ public class AttachmentApprovalViewController: OWSViewController, CaptioningTool
 
     public func playerProgressBarDidStartScrubbing(_ playerProgressBar: PlayerProgressBar) {
         guard let videoPlayer = self.videoPlayer else {
-            owsFail("\(logTag) video player was unexpectedly nil")
+            owsFail("video player was unexpectedly nil")
             return
         }
         videoPlayer.pause()
@@ -328,7 +326,7 @@ public class AttachmentApprovalViewController: OWSViewController, CaptioningTool
 
     public func playerProgressBar(_ playerProgressBar: PlayerProgressBar, scrubbedToTime time: CMTime) {
         guard let videoPlayer = self.videoPlayer else {
-            owsFail("\(logTag) video player was unexpectedly nil")
+            owsFail("video player was unexpectedly nil")
             return
         }
 
@@ -337,7 +335,7 @@ public class AttachmentApprovalViewController: OWSViewController, CaptioningTool
 
     public func playerProgressBar(_ playerProgressBar: PlayerProgressBar, didFinishScrubbingAtTime time: CMTime, shouldResumePlayback: Bool) {
         guard let videoPlayer = self.videoPlayer else {
-            owsFail("\(logTag) video player was unexpectedly nil")
+            owsFail("video player was unexpectedly nil")
             return
         }
 
@@ -414,12 +412,12 @@ extension AttachmentApprovalViewController: UIScrollViewDelegate {
     }
 
     fileprivate func updateMinZoomScaleForSize(_ size: CGSize) {
-        Logger.debug("\(logTag) in \(#function)")
+        Logger.debug("")
 
         // Ensure bounds have been computed
         mediaMessageView.layoutIfNeeded()
         guard mediaMessageView.bounds.width > 0, mediaMessageView.bounds.height > 0 else {
-            Logger.warn("\(logTag) bad bounds in \(#function)")
+            Logger.warn("bad bounds")
             return
         }
 
@@ -644,7 +642,7 @@ class CaptioningToolbar: UIView, UITextViewDelegate {
         let proposedText: String = (existingText as NSString).replacingCharacters(in: range, with: text)
 
         guard proposedText.utf8.count <= kOversizeTextMessageSizeThreshold else {
-            Logger.debug("\(self.logTag) in \(#function) long text was truncated")
+            Logger.debug("long text was truncated")
             self.lengthLimitLabel.isHidden = false
 
             // `range` represents the section of the existing text we will replace. We can re-use that space.
@@ -689,7 +687,7 @@ class CaptioningToolbar: UIView, UITextViewDelegate {
         let newHeight = clampedTextViewHeight(fixedWidth: currentSize.width)
 
         if newHeight != self.textViewHeight {
-            Logger.debug("\(self.logTag) TextView height changed: \(self.textViewHeight) -> \(newHeight)")
+            Logger.debug("TextView height changed: \(self.textViewHeight) -> \(newHeight)")
             self.textViewHeight = newHeight
             self.textViewHeightConstraint?.constant = textViewHeight
             self.invalidateIntrinsicContentSize()

--- a/SignalMessaging/ViewControllers/ContactFieldView.swift
+++ b/SignalMessaging/ViewControllers/ContactFieldView.swift
@@ -26,7 +26,7 @@ public class ContactFieldView: UIView {
 
         let addSpacerRow = {
             guard let prevRow = lastRow else {
-                owsFail("\(self.logTag) missing last row")
+                owsFail("missing last row")
                 return
             }
             let row = UIView()

--- a/SignalMessaging/ViewControllers/ContactShareApprovalViewController.swift
+++ b/SignalMessaging/ViewControllers/ContactShareApprovalViewController.swift
@@ -204,7 +204,7 @@ class ContactShareFieldView: UIStackView {
     }
 
     @objc func wasTapped(sender: UIGestureRecognizer) {
-        Logger.info("\(self.logTag) \(#function)")
+        Logger.info("")
 
         guard sender.state == .recognized else {
             return
@@ -264,7 +264,7 @@ public class ContactShareApprovalViewController: OWSViewController, EditContactS
                                                       delegate: self)
                 fieldViews.append(fieldView)
             } else {
-                owsFail("\(logTag) could not load avatar image.")
+                owsFail("could not load avatar image.")
             }
         }
 
@@ -354,7 +354,7 @@ public class ContactShareApprovalViewController: OWSViewController, EditContactS
         AssertIsOnMainThread()
 
         guard let rootView = self.view else {
-            owsFail("\(logTag) missing root view.")
+            owsFail("missing root view.")
             return
         }
 
@@ -461,10 +461,10 @@ public class ContactShareApprovalViewController: OWSViewController, EditContactS
             return
         }
 
-        Logger.info("\(logTag) \(#function)")
+        Logger.info("")
 
         guard let delegate = self.delegate else {
-            owsFail("\(logTag) missing delegate.")
+            owsFail("missing delegate.")
             return
         }
 
@@ -476,10 +476,10 @@ public class ContactShareApprovalViewController: OWSViewController, EditContactS
     }
 
     @objc func didPressCancel() {
-        Logger.info("\(logTag) \(#function)")
+        Logger.info("")
 
         guard let delegate = self.delegate else {
-            owsFail("\(logTag) missing delegate.")
+            owsFail("missing delegate.")
             return
         }
 
@@ -487,7 +487,7 @@ public class ContactShareApprovalViewController: OWSViewController, EditContactS
     }
 
     func didPressEditName() {
-        Logger.info("\(logTag) \(#function)")
+        Logger.info("")
 
         let view = EditContactShareNameViewController(contactShare: contactShare, delegate: self)
         self.navigationController?.pushViewController(view, animated: true)

--- a/SignalMessaging/ViewControllers/EditContactShareNameViewController.swift
+++ b/SignalMessaging/ViewControllers/EditContactShareNameViewController.swift
@@ -77,7 +77,7 @@ class ContactNameFieldView: UIView {
     }
 
     @objc func wasTapped(sender: UIGestureRecognizer) {
-        Logger.info("\(self.logTag) \(#function)")
+        Logger.info("")
 
         guard sender.state == .recognized else {
             return
@@ -87,12 +87,12 @@ class ContactNameFieldView: UIView {
     }
 
     @objc func textFieldDidChange(sender: UITextField) {
-        Logger.info("\(self.logTag) \(#function)")
+        Logger.info("")
 
         hasUnsavedChanges = true
 
         guard let delegate = self.delegate else {
-            owsFail("\(logTag) missing delegate.")
+            owsFail("missing delegate.")
             return
         }
 
@@ -244,7 +244,7 @@ public class EditContactShareNameViewController: OWSViewController, ContactNameF
         AssertIsOnMainThread()
 
         guard let rootView = self.view else {
-            owsFail("\(logTag) missing root view.")
+            owsFail("missing root view.")
             return
         }
 
@@ -286,10 +286,10 @@ public class EditContactShareNameViewController: OWSViewController, ContactNameF
     // MARK: -
 
     @objc func didPressSave() {
-        Logger.info("\(logTag) \(#function)")
+        Logger.info("")
 
         guard let newName = OWSContactName() else {
-            owsFail("\(logTag) could not create a new name.")
+            owsFail("could not create a new name.")
             return
         }
         newName.namePrefix = namePrefixView.value().ows_stripped()
@@ -302,24 +302,24 @@ public class EditContactShareNameViewController: OWSViewController, ContactNameF
         let modifiedContactShare = contactShare.copy(withName: newName)
 
         guard let delegate = self.delegate else {
-            owsFail("\(logTag) missing delegate.")
+            owsFail("missing delegate.")
             return
         }
 
         delegate.editContactShareNameView(self, didEditContactShare: modifiedContactShare)
 
         guard let navigationController = self.navigationController else {
-            owsFail("\(logTag) Missing navigationController.")
+            owsFail("Missing navigationController.")
             return
         }
         navigationController.popViewController(animated: true)
     }
 
     @objc func didPressCancel() {
-        Logger.info("\(logTag) \(#function)")
+        Logger.info("")
 
         guard let navigationController = self.navigationController else {
-            owsFail("\(logTag) Missing navigationController.")
+            owsFail("Missing navigationController.")
             return
         }
         navigationController.popViewController(animated: true)

--- a/SignalMessaging/ViewControllers/ReturnToCallViewController.swift
+++ b/SignalMessaging/ViewControllers/ReturnToCallViewController.swift
@@ -67,13 +67,13 @@ public class ReturnToCallViewController: UIViewController {
     }
 
     override public func viewWillLayoutSubviews() {
-        Logger.debug("\(self.logTag) in \(#function)")
+        Logger.debug("")
 
         super.viewWillLayoutSubviews()
     }
 
     override public func viewDidLayoutSubviews() {
-        Logger.debug("\(self.logTag) in \(#function)")
+        Logger.debug("")
 
         super.viewDidLayoutSubviews()
     }

--- a/SignalMessaging/Views/AvatarImageView.swift
+++ b/SignalMessaging/Views/AvatarImageView.swift
@@ -70,7 +70,7 @@ public class ConversationAvatarImageView: AvatarImageView {
             self.recipientId = nil
             self.groupThreadId = groupThread.uniqueId
         default:
-            owsFail("in \(#function) unexpected thread type: \(thread)")
+            owsFail("unexpected thread type: \(thread)")
             self.recipientId = nil
             self.groupThreadId = nil
         }
@@ -96,7 +96,7 @@ public class ConversationAvatarImageView: AvatarImageView {
     }
 
     @objc func handleSignalAccountsChanged(notification: Notification) {
-        Logger.debug("\(self.logTag) in \(#function)")
+        Logger.debug("")
 
         // PERF: It would be nice if we could do this only if *this* user's SignalAccount changed,
         // but currently this is only a course grained notification.
@@ -105,16 +105,16 @@ public class ConversationAvatarImageView: AvatarImageView {
     }
 
     @objc func handleOtherUsersProfileChanged(notification: Notification) {
-        Logger.debug("\(self.logTag) in \(#function)")
+        Logger.debug("")
 
         guard let changedRecipientId = notification.userInfo?[kNSNotificationKey_ProfileRecipientId] as? String else {
-            owsFail("\(logTag) in \(#function) recipientId was unexpectedly nil")
+            owsFail("recipientId was unexpectedly nil")
             return
         }
 
         guard let recipientId = self.recipientId else {
             // shouldn't call this for group threads
-            owsFail("\(logTag) in \(#function) contactId was unexpectedly nil")
+            owsFail("contactId was unexpectedly nil")
             return
         }
 
@@ -127,16 +127,16 @@ public class ConversationAvatarImageView: AvatarImageView {
     }
 
     @objc func handleGroupAvatarChanged(notification: Notification) {
-        Logger.debug("\(self.logTag) in \(#function)")
+        Logger.debug("")
 
         guard let changedGroupThreadId = notification.userInfo?[TSGroupThread_NotificationKey_UniqueId] as? String else {
-            owsFail("\(logTag) in \(#function) groupThreadId was unexpectedly nil")
+            owsFail("groupThreadId was unexpectedly nil")
             return
         }
 
         guard let groupThreadId = self.groupThreadId else {
             // shouldn't call this for contact threads
-            owsFail("\(logTag) in \(#function) groupThreadId was unexpectedly nil")
+            owsFail("groupThreadId was unexpectedly nil")
             return
         }
 
@@ -151,7 +151,7 @@ public class ConversationAvatarImageView: AvatarImageView {
     }
 
     public func updateImage() {
-        Logger.debug("\(self.logTag) in \(#function) updateImage")
+        Logger.debug("updateImage")
 
         self.image = OWSAvatarBuilder.buildImage(thread: thread, diameter: diameter, contactsManager: contactsManager)
     }

--- a/SignalMessaging/Views/DisappearingTimerConfigurationView.swift
+++ b/SignalMessaging/Views/DisappearingTimerConfigurationView.swift
@@ -28,13 +28,13 @@ public class DisappearingTimerConfigurationView: UIView {
 
     override public var frame: CGRect {
         didSet {
-            Logger.verbose("\(oldValue) -> \(frame)")
+            Logger.verbose("\(oldValue) -> \(self.frame)")
         }
     }
 
     override public var bounds: CGRect {
         didSet {
-            Logger.verbose("\(oldValue) -> \(bounds)")
+            Logger.verbose("\(oldValue) -> \(self.bounds)")
         }
     }
 

--- a/SignalMessaging/Views/DisappearingTimerConfigurationView.swift
+++ b/SignalMessaging/Views/DisappearingTimerConfigurationView.swift
@@ -28,20 +28,20 @@ public class DisappearingTimerConfigurationView: UIView {
 
     override public var frame: CGRect {
         didSet {
-            Logger.verbose("\(logTag) in \(#function): \(oldValue) -> \(frame)")
+            Logger.verbose("\(oldValue) -> \(frame)")
         }
     }
 
     override public var bounds: CGRect {
         didSet {
-            Logger.verbose("\(logTag) in \(#function): \(oldValue) -> \(bounds)")
+            Logger.verbose("\(oldValue) -> \(bounds)")
         }
     }
 
     override public func layoutSubviews() {
         let oldFrame = self.frame
         super.layoutSubviews()
-        Logger.verbose("\(logTag) in \(#function). Frame: \(oldFrame) -> \(self.frame)")
+        Logger.verbose("Frame: \(oldFrame) -> \(self.frame)")
     }
 
     private let imageView: UIImageView
@@ -97,7 +97,7 @@ public class DisappearingTimerConfigurationView: UIView {
 
     @objc
     func pressHandler(_ gestureRecognizer: UILongPressGestureRecognizer) {
-        Logger.verbose("\(self.logTag) in \(#function)")
+        Logger.verbose("")
 
         // handle touch down and touch up events separately
         if gestureRecognizer.state == .began {

--- a/SignalMessaging/Views/DisappearingTimerConfigurationView.swift
+++ b/SignalMessaging/Views/DisappearingTimerConfigurationView.swift
@@ -28,13 +28,13 @@ public class DisappearingTimerConfigurationView: UIView {
 
     override public var frame: CGRect {
         didSet {
-            Logger.verbose("\(oldValue) -> \(self.frame)")
+            Logger.verbose("\(oldValue) -> \(frame)")
         }
     }
 
     override public var bounds: CGRect {
         didSet {
-            Logger.verbose("\(oldValue) -> \(self.bounds)")
+            Logger.verbose("\(oldValue) -> \(bounds)")
         }
     }
 

--- a/SignalMessaging/Views/OWSAlerts.swift
+++ b/SignalMessaging/Views/OWSAlerts.swift
@@ -24,7 +24,7 @@ import Foundation
     @objc
     public class func showAlert(_ alert: UIAlertController) {
         guard let frontmostViewController = CurrentAppContext().frontmostViewController() else {
-            owsFail("\(self.logTag) in \(#function) frontmostViewController was unexpectedly nil")
+            owsFail("frontmostViewController was unexpectedly nil")
             return
         }
         frontmostViewController.present(alert, animated: true, completion: nil)

--- a/SignalMessaging/Views/OWSNavigationBar.swift
+++ b/SignalMessaging/Views/OWSNavigationBar.swift
@@ -103,7 +103,7 @@ public class OWSNavigationBar: UINavigationBar {
 
     @objc
     public func themeDidChange() {
-        Logger.debug("\(self.logTag) in \(#function)")
+        Logger.debug("")
         applyTheme()
     }
 
@@ -111,13 +111,13 @@ public class OWSNavigationBar: UINavigationBar {
 
     @objc
     public func callDidChange() {
-        Logger.debug("\(self.logTag) in \(#function)")
+        Logger.debug("")
         self.navBarLayoutDelegate?.navBarCallLayoutDidChange(navbar: self)
     }
 
     @objc
     public func didChangeStatusBarFrame() {
-        Logger.debug("\(self.logTag) in \(#function)")
+        Logger.debug("")
         self.navBarLayoutDelegate?.navBarCallLayoutDidChange(navbar: self)
     }
 

--- a/SignalMessaging/Views/TappableStackView.swift
+++ b/SignalMessaging/Views/TappableStackView.swift
@@ -24,7 +24,7 @@ public class TappableStackView: UIStackView {
     }
 
     @objc func wasTapped(sender: UIGestureRecognizer) {
-        Logger.info("\(logTag) \(#function)")
+        Logger.info("")
 
         guard sender.state == .recognized else {
             return

--- a/SignalMessaging/Views/TappableView.swift
+++ b/SignalMessaging/Views/TappableView.swift
@@ -23,7 +23,7 @@ public class TappableView: UIView {
     }
 
     @objc func wasTapped(sender: UIGestureRecognizer) {
-        Logger.info("\(logTag) \(#function)")
+        Logger.info("")
 
         guard sender.state == .recognized else {
             return

--- a/SignalMessaging/Views/VideoPlayerView.swift
+++ b/SignalMessaging/Views/VideoPlayerView.swift
@@ -184,12 +184,12 @@ public class PlayerProgressBar: UIView {
 
     private func updateState() {
         guard let player = player else {
-            owsFail("\(logTag) player isn't set.")
+            owsFail("player isn't set.")
             return
         }
 
         guard let item = player.currentItem else {
-            owsFail("\(logTag) player has no item.")
+            owsFail("player has no item.")
             return
         }
 

--- a/SignalMessaging/attachments/OWSVideoPlayer.swift
+++ b/SignalMessaging/attachments/OWSVideoPlayer.swift
@@ -45,7 +45,7 @@ public class OWSVideoPlayer: NSObject {
         OWSAudioSession.shared.startPlaybackAudioActivity(self.audioActivity)
 
         guard let item = avPlayer.currentItem else {
-            owsFail("\(logTag) video player item was unexpectedly nil")
+            owsFail("video player item was unexpectedly nil")
             return
         }
 

--- a/SignalMessaging/attachments/SignalAttachment.swift
+++ b/SignalMessaging/attachments/SignalAttachment.swift
@@ -160,7 +160,7 @@ public class SignalAttachment: NSObject {
             AssertIsOnMainThread()
 
             assert(oldValue == nil)
-            Logger.verbose("Attachment has error: \(String(describing: error))")
+            Logger.verbose("Attachment has error: \(String(describing: self.error))")
         }
     }
 

--- a/SignalMessaging/attachments/SignalAttachment.swift
+++ b/SignalMessaging/attachments/SignalAttachment.swift
@@ -160,7 +160,7 @@ public class SignalAttachment: NSObject {
             AssertIsOnMainThread()
 
             assert(oldValue == nil)
-            Logger.verbose("\(logTag) Attachment has error: \(String(describing: error))")
+            Logger.verbose("Attachment has error: \(String(describing: error))")
         }
     }
 
@@ -208,7 +208,7 @@ public class SignalAttachment: NSObject {
     public var errorName: String? {
         guard let error = error else {
             // This method should only be called if there is an error.
-            owsFail("\(logTag) Missing error")
+            owsFail("Missing error")
             return nil
         }
 
@@ -219,11 +219,11 @@ public class SignalAttachment: NSObject {
     public var localizedErrorDescription: String? {
         guard let error = self.error else {
             // This method should only be called if there is an error.
-            owsFail("\(logTag) Missing error")
+            owsFail("Missing error")
             return nil
         }
         guard let errorDescription = error.errorDescription else {
-            owsFail("\(logTag) Missing error description")
+            owsFail("Missing error description")
             return nil
         }
 
@@ -233,7 +233,7 @@ public class SignalAttachment: NSObject {
     @objc
     public class var missingDataErrorMessage: String {
         guard let errorDescription = SignalAttachmentError.missingData.errorDescription else {
-            owsFail("\(logTag) Missing error description")
+            owsFail("Missing error description")
             return ""
         }
         return errorDescription
@@ -278,7 +278,7 @@ public class SignalAttachment: NSObject {
             return image
 
         } catch let error {
-            Logger.verbose("\(logTag) Could not generate video thumbnail: \(error.localizedDescription)")
+            Logger.verbose("Could not generate video thumbnail: \(error.localizedDescription)")
             return nil
         }
     }
@@ -516,7 +516,7 @@ public class SignalAttachment: NSObject {
         for dataUTI in inputImageUTISet {
             if pasteboardUTISet.contains(dataUTI) {
                 guard let data = dataForFirstPasteboardItem(dataUTI: dataUTI) else {
-                    owsFail("\(logTag) Missing expected pasteboard data for UTI: \(dataUTI)")
+                    owsFail("Missing expected pasteboard data for UTI: \(dataUTI)")
                     return nil
                 }
                 let dataSource = DataSourceValue.dataSource(with: data, utiType: dataUTI)
@@ -527,7 +527,7 @@ public class SignalAttachment: NSObject {
         for dataUTI in videoUTISet {
             if pasteboardUTISet.contains(dataUTI) {
                 guard let data = dataForFirstPasteboardItem(dataUTI: dataUTI) else {
-                    owsFail("\(logTag) Missing expected pasteboard data for UTI: \(dataUTI)")
+                    owsFail("Missing expected pasteboard data for UTI: \(dataUTI)")
                     return nil
                 }
                 let dataSource = DataSourceValue.dataSource(with: data, utiType: dataUTI)
@@ -537,7 +537,7 @@ public class SignalAttachment: NSObject {
         for dataUTI in audioUTISet {
             if pasteboardUTISet.contains(dataUTI) {
                 guard let data = dataForFirstPasteboardItem(dataUTI: dataUTI) else {
-                    owsFail("\(logTag) Missing expected pasteboard data for UTI: \(dataUTI)")
+                    owsFail("Missing expected pasteboard data for UTI: \(dataUTI)")
                     return nil
                 }
                 let dataSource = DataSourceValue.dataSource(with: data, utiType: dataUTI)
@@ -547,7 +547,7 @@ public class SignalAttachment: NSObject {
 
         let dataUTI = pasteboardUTISet[pasteboardUTISet.startIndex]
         guard let data = dataForFirstPasteboardItem(dataUTI: dataUTI) else {
-            owsFail("\(logTag) Missing expected pasteboard data for UTI: \(dataUTI)")
+            owsFail("Missing expected pasteboard data for UTI: \(dataUTI)")
             return nil
         }
         let dataSource = DataSourceValue.dataSource(with: data, utiType: dataUTI)
@@ -559,15 +559,15 @@ public class SignalAttachment: NSObject {
     private class func dataForFirstPasteboardItem(dataUTI: String) -> Data? {
         let itemSet = IndexSet(integer: 0)
         guard let datas = UIPasteboard.general.data(forPasteboardType: dataUTI, inItemSet: itemSet) else {
-            owsFail("\(logTag) Missing expected pasteboard data for UTI: \(dataUTI)")
+            owsFail("Missing expected pasteboard data for UTI: \(dataUTI)")
             return nil
         }
         guard datas.count > 0 else {
-            owsFail("\(logTag) Missing expected pasteboard data for UTI: \(dataUTI)")
+            owsFail("Missing expected pasteboard data for UTI: \(dataUTI)")
             return nil
         }
         guard let data = datas[0] as? Data else {
-            owsFail("\(logTag) Missing expected pasteboard data for UTI: \(dataUTI)")
+            owsFail("Missing expected pasteboard data for UTI: \(dataUTI)")
             return nil
         }
         return data
@@ -597,7 +597,7 @@ public class SignalAttachment: NSObject {
         }
 
         guard dataSource.dataLength() > 0 else {
-            owsFail("\(self.logTag) in \(#function) imageData was empty")
+            owsFail("imageData was empty")
             attachment.error = .invalidData
             return attachment
         }
@@ -609,7 +609,7 @@ public class SignalAttachment: NSObject {
             }
 
             // Never re-encode animated images (i.e. GIFs) as JPEGs.
-            Logger.verbose("\(logTag) Sending raw \(attachment.mimeType) to retain any animation")
+            Logger.verbose("Sending raw \(attachment.mimeType) to retain any animation")
             return attachment
         } else {
             guard let image = UIImage(data: dataSource.data()) else {
@@ -633,17 +633,17 @@ public class SignalAttachment: NSObject {
                 // However the problem comes in when you edit an HEIC image in Photos.app - the image is saved
                 // in the Photos.app as a JPEG, but retains the (now incongruous) HEIC extension in the filename.
                 assert(dataUTI == kUTTypeJPEG as String || !isValidOutput)
-                Logger.verbose("\(self.logTag) changing extension: \(sourceFileExtension) to match jpg uti type")
+                Logger.verbose("changing extension: \(sourceFileExtension) to match jpg uti type")
 
                 let baseFilename = sourceFilename.filenameWithoutExtension
                 dataSource.sourceFilename = baseFilename.appendingFileExtension("jpg")
             }
 
             if isValidOutput {
-                Logger.verbose("\(logTag) Rewriting attachment with metadata removed \(attachment.mimeType)")
+                Logger.verbose("Rewriting attachment with metadata removed \(attachment.mimeType)")
                 return removeImageMetadata(attachment: attachment)
             } else {
-                Logger.verbose("\(logTag) Compressing attachment as image/jpeg, \(dataSource.dataLength()) bytes")
+                Logger.verbose("Compressing attachment as image/jpeg, \(dataSource.dataLength()) bytes")
                 return compressImageAsJPEG(image: image, attachment: attachment, filename: dataSource.sourceFilename, imageQuality: imageQuality)
             }
         }
@@ -690,7 +690,7 @@ public class SignalAttachment: NSObject {
         let attachment = SignalAttachment(dataSource: dataSource, dataUTI: dataUTI)
         attachment.cachedImage = image
 
-        Logger.verbose("\(logTag) Writing \(attachment.mimeType) as image/jpeg")
+        Logger.verbose("Writing \(attachment.mimeType) as image/jpeg")
         return compressImageAsJPEG(image: image, attachment: attachment, filename: filename, imageQuality: imageQuality)
     }
 
@@ -736,7 +736,7 @@ public class SignalAttachment: NSObject {
                 dataSource.dataLength() <= kMaxFileSizeImage {
                 let recompressedAttachment = SignalAttachment(dataSource: dataSource, dataUTI: kUTTypeJPEG as String)
                 recompressedAttachment.cachedImage = dstImage
-                Logger.verbose("\(logTag) Converted \(attachment.mimeType) to image/jpeg, \(jpgImageData.count) bytes")
+                Logger.verbose("Converted \(attachment.mimeType) to image/jpeg, \(jpgImageData.count) bytes")
                 return recompressedAttachment
             }
 
@@ -766,7 +766,7 @@ public class SignalAttachment: NSObject {
     // Resizing using a CGContext seems to work fine.
     private class func imageScaled(_ uiImage: UIImage, toMaxSize maxSize: CGFloat) -> UIImage? {
         guard let cgImage = uiImage.cgImage else {
-            owsFail("\(logTag) UIImage missing cgImage.")
+            owsFail("UIImage missing cgImage.")
             return nil
         }
 
@@ -791,7 +791,7 @@ public class SignalAttachment: NSObject {
                                            bytesPerRow: 0,
                                            space: colorSpace,
                                            bitmapInfo: bitmapInfo.rawValue) else {
-                                            owsFail("\(logTag) could not create CGContext.")
+                                            owsFail("could not create CGContext.")
             return nil
         }
         context.interpolationQuality = .high
@@ -801,7 +801,7 @@ public class SignalAttachment: NSObject {
         context.draw(cgImage, in: drawRect)
 
         guard let newCGImage = context.makeImage() else {
-            owsFail("\(logTag) could not create new CGImage.")
+            owsFail("could not create new CGImage.")
             return nil
         }
         return UIImage(cgImage: newCGImage,
@@ -901,7 +901,7 @@ public class SignalAttachment: NSObject {
             return strippedAttachment
 
         } else {
-            Logger.verbose("\(logTag) CGImageDestinationFinalize failed")
+            Logger.verbose("CGImageDestinationFinalize failed")
             attachment.error = .couldNotRemoveMetadata
             return attachment
         }
@@ -936,7 +936,7 @@ public class SignalAttachment: NSObject {
         OWSFileSystem.ensureDirectoryExists(baseDir.path)
         let toUrl = baseDir.appendingPathComponent(fromUrl.lastPathComponent)
 
-        Logger.debug("\(self.logTag) moving \(fromUrl) -> \(toUrl)")
+        Logger.debug("moving \(fromUrl) -> \(toUrl)")
         try FileManager.default.copyItem(at: fromUrl, to: toUrl)
 
         return toUrl
@@ -949,7 +949,7 @@ public class SignalAttachment: NSObject {
     }
 
     public class func compressVideoAsMp4(dataSource: DataSource, dataUTI: String) -> (Promise<SignalAttachment>, AVAssetExportSession?) {
-        Logger.debug("\(self.logTag) in \(#function)")
+        Logger.debug("")
 
         guard let url = dataSource.dataUrl() else {
             let attachment = SignalAttachment(dataSource: DataSourceValue.emptyDataSource(), dataUTI: dataUTI)
@@ -974,9 +974,9 @@ public class SignalAttachment: NSObject {
 
         let (promise, fulfill, _) = Promise<SignalAttachment>.pending()
 
-        Logger.debug("\(self.logTag) starting video export")
+        Logger.debug("starting video export")
         exportSession.exportAsynchronously {
-            Logger.debug("\(self.logTag) Completed video export")
+            Logger.debug("Completed video export")
             let baseFilename = dataSource.sourceFilename
             let mp4Filename = baseFilename?.filenameWithoutExtension.appendingFileExtension("mp4")
 
@@ -1108,7 +1108,7 @@ public class SignalAttachment: NSObject {
     @objc
     public class func attachment(dataSource: DataSource?, dataUTI: String) -> SignalAttachment {
         if inputImageUTISet.contains(dataUTI) {
-            owsFail("\(logTag) must specify image quality type")
+            owsFail("must specify image quality type")
         }
         return attachment(dataSource: dataSource, dataUTI: dataUTI, imageQuality: .original)
     }
@@ -1162,7 +1162,7 @@ public class SignalAttachment: NSObject {
         }
 
         guard dataSource.dataLength() > 0 else {
-            owsFail("\(logTag) Empty attachment")
+            owsFail("Empty attachment")
             assert(dataSource.dataLength() > 0)
             attachment.error = .invalidData
             return attachment

--- a/SignalMessaging/attachments/SignalAttachment.swift
+++ b/SignalMessaging/attachments/SignalAttachment.swift
@@ -160,7 +160,7 @@ public class SignalAttachment: NSObject {
             AssertIsOnMainThread()
 
             assert(oldValue == nil)
-            Logger.verbose("Attachment has error: \(String(describing: self.error))")
+            Logger.verbose("Attachment has error: \(String(describing: error))")
         }
     }
 

--- a/SignalMessaging/categories/String+OWS.swift
+++ b/SignalMessaging/categories/String+OWS.swift
@@ -17,7 +17,7 @@ public extension String {
 
         while (lowerBoundCharCount < upperBoundCharCount) {
             guard let upperBoundData = self.prefix(upperBoundCharCount).data(using: .utf8) else {
-                owsFail("in \(#function) upperBoundData was unexpectedly nil")
+                owsFail("upperBoundData was unexpectedly nil")
                 return nil
             }
 
@@ -35,7 +35,7 @@ public extension String {
             let midpointString = self.prefix(midpointCharCount)
 
             guard let midpointData = midpointString.data(using: .utf8) else {
-                owsFail("in \(#function) midpointData was unexpectedly nil")
+                owsFail("midpointData was unexpectedly nil")
                 return nil
             }
             let midpointByteCount = midpointData.count

--- a/SignalMessaging/categories/UIDevice+featureSupport.swift
+++ b/SignalMessaging/categories/UIDevice+featureSupport.swift
@@ -29,7 +29,7 @@ public extension UIDevice {
             return true
         default:
             // Verify all our IOS_DEVICE_CONSTANT tags make sense when adding a new device size.
-            owsFail("\(logTag) in \(#function) unknown device format")
+            owsFail("unknown device format")
             return false
         }
     }

--- a/SignalMessaging/environment/NoopCallMessageHandler.swift
+++ b/SignalMessaging/environment/NoopCallMessageHandler.swift
@@ -8,22 +8,22 @@ import SignalServiceKit
 public class NoopCallMessageHandler: NSObject, OWSCallMessageHandler {
 
     public func receivedOffer(_ offer: SSKProtoCallMessageOffer, from callerId: String) {
-        owsFail("\(self.logTag) in \(#function).")
+        owsFail("")
     }
 
     public func receivedAnswer(_ answer: SSKProtoCallMessageAnswer, from callerId: String) {
-        owsFail("\(self.logTag) in \(#function).")
+        owsFail("")
     }
 
     public func receivedIceUpdate(_ iceUpdate: SSKProtoCallMessageIceUpdate, from callerId: String) {
-        owsFail("\(self.logTag) in \(#function).")
+        owsFail("")
     }
 
     public func receivedHangup(_ hangup: SSKProtoCallMessageHangup, from callerId: String) {
-        owsFail("\(self.logTag) in \(#function).")
+        owsFail("")
     }
 
     public func receivedBusy(_ busy: SSKProtoCallMessageBusy, from callerId: String) {
-        owsFail("\(self.logTag) in \(#function).")
+        owsFail("")
     }
 }

--- a/SignalMessaging/environment/NoopNotificationsManager.swift
+++ b/SignalMessaging/environment/NoopNotificationsManager.swift
@@ -8,14 +8,14 @@ import SignalServiceKit
 public class NoopNotificationsManager: NSObject, NotificationsProtocol {
 
     public func notifyUser(for incomingMessage: TSIncomingMessage, in thread: TSThread, contactsManager: ContactsManagerProtocol, transaction: YapDatabaseReadTransaction) {
-        owsFail("\(self.logTag) in \(#function).")
+        owsFail("")
     }
 
     public func notifyUser(for error: TSErrorMessage, thread: TSThread, transaction: YapDatabaseReadWriteTransaction) {
-        Logger.warn("\(self.logTag) in \(#function), skipping notification for: \(error.description)")
+        Logger.warn("skipping notification for: \(error.description)")
     }
 
     public func notifyUser(forThreadlessErrorMessage error: TSErrorMessage, transaction: YapDatabaseReadWriteTransaction) {
-        Logger.warn("\(self.logTag) in \(#function), skipping notification for: \(error.description)")
+        Logger.warn("skipping notification for: \(error.description)")
     }
 }

--- a/SignalMessaging/environment/OWSAudioSession.swift
+++ b/SignalMessaging/environment/OWSAudioSession.swift
@@ -37,7 +37,7 @@ public class OWSAudioSession: NSObject {
     // appropriate for foreground sound effects.
     @objc
     public func startAmbientAudioActivity(_ audioActivity: AudioActivity) {
-        Logger.debug("\(logTag) in \(#function)")
+        Logger.debug("")
 
         objc_sync_enter(self)
         defer { objc_sync_exit(self) }
@@ -45,21 +45,21 @@ public class OWSAudioSession: NSObject {
         startAudioActivity(audioActivity)
         guard currentActivities.count == 1 else {
             // We don't want to clobber the audio capabilities configured by (e.g.) media playback or an in-progress call
-            Logger.info("\(logTag) in \(#function) not touching audio session since another currentActivity exists.")
+            Logger.info("not touching audio session since another currentActivity exists.")
             return
         }
 
         do {
             try avAudioSession.setCategory(AVAudioSessionCategoryAmbient)
         } catch {
-            owsFail("\(logTag) in \(#function) failed with error: \(error)")
+            owsFail("failed with error: \(error)")
         }
     }
 
     // Ignores hardware mute switch, plays through external speaker
     @objc
     public func startPlaybackAudioActivity(_ audioActivity: AudioActivity) {
-        Logger.debug("\(logTag) in \(#function)")
+        Logger.debug("")
 
         objc_sync_enter(self)
         defer { objc_sync_exit(self) }
@@ -69,13 +69,13 @@ public class OWSAudioSession: NSObject {
         do {
             try avAudioSession.setCategory(AVAudioSessionCategoryPlayback)
         } catch {
-            owsFail("\(logTag) in \(#function) failed with error: \(error)")
+            owsFail("failed with error: \(error)")
         }
     }
 
     @objc
     public func startRecordingAudioActivity(_ audioActivity: AudioActivity) -> Bool {
-        Logger.debug("\(logTag) in \(#function)")
+        Logger.debug("")
 
         objc_sync_enter(self)
         defer { objc_sync_exit(self) }
@@ -88,14 +88,14 @@ public class OWSAudioSession: NSObject {
             try avAudioSession.setCategory(AVAudioSessionCategoryRecord)
             return true
         } catch {
-            owsFail("\(logTag) in \(#function) failed with error: \(error)")
+            owsFail("failed with error: \(error)")
             return false
         }
     }
 
     @objc
     public func startAudioActivity(_ audioActivity: AudioActivity) {
-        Logger.debug("\(logTag) in \(#function) with \(audioActivity)")
+        Logger.debug("with \(audioActivity)")
 
         objc_sync_enter(self)
         defer { objc_sync_exit(self) }
@@ -105,7 +105,7 @@ public class OWSAudioSession: NSObject {
 
     @objc
     public func endAudioActivity(_ audioActivity: AudioActivity) {
-        Logger.debug("\(logTag) in \(#function) with audioActivity: \(audioActivity)")
+        Logger.debug("with audioActivity: \(audioActivity)")
 
         objc_sync_enter(self)
         defer { objc_sync_exit(self) }
@@ -133,7 +133,7 @@ public class OWSAudioSession: NSObject {
                 // Normally we should be explicitly stopping an audio activity, but this allows
                 // for recovery if the owner of the AudioAcivity was GC'd without ending it's
                 // audio activity
-                Logger.warn("\(logTag) an old activity has been gc'd")
+                Logger.warn("an old activity has been gc'd")
                 return nil
             }
 
@@ -142,7 +142,7 @@ public class OWSAudioSession: NSObject {
         }
 
         guard currentActivities.isEmpty else {
-            Logger.debug("\(logTag) not deactivating due to currentActivities: \(currentActivities)")
+            Logger.debug("not deactivating due to currentActivities: \(currentActivities)")
             return
         }
 
@@ -151,7 +151,7 @@ public class OWSAudioSession: NSObject {
             // By notifying when we deactivate, the other app can resume playback.
             try avAudioSession.setActive(false, with: [.notifyOthersOnDeactivation])
         } catch {
-            owsFail("\(logTag) in \(#function) failed with error: \(error)")
+            owsFail("failed with error: \(error)")
         }
     }
 
@@ -178,7 +178,7 @@ public class OWSAudioSession: NSObject {
      */
     @objc
     public func configureRTCAudio() {
-        Logger.info("\(logTag) in \(#function)")
+        Logger.info("")
         rtcAudioSession.useManualAudio = true
     }
 

--- a/SignalMessaging/environment/OWSAudioSession.swift
+++ b/SignalMessaging/environment/OWSAudioSession.swift
@@ -142,7 +142,7 @@ public class OWSAudioSession: NSObject {
         }
 
         guard currentActivities.isEmpty else {
-            Logger.debug("not deactivating due to currentActivities: \(currentActivities)")
+            Logger.debug("not deactivating due to currentActivities: \(self.currentActivities)")
             return
         }
 

--- a/SignalMessaging/environment/OWSAudioSession.swift
+++ b/SignalMessaging/environment/OWSAudioSession.swift
@@ -142,7 +142,7 @@ public class OWSAudioSession: NSObject {
         }
 
         guard currentActivities.isEmpty else {
-            Logger.debug("not deactivating due to currentActivities: \(self.currentActivities)")
+            Logger.debug("not deactivating due to currentActivities: \(currentActivities)")
             return
         }
 

--- a/SignalMessaging/environment/migrations/OWS106EnsureProfileComplete.swift
+++ b/SignalMessaging/environment/migrations/OWS106EnsureProfileComplete.swift
@@ -23,10 +23,10 @@ public class OWS106EnsureProfileComplete: OWSDatabaseMigration {
         let job = CompleteRegistrationFixerJob(completionHandler: { (didSucceed) in
 
             if (didSucceed) {
-                Logger.info("\(self.logTag) Completed. Saving.")
+                Logger.info("Completed. Saving.")
                 self.save()
             } else {
-                Logger.error("\(self.logTag) Failed.")
+                Logger.error("Failed.")
             }
 
             completion()
@@ -60,7 +60,7 @@ public class OWS106EnsureProfileComplete: OWSDatabaseMigration {
             }
 
             self.ensureProfileComplete().then { _ -> Void in
-                Logger.info("\(self.logTag) complete. Canceling timer and saving.")
+                Logger.info("complete. Canceling timer and saving.")
                 self.completionHandler(true)
             }.catch { error in
                 let nserror = error as NSError
@@ -69,13 +69,13 @@ public class OWS106EnsureProfileComplete: OWSDatabaseMigration {
                     // In particular, 401 (invalid auth) is unrecoverable.
                     let isUnrecoverableError = nserror.code == 401
                     if isUnrecoverableError {
-                        Logger.error("\(self.logTag) failed due to unrecoverable error: \(error). Aborting.")
+                        Logger.error("failed due to unrecoverable error: \(error). Aborting.")
                         self.completionHandler(true)
                         return
                     }
                 }
 
-                Logger.error("\(self.logTag) failed with \(error).")
+                Logger.error("failed with \(error).")
                 self.completionHandler(false)
             }.retainUntilComplete()
         }
@@ -89,25 +89,25 @@ public class OWS106EnsureProfileComplete: OWSDatabaseMigration {
             let (promise, fulfill, reject) = Promise<Void>.pending()
 
             guard let networkManager = Environment.current().networkManager else {
-                return Promise(error: OWSErrorMakeAssertionError("\(logTag) network manager was unexpectedly not set"))
+                return Promise(error: OWSErrorMakeAssertionError("network manager was unexpectedly not set"))
             }
 
             ProfileFetcherJob(networkManager: networkManager).getProfile(recipientId: localRecipientId).then { _ -> Void in
-                Logger.info("\(self.logTag) verified recipient profile is in good shape: \(localRecipientId)")
+                Logger.info("verified recipient profile is in good shape: \(localRecipientId)")
 
                 fulfill(())
             }.catch { error in
                 switch error {
                 case SignalServiceProfile.ValidationError.invalidIdentityKey(let description):
-                    Logger.warn("\(self.logTag) detected incomplete profile for \(localRecipientId) error: \(description)")
+                    Logger.warn("detected incomplete profile for \(localRecipientId) error: \(description)")
                     // This is the error condition we're looking for. Update prekeys to properly set the identity key, completing registration.
                     TSPreKeyManager.registerPreKeys(with: .signedAndOneTime,
                                                     success: {
-                                                        Logger.info("\(self.logTag) successfully uploaded pre-keys. Profile should be fixed.")
+                                                        Logger.info("successfully uploaded pre-keys. Profile should be fixed.")
                                                         fulfill(())
                     },
                                                     failure: { _ in
-                                                        reject(OWSErrorWithCodeDescription(.signalServiceFailure, "\(self.logTag) Unknown error in \(#function)"))
+                                                        reject(OWSErrorWithCodeDescription(.signalServiceFailure, "\(self.logTag) Unknown error"))
                     })
                 default:
                     reject(error)

--- a/SignalMessaging/profiles/ProfileFetcherJob.swift
+++ b/SignalMessaging/profiles/ProfileFetcherJob.swift
@@ -77,14 +77,14 @@ public class ProfileFetcherJob: NSObject {
         }.catch { error in
             switch error {
             case ProfileFetcherJobError.throttled(let lastTimeInterval):
-                Logger.info("\(self.logTag) skipping updateProfile: \(recipientId), lastTimeInterval: \(lastTimeInterval)")
+                Logger.info("skipping updateProfile: \(recipientId), lastTimeInterval: \(lastTimeInterval)")
             case let error as SignalServiceProfile.ValidationError:
-                Logger.warn("\(self.logTag) skipping updateProfile retry. Invalid profile for: \(recipientId) error: \(error)")
+                Logger.warn("skipping updateProfile retry. Invalid profile for: \(recipientId) error: \(error)")
             default:
                 if remainingRetries > 0 {
                     self.updateProfile(recipientId: recipientId, remainingRetries: remainingRetries - 1)
                 } else {
-                    Logger.error("\(self.logTag) in \(#function) failed to get profile with error: \(error)")
+                    Logger.error("failed to get profile with error: \(error)")
                 }
             }
         }.retainUntilComplete()
@@ -107,7 +107,7 @@ public class ProfileFetcherJob: NSObject {
         }
         ProfileFetcherJob.fetchDateMap[recipientId] = Date()
 
-        Logger.error("\(self.logTag) getProfile: \(recipientId)")
+        Logger.error("getProfile: \(recipientId)")
 
         let request = OWSRequestFactory.getProfileRequest(withRecipientId: recipientId)
 
@@ -160,7 +160,7 @@ public class ProfileFetcherJob: NSObject {
     private func verifyIdentityUpToDateAsync(recipientId: String, latestIdentityKey: Data) {
         primaryStorage.newDatabaseConnection().asyncReadWrite { (transaction) in
             if OWSIdentityManager.shared().saveRemoteIdentity(latestIdentityKey, recipientId: recipientId, protocolContext: transaction) {
-                Logger.info("\(self.logTag) updated identity key with fetched profile for recipient: \(recipientId)")
+                Logger.info("updated identity key with fetched profile for recipient: \(recipientId)")
                 self.primaryStorage.archiveAllSessions(forContact: recipientId, protocolContext: transaction)
             } else {
                 // no change in identity.

--- a/SignalMessaging/utils/ConversationSearcher.swift
+++ b/SignalMessaging/utils/ConversationSearcher.swift
@@ -23,7 +23,7 @@ public class ConversationSearchResult: Comparable {
         self.snippet = snippet
     }
 
-    // Mark: Comparable
+    // MARK: Comparable
 
     public static func < (lhs: ConversationSearchResult, rhs: ConversationSearchResult) -> Bool {
         return lhs.sortKey < rhs.sortKey
@@ -50,7 +50,7 @@ public class ContactSearchResult: Comparable {
         self.contactsManager = contactsManager
     }
 
-    // Mark: Comparable
+    // MARK: Comparable
 
     public static func < (lhs: ContactSearchResult, rhs: ContactSearchResult) -> Bool {
         return lhs.contactsManager.compare(signalAccount: lhs.signalAccount, with: rhs.signalAccount) == .orderedAscending
@@ -136,7 +136,7 @@ public class ConversationSearcher: NSObject {
                 let searchResult = ContactSearchResult(signalAccount: signalAccount, contactsManager: contactsManager)
                 contacts.append(searchResult)
             } else {
-                owsFail("\(self.logTag) in \(#function) unhandled item: \(match)")
+                owsFail("unhandled item: \(match)")
             }
         }
 

--- a/SignalMessaging/utils/OWSScreenLock.swift
+++ b/SignalMessaging/utils/OWSScreenLock.swift
@@ -33,7 +33,7 @@ import LocalAuthentication
     private let OWSScreenLock_Key_IsScreenLockEnabled = "OWSScreenLock_Key_IsScreenLockEnabled"
     private let OWSScreenLock_Key_ScreenLockTimeoutSeconds = "OWSScreenLock_Key_ScreenLockTimeoutSeconds"
 
-    // MARK - Singleton class
+    // MARK: - Singleton class
 
     @objc(sharedManager)
     public static let shared = OWSScreenLock()
@@ -53,7 +53,7 @@ import LocalAuthentication
         AssertIsOnMainThread()
 
         if !OWSStorage.isStorageReady() {
-            owsFail("\(logTag) accessed screen lock state before storage is ready.")
+            owsFail("accessed screen lock state before storage is ready.")
             return false
         }
 
@@ -74,7 +74,7 @@ import LocalAuthentication
         AssertIsOnMainThread()
 
         if !OWSStorage.isStorageReady() {
-            owsFail("\(logTag) accessed screen lock state before storage is ready.")
+            owsFail("accessed screen lock state before storage is ready.")
             return 0
         }
 
@@ -113,16 +113,16 @@ import LocalAuthentication
 
                                         switch outcome {
                                         case .failure(let error):
-                                            Logger.error("\(self.logTag) local authentication failed with error: \(error)")
+                                            Logger.error("local authentication failed with error: \(error)")
                                             failure(self.authenticationError(errorDescription: error))
                                         case .unexpectedFailure(let error):
-                                            Logger.error("\(self.logTag) local authentication failed with unexpected error: \(error)")
+                                            Logger.error("local authentication failed with unexpected error: \(error)")
                                             unexpectedFailure(self.authenticationError(errorDescription: error))
                                         case .success:
-                                            Logger.verbose("\(self.logTag) local authentication succeeded.")
+                                            Logger.verbose("local authentication succeeded.")
                                             success()
                                         case .cancel:
-                                            Logger.verbose("\(self.logTag) local authentication cancelled.")
+                                            Logger.verbose("local authentication cancelled.")
                                             cancel()
                                         }
         })
@@ -155,13 +155,13 @@ import LocalAuthentication
         var authError: NSError?
         let canEvaluatePolicy = context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &authError)
         if !canEvaluatePolicy || authError != nil {
-            Logger.error("\(logTag) could not determine if local authentication is supported: \(String(describing: authError))")
+            Logger.error("could not determine if local authentication is supported: \(String(describing: authError))")
 
             let outcome = self.outcomeForLAError(errorParam: authError,
                                                  defaultErrorDescription: defaultErrorDescription)
             switch outcome {
             case .success:
-                owsFail("\(self.logTag) local authentication unexpected success")
+                owsFail("local authentication unexpected success")
                 completion(.failure(error:defaultErrorDescription))
             case .cancel, .failure, .unexpectedFailure:
                 completion(outcome)
@@ -172,14 +172,14 @@ import LocalAuthentication
         context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: localizedReason) { success, evaluateError in
 
             if success {
-                Logger.info("\(self.logTag) local authentication succeeded.")
+                Logger.info("local authentication succeeded.")
                 completion(.success)
             } else {
                 let outcome = self.outcomeForLAError(errorParam: evaluateError,
                                                      defaultErrorDescription: defaultErrorDescription)
                 switch outcome {
                 case .success:
-                    owsFail("\(self.logTag) local authentication unexpected success")
+                    owsFail("local authentication unexpected success")
                     completion(.failure(error:defaultErrorDescription))
                 case .cancel, .failure, .unexpectedFailure:
                     completion(outcome)
@@ -199,15 +199,15 @@ import LocalAuthentication
             if #available(iOS 11.0, *) {
                 switch laError.code {
                 case .biometryNotAvailable:
-                    Logger.error("\(self.logTag) local authentication error: biometryNotAvailable.")
+                    Logger.error("local authentication error: biometryNotAvailable.")
                     return .failure(error: NSLocalizedString("SCREEN_LOCK_ERROR_LOCAL_AUTHENTICATION_NOT_AVAILABLE",
                                                              comment: "Indicates that Touch ID/Face ID/Phone Passcode are not available on this device."))
                 case .biometryNotEnrolled:
-                    Logger.error("\(self.logTag) local authentication error: biometryNotEnrolled.")
+                    Logger.error("local authentication error: biometryNotEnrolled.")
                     return .failure(error: NSLocalizedString("SCREEN_LOCK_ERROR_LOCAL_AUTHENTICATION_NOT_ENROLLED",
                                                              comment: "Indicates that Touch ID/Face ID/Phone Passcode is not configured on this device."))
                 case .biometryLockout:
-                    Logger.error("\(self.logTag) local authentication error: biometryLockout.")
+                    Logger.error("local authentication error: biometryLockout.")
                     return .failure(error: NSLocalizedString("SCREEN_LOCK_ERROR_LOCAL_AUTHENTICATION_LOCKOUT",
                                                              comment: "Indicates that Touch ID/Face ID/Phone Passcode is 'locked out' on this device due to authentication failures."))
                 default:
@@ -218,33 +218,33 @@ import LocalAuthentication
 
             switch laError.code {
             case .authenticationFailed:
-                Logger.error("\(self.logTag) local authentication error: authenticationFailed.")
+                Logger.error("local authentication error: authenticationFailed.")
                 return .failure(error: NSLocalizedString("SCREEN_LOCK_ERROR_LOCAL_AUTHENTICATION_FAILED",
                                                          comment: "Indicates that Touch ID/Face ID/Phone Passcode authentication failed."))
             case .userCancel, .userFallback, .systemCancel, .appCancel:
-                Logger.info("\(self.logTag) local authentication cancelled.")
+                Logger.info("local authentication cancelled.")
                 return .cancel
             case .passcodeNotSet:
-                Logger.error("\(self.logTag) local authentication error: passcodeNotSet.")
+                Logger.error("local authentication error: passcodeNotSet.")
                 return .failure(error: NSLocalizedString("SCREEN_LOCK_ERROR_LOCAL_AUTHENTICATION_PASSCODE_NOT_SET",
                                                          comment: "Indicates that Touch ID/Face ID/Phone Passcode passcode is not set."))
             case .touchIDNotAvailable:
-                Logger.error("\(self.logTag) local authentication error: touchIDNotAvailable.")
+                Logger.error("local authentication error: touchIDNotAvailable.")
                 return .failure(error: NSLocalizedString("SCREEN_LOCK_ERROR_LOCAL_AUTHENTICATION_NOT_AVAILABLE",
                                                          comment: "Indicates that Touch ID/Face ID/Phone Passcode are not available on this device."))
             case .touchIDNotEnrolled:
-                Logger.error("\(self.logTag) local authentication error: touchIDNotEnrolled.")
+                Logger.error("local authentication error: touchIDNotEnrolled.")
                 return .failure(error: NSLocalizedString("SCREEN_LOCK_ERROR_LOCAL_AUTHENTICATION_NOT_ENROLLED",
                                                          comment: "Indicates that Touch ID/Face ID/Phone Passcode is not configured on this device."))
             case .touchIDLockout:
-                Logger.error("\(self.logTag) local authentication error: touchIDLockout.")
+                Logger.error("local authentication error: touchIDLockout.")
                 return .failure(error: NSLocalizedString("SCREEN_LOCK_ERROR_LOCAL_AUTHENTICATION_LOCKOUT",
                                                          comment: "Indicates that Touch ID/Face ID/Phone Passcode is 'locked out' on this device due to authentication failures."))
             case .invalidContext:
-                owsFail("\(self.logTag) context not valid.")
+                owsFail("context not valid.")
                 return .unexpectedFailure(error:defaultErrorDescription)
             case .notInteractive:
-                owsFail("\(self.logTag) context not interactive.")
+                owsFail("context not interactive.")
                 return .unexpectedFailure(error:defaultErrorDescription)
             }
         }

--- a/SignalMessaging/utils/SwiftSingletons.swift
+++ b/SignalMessaging/utils/SwiftSingletons.swift
@@ -1,5 +1,5 @@
 //
-//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//  Copyright (c) 2018 Open Whisper Systems. All rights reserved.
 //
 
 import Foundation
@@ -20,12 +20,12 @@ public class SwiftSingletons: NSObject {
         guard _isDebugAssertConfiguration() else {
             return
         }
-        let singletonClassName = String(describing:type(of:singleton))
+        let singletonClassName = String(describing: type(of: singleton))
         guard !classSet.contains(singletonClassName) else {
-            owsFail("\(self.logTag) in \(#function) Duplicate singleton: \(singletonClassName).")
+            owsFail("Duplicate singleton: \(singletonClassName).")
             return
         }
-        Logger.verbose("\(self.logTag) in \(#function) Registering singleton: \(singletonClassName).")
+        Logger.verbose("Registering singleton: \(singletonClassName).")
         classSet.insert(singletonClassName)
     }
 

--- a/SignalServiceKit/src/Contacts/OWSContactDiscoveryOperation.swift
+++ b/SignalServiceKit/src/Contacts/OWSContactDiscoveryOperation.swift
@@ -26,17 +26,17 @@ class LegacyContactDiscoveryBatchOperation: OWSOperation {
 
         super.init()
 
-        Logger.debug("\(logTag) in \(#function) with recipientIdsToLookup: \(recipientIdsToLookup.count)")
+        Logger.debug("with recipientIdsToLookup: \(recipientIdsToLookup.count)")
     }
 
     // MARK: OWSOperation Overrides
 
     // Called every retry, this is where the bulk of the operation's work should go.
     override func run() {
-        Logger.debug("\(logTag) in \(#function)")
+        Logger.debug("")
 
         guard !isCancelled else {
-            Logger.info("\(logTag) in \(#function) no work to do, since we were canceled")
+            Logger.info("no work to do, since we were canceled")
             self.reportCancelled()
             return
         }
@@ -45,7 +45,7 @@ class LegacyContactDiscoveryBatchOperation: OWSOperation {
 
         for recipientId in recipientIdsToLookup {
             guard let hash = Cryptography.truncatedSHA1Base64EncodedWithoutPadding(recipientId) else {
-                owsFail("\(logTag) could not hash recipient id: \(recipientId)")
+                owsFail("could not hash recipient id: \(recipientId)")
                 continue
             }
             assert(phoneNumbersByHashes[hash] == nil)
@@ -119,17 +119,17 @@ class LegacyContactDiscoveryBatchOperation: OWSOperation {
 
         for contactDict in contactDicts {
             guard let hash = contactDict["token"] as? String, hash.count > 0 else {
-                owsFail("\(self.logTag) in \(#function) hash was unexpectedly nil")
+                owsFail("hash was unexpectedly nil")
                 continue
             }
 
             guard let recipientId = phoneNumbersByHashes[hash], recipientId.count > 0 else {
-                owsFail("\(self.logTag) in \(#function) recipientId was unexpectedly nil")
+                owsFail("recipientId was unexpectedly nil")
                 continue
             }
 
             guard recipientIdsToLookup.contains(recipientId) else {
-                owsFail("\(self.logTag) in \(#function) unexpected recipientId")
+                owsFail("unexpected recipientId")
                 continue
             }
 
@@ -172,7 +172,7 @@ class CDSOperation: OWSOperation {
 
         super.init()
 
-        Logger.debug("\(logTag) in \(#function) with recipientIdsToLookup: \(recipientIdsToLookup.count)")
+        Logger.debug("with recipientIdsToLookup: \(recipientIdsToLookup.count)")
         for batchIds in recipientIdsToLookup.chunked(by: batchSize) {
             let batchOperation = CDSBatchOperation(recipientIdsToLookup: batchIds)
             self.addDependency(batchOperation)
@@ -183,11 +183,11 @@ class CDSOperation: OWSOperation {
 
     // Called every retry, this is where the bulk of the operation's work should go.
     override func run() {
-        Logger.debug("\(logTag) in \(#function)")
+        Logger.debug("")
 
         for dependency in self.dependencies {
             guard let batchOperation = dependency as? CDSBatchOperation else {
-                owsFail("\(self.logTag) in \(#function) unexpected dependency: \(dependency)")
+                owsFail("unexpected dependency: \(dependency)")
                 continue
             }
 
@@ -221,17 +221,17 @@ class CDSBatchOperation: OWSOperation {
 
         super.init()
 
-        Logger.debug("\(logTag) in \(#function) with recipientIdsToLookup: \(recipientIdsToLookup.count)")
+        Logger.debug("with recipientIdsToLookup: \(recipientIdsToLookup.count)")
     }
 
     // MARK: OWSOperationOverrides
 
     // Called every retry, this is where the bulk of the operation's work should go.
     override public func run() {
-        Logger.debug("\(logTag) in \(#function)")
+        Logger.debug("")
 
         guard !isCancelled else {
-            Logger.info("\(logTag) in \(#function) no work to do, since we were canceled")
+            Logger.info("no work to do, since we were canceled")
             self.reportCancelled()
             return
         }
@@ -251,7 +251,7 @@ class CDSBatchOperation: OWSOperation {
     private func makeContactDiscoveryRequest(remoteAttestation: RemoteAttestation) {
 
         guard !isCancelled else {
-            Logger.info("\(logTag) in \(#function) no work to do, since we were canceled")
+            Logger.info("no work to do, since we were canceled")
             self.reportCancelled()
             return
         }
@@ -434,7 +434,7 @@ class CDSFeedbackOperation: OWSOperation {
 
         super.init()
 
-        Logger.debug("\(logTag) in \(#function)")
+        Logger.debug("")
     }
 
     // MARK: OWSOperation Overrides
@@ -450,13 +450,13 @@ class CDSFeedbackOperation: OWSOperation {
     override func run() {
 
         guard !isCancelled else {
-            Logger.info("\(logTag) in \(#function) no work to do, since we were canceled")
+            Logger.info("no work to do, since we were canceled")
             self.reportCancelled()
             return
         }
 
         guard let cdsOperation = dependencies.first as? CDSOperation else {
-            let error = OWSErrorMakeAssertionError("\(self.logTag) in \(#function) cdsOperation was unexpectedly nil")
+            let error = OWSErrorMakeAssertionError("cdsOperation was unexpectedly nil")
             self.reportError(error)
             return
         }

--- a/SignalServiceKit/src/Network/OutageDetection.swift
+++ b/SignalServiceKit/src/Network/OutageDetection.swift
@@ -19,7 +19,7 @@ public class OutageDetection: NSObject {
             AssertIsOnMainThread()
 
             if hasOutage != oldValue {
-                Logger.info("hasOutage: \(self.hasOutage).")
+                Logger.info("hasOutage: \(hasOutage).")
 
                 NotificationCenter.default.postNotificationNameAsync(OutageDetection.outageStateDidChange, object: nil)
             }

--- a/SignalServiceKit/src/Network/OutageDetection.swift
+++ b/SignalServiceKit/src/Network/OutageDetection.swift
@@ -19,7 +19,7 @@ public class OutageDetection: NSObject {
             AssertIsOnMainThread()
 
             if hasOutage != oldValue {
-                Logger.info("\(self.logTag) hasOutage: \(hasOutage).")
+                Logger.info("hasOutage: \(hasOutage).")
 
                 NotificationCenter.default.postNotificationNameAsync(OutageDetection.outageStateDidChange, object: nil)
             }
@@ -40,11 +40,11 @@ public class OutageDetection: NSObject {
         CFHostStartInfoResolution(host, .addresses, nil)
         var success: DarwinBoolean = false
         guard let addresses = CFHostGetAddressing(host, &success)?.takeUnretainedValue() as NSArray? else {
-            Logger.error("\(logTag) CFHostGetAddressing failed: no addresses.")
+            Logger.error("CFHostGetAddressing failed: no addresses.")
             return false
         }
         guard success.boolValue else {
-            Logger.error("\(logTag) CFHostGetAddressing failed.")
+            Logger.error("CFHostGetAddressing failed.")
             return false
         }
         var isOutageDetected = false
@@ -60,7 +60,7 @@ public class OutageDetection: NSObject {
                 } else if addressString == kOutageAddress {
                     isOutageDetected = true
                 } else {
-                    owsFail("\(logTag) unexpected address: \(addressString)")
+                    owsFail("unexpected address: \(addressString)")
                 }
             }
         }
@@ -68,7 +68,7 @@ public class OutageDetection: NSObject {
     }
 
     private func checkForOutageAsync() {
-        Logger.info("\(self.logTag) \(#function).")
+        Logger.info("")
 
         DispatchQueue.global().async {
             let isOutageDetected = self.checkForOutageSync()

--- a/SignalServiceKit/src/Network/OutageDetection.swift
+++ b/SignalServiceKit/src/Network/OutageDetection.swift
@@ -19,7 +19,7 @@ public class OutageDetection: NSObject {
             AssertIsOnMainThread()
 
             if hasOutage != oldValue {
-                Logger.info("hasOutage: \(hasOutage).")
+                Logger.info("hasOutage: \(self.hasOutage).")
 
                 NotificationCenter.default.postNotificationNameAsync(OutageDetection.outageStateDidChange, object: nil)
             }

--- a/SignalServiceKit/src/Storage/FullTextSearchFinder.swift
+++ b/SignalServiceKit/src/Storage/FullTextSearchFinder.swift
@@ -81,13 +81,13 @@ public class FullTextSearchFinder: NSObject {
 
     public func enumerateObjects(searchText: String, transaction: YapDatabaseReadTransaction, block: @escaping (Any, String) -> Void) {
         guard let ext: YapDatabaseFullTextSearchTransaction = ext(transaction: transaction) else {
-            owsFail("\(logTag) ext was unexpectedly nil")
+            owsFail("ext was unexpectedly nil")
             return
         }
 
         let query = FullTextSearchFinder.query(searchText: searchText)
 
-        Logger.verbose("\(logTag) query: \(query)")
+        Logger.verbose("query: \(query)")
 
         let maxSearchResults = 500
         var searchResultCount = 0
@@ -178,12 +178,12 @@ public class FullTextSearchFinder: NSObject {
         let nationalNumber: String = { (recipientId: String) -> String in
 
             guard let phoneNumber = PhoneNumber(fromE164: recipientId) else {
-                owsFail("\(logTag) unexpected unparseable recipientId: \(recipientId)")
+                owsFail("unexpected unparseable recipientId: \(recipientId)")
                 return ""
             }
 
             guard let digitScalars = phoneNumber.nationalNumber?.unicodeScalars.filter({ CharacterSet.decimalDigits.contains($0) }) else {
-                owsFail("\(logTag) unexpected unparseable recipientId: \(recipientId)")
+                owsFail("unexpected unparseable recipientId: \(recipientId)")
                 return ""
             }
 
@@ -209,7 +209,7 @@ public class FullTextSearchFinder: NSObject {
         }
 
         guard let attachment = message.attachment(with: transaction) else {
-            owsFail("\(self.logTag) in \(#function) attachment was unexpectedly nil")
+            owsFail("attachment was unexpectedly nil")
             return nil
         }
 

--- a/SignalServiceKit/src/Util/Logger.swift
+++ b/SignalServiceKit/src/Util/Logger.swift
@@ -21,7 +21,7 @@ public func owsFormatLogMessage(_ logString: String,
  */
 open class Logger: NSObject {
 
-    open class func verbose(_ logString: @escaping @autoclosure () -> String,
+    open class func verbose(_ logString: @autoclosure () -> String,
                             file: String = #file,
                             function: String = #function,
                             line: Int = #line) {
@@ -31,7 +31,7 @@ open class Logger: NSObject {
         OWSLogger.verbose(owsFormatLogMessage(logString(), file: file, function: function, line: line))
     }
 
-    open class func debug(_ logString: @escaping @autoclosure () -> String,
+    open class func debug(_ logString: @autoclosure () -> String,
                           file: String = #file,
                           function: String = #function,
                           line: Int = #line) {
@@ -41,34 +41,34 @@ open class Logger: NSObject {
         OWSLogger.debug(owsFormatLogMessage(logString(), file: file, function: function, line: line))
     }
 
-    open class func info(_ logString: String,
+    open class func info(_ logString: @autoclosure () -> String,
                          file: String = #file,
                          function: String = #function,
                          line: Int = #line) {
         guard ShouldLogInfo() else {
             return
         }
-        OWSLogger.info(owsFormatLogMessage(logString, file: file, function: function, line: line))
+        OWSLogger.info(owsFormatLogMessage(logString(), file: file, function: function, line: line))
     }
 
-    open class func warn(_ logString: String,
+    open class func warn(_ logString: @autoclosure () -> String,
                          file: String = #file,
                          function: String = #function,
                          line: Int = #line) {
         guard ShouldLogWarning() else {
             return
         }
-        OWSLogger.warn(owsFormatLogMessage(logString, file: file, function: function, line: line))
+        OWSLogger.warn(owsFormatLogMessage(logString(), file: file, function: function, line: line))
     }
 
-    open class func error(_ logString: String,
+    open class func error(_ logString: @autoclosure () -> String,
                           file: String = #file,
                           function: String = #function,
                           line: Int = #line) {
         guard ShouldLogError() else {
             return
         }
-        OWSLogger.error(owsFormatLogMessage(logString, file: file, function: function, line: line))
+        OWSLogger.error(owsFormatLogMessage(logString(), file: file, function: function, line: line))
     }
 
     open class func flush() {

--- a/SignalServiceKit/src/Util/OWSLogger.h
+++ b/SignalServiceKit/src/Util/OWSLogger.h
@@ -4,18 +4,42 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef NSString * (^OWSLogBlock)(void);
+static inline BOOL ShouldLogVerbose()
+{
+    return ddLogLevel >= DDLogLevelVerbose;
+}
+
+static inline BOOL ShouldLogDebug()
+{
+    return ddLogLevel >= DDLogLevelDebug;
+}
+
+static inline BOOL ShouldLogInfo()
+{
+    return ddLogLevel >= DDLogLevelInfo;
+}
+
+static inline BOOL ShouldLogWarning()
+{
+    return ddLogLevel >= DDLogLevelWarning;
+}
+
+static inline BOOL ShouldLogError()
+{
+    return ddLogLevel >= DDLogLevelError;
+}
 
 /**
  * A minimal DDLog wrapper for swift.
  */
 @interface OWSLogger : NSObject
 
-+ (void)verbose:(OWSLogBlock)logBlock;
-+ (void)debug:(OWSLogBlock)logBlock;
-+ (void)info:(OWSLogBlock)logBlock;
-+ (void)warn:(OWSLogBlock)logBlock;
-+ (void)error:(OWSLogBlock)logBlock;
++ (void)verbose:(NSString *)logString;
++ (void)debug:(NSString *)logString;
++ (void)info:(NSString *)logString;
++ (void)warn:(NSString *)logString;
++ (void)error:(NSString *)logString;
+
 + (void)flush;
 
 @end

--- a/SignalServiceKit/src/Util/OWSLogger.h
+++ b/SignalServiceKit/src/Util/OWSLogger.h
@@ -4,16 +4,18 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef NSString * (^OWSLogBlock)(void);
+
 /**
  * A minimal DDLog wrapper for swift.
  */
 @interface OWSLogger : NSObject
 
-+ (void)verbose:(NSString *)logString;
-+ (void)debug:(NSString *)logString;
-+ (void)info:(NSString *)logString;
-+ (void)warn:(NSString *)logString;
-+ (void)error:(NSString *)logString;
++ (void)verbose:(OWSLogBlock)logBlock;
++ (void)debug:(OWSLogBlock)logBlock;
++ (void)info:(OWSLogBlock)logBlock;
++ (void)warn:(OWSLogBlock)logBlock;
++ (void)error:(OWSLogBlock)logBlock;
 + (void)flush;
 
 @end

--- a/SignalServiceKit/src/Util/OWSLogger.h
+++ b/SignalServiceKit/src/Util/OWSLogger.h
@@ -7,7 +7,6 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * A minimal DDLog wrapper for swift.
  */
-NS_SWIFT_NAME(Logger)
 @interface OWSLogger : NSObject
 
 + (void)verbose:(NSString *)logString;

--- a/SignalServiceKit/src/Util/OWSLogger.m
+++ b/SignalServiceKit/src/Util/OWSLogger.m
@@ -8,27 +8,27 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation OWSLogger
 
-+ (void)verbose:(NSString *)logString;
++ (void)verbose:(NSString *)logString
 {
     DDLogVerbose(@"%@", logString);
 }
 
-+ (void)debug:(NSString *)logString;
++ (void)debug:(NSString *)logString
 {
     DDLogDebug(@"%@", logString);
 }
 
-+ (void)info:(NSString *)logString;
++ (void)info:(NSString *)logString
 {
     DDLogInfo(@"%@", logString);
 }
 
-+ (void)warn:(NSString *)logString;
++ (void)warn:(NSString *)logString
 {
     DDLogWarn(@"%@", logString);
 }
 
-+ (void)error:(NSString *)logString;
++ (void)error:(NSString *)logString
 {
     DDLogError(@"%@", logString);
 }

--- a/SignalServiceKit/src/Util/OWSLogger.m
+++ b/SignalServiceKit/src/Util/OWSLogger.m
@@ -8,29 +8,29 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation OWSLogger
 
-+ (void)verbose:(NSString *)logString
++ (void)verbose:(OWSLogBlock)logBlock;
 {
-    DDLogVerbose(@"%@", logString);
+    DDLogVerbose(@"%@", logBlock());
 }
 
-+ (void)debug:(NSString *)logString
++ (void)debug:(OWSLogBlock)logBlock;
 {
-    DDLogDebug(@"%@", logString);
+    DDLogDebug(@"%@", logBlock());
 }
 
-+ (void)info:(NSString *)logString
++ (void)info:(OWSLogBlock)logBlock;
 {
-    DDLogInfo(@"%@", logString);
+    DDLogInfo(@"%@", logBlock());
 }
 
-+ (void)warn:(NSString *)logString
++ (void)warn:(OWSLogBlock)logBlock;
 {
-    DDLogWarn(@"%@", logString);
+    DDLogWarn(@"%@", logBlock());
 }
 
-+ (void)error:(NSString *)logString
++ (void)error:(OWSLogBlock)logBlock;
 {
-    DDLogError(@"%@", logString);
+    DDLogError(@"%@", logBlock());
 }
 
 + (void)flush

--- a/SignalServiceKit/src/Util/OWSLogger.m
+++ b/SignalServiceKit/src/Util/OWSLogger.m
@@ -8,29 +8,29 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation OWSLogger
 
-+ (void)verbose:(OWSLogBlock)logBlock;
++ (void)verbose:(NSString *)logString;
 {
-    DDLogVerbose(@"%@", logBlock());
+    DDLogVerbose(@"%@", logString);
 }
 
-+ (void)debug:(OWSLogBlock)logBlock;
++ (void)debug:(NSString *)logString;
 {
-    DDLogDebug(@"%@", logBlock());
+    DDLogDebug(@"%@", logString);
 }
 
-+ (void)info:(OWSLogBlock)logBlock;
++ (void)info:(NSString *)logString;
 {
-    DDLogInfo(@"%@", logBlock());
+    DDLogInfo(@"%@", logString);
 }
 
-+ (void)warn:(OWSLogBlock)logBlock;
++ (void)warn:(NSString *)logString;
 {
-    DDLogWarn(@"%@", logBlock());
+    DDLogWarn(@"%@", logString);
 }
 
-+ (void)error:(OWSLogBlock)logBlock;
++ (void)error:(NSString *)logString;
 {
-    DDLogError(@"%@", logBlock());
+    DDLogError(@"%@", logString);
 }
 
 + (void)flush

--- a/SignalServiceKit/src/Util/OWSLogger.swift
+++ b/SignalServiceKit/src/Util/OWSLogger.swift
@@ -7,9 +7,9 @@ import Foundation
 // Once we're on Swift4.2 we can mark this as inlineable
 // @inlinable
 public func owsFormatLogMessage(_ logString: String,
-                    file: String = #file,
-                    function: String = #function,
-                    line: Int = #line) -> String {
+                                file: String = #file,
+                                function: String = #function,
+                                line: Int = #line) -> String {
     let filename = (file as NSString).lastPathComponent
     // We format the filename & line number in a format compatible
     // with XCode's "Open Quickly..." feature.
@@ -25,49 +25,50 @@ open class Logger: NSObject {
                             file: String = #file,
                             function: String = #function,
                             line: Int = #line) {
-        #if DEBUG
-        OWSLogger.verbose({
-            return owsFormatLogMessage(logString(), file: file, function: function, line: line)
-        })
-        #endif
+        guard ShouldLogVerbose() else {
+            return
+        }
+        OWSLogger.verbose(owsFormatLogMessage(logString(), file: file, function: function, line: line))
     }
 
     open class func debug(_ logString: @escaping @autoclosure () -> String,
                           file: String = #file,
                           function: String = #function,
                           line: Int = #line) {
-        #if DEBUG
-        OWSLogger.debug({
-            return owsFormatLogMessage(logString(), file: file, function: function, line: line)
-        })
-        #endif
+        guard ShouldLogDebug() else {
+            return
+        }
+        OWSLogger.debug(owsFormatLogMessage(logString(), file: file, function: function, line: line))
     }
 
     open class func info(_ logString: String,
                          file: String = #file,
                          function: String = #function,
                          line: Int = #line) {
-        OWSLogger.info({
-            return owsFormatLogMessage(logString, file: file, function: function, line: line)
-        })
+        guard ShouldLogInfo() else {
+            return
+        }
+        OWSLogger.info(owsFormatLogMessage(logString, file: file, function: function, line: line))
     }
 
     open class func warn(_ logString: String,
                          file: String = #file,
                          function: String = #function,
                          line: Int = #line) {
-        OWSLogger.warn({
-            return owsFormatLogMessage(logString, file: file, function: function, line: line)
-        })
+        guard ShouldLogWarning() else {
+            return
+        }
+        OWSLogger.warn(owsFormatLogMessage(logString, file: file, function: function, line: line))
     }
 
     open class func error(_ logString: String,
                           file: String = #file,
                           function: String = #function,
                           line: Int = #line) {
-        OWSLogger.error({
-            return owsFormatLogMessage(logString, file: file, function: function, line: line)
-        })
+        guard ShouldLogError() else {
+            return
+        }
+        OWSLogger.error(owsFormatLogMessage(logString, file: file, function: function, line: line))
     }
 
     open class func flush() {

--- a/SignalServiceKit/src/Util/OWSLogger.swift
+++ b/SignalServiceKit/src/Util/OWSLogger.swift
@@ -21,23 +21,25 @@ public func owsFormatLogMessage(_ logString: String,
  */
 open class Logger: NSObject {
 
-    open class func verbose(_ logString: @autoclosure () -> String,
+    open class func verbose(_ logString: @escaping @autoclosure () -> String,
                             file: String = #file,
                             function: String = #function,
                             line: Int = #line) {
         #if DEBUG
-        let message = owsFormatLogMessage(logString(), file: file, function: function, line: line)
-        OWSLogger.verbose(message)
+        OWSLogger.verbose({
+            return owsFormatLogMessage(logString(), file: file, function: function, line: line)
+        })
         #endif
     }
 
-    open class func debug(_ logString: @autoclosure () -> String,
+    open class func debug(_ logString: @escaping @autoclosure () -> String,
                           file: String = #file,
                           function: String = #function,
                           line: Int = #line) {
         #if DEBUG
-        let message = owsFormatLogMessage(logString(), file: file, function: function, line: line)
-        OWSLogger.debug(message)
+        OWSLogger.debug({
+            return owsFormatLogMessage(logString(), file: file, function: function, line: line)
+        })
         #endif
     }
 
@@ -45,24 +47,27 @@ open class Logger: NSObject {
                          file: String = #file,
                          function: String = #function,
                          line: Int = #line) {
-        let message = owsFormatLogMessage(logString, file: file, function: function, line: line)
-        OWSLogger.info(message)
+        OWSLogger.info({
+            return owsFormatLogMessage(logString, file: file, function: function, line: line)
+        })
     }
 
     open class func warn(_ logString: String,
                          file: String = #file,
                          function: String = #function,
                          line: Int = #line) {
-        let message = owsFormatLogMessage(logString, file: file, function: function, line: line)
-        OWSLogger.warn(message)
+        OWSLogger.warn({
+            return owsFormatLogMessage(logString, file: file, function: function, line: line)
+        })
     }
 
     open class func error(_ logString: String,
                           file: String = #file,
                           function: String = #function,
                           line: Int = #line) {
-        let message = owsFormatLogMessage(logString, file: file, function: function, line: line)
-        OWSLogger.error(message)
+        OWSLogger.error({
+            return owsFormatLogMessage(logString, file: file, function: function, line: line)
+        })
     }
 
     open class func flush() {

--- a/SignalServiceKit/src/Util/OWSLogger.swift
+++ b/SignalServiceKit/src/Util/OWSLogger.swift
@@ -1,0 +1,67 @@
+//
+//  Copyright (c) 2018 Open Whisper Systems. All rights reserved.
+//
+
+import Foundation
+
+// Once we're on Swift4.2 we can mark this as inlineable
+// @inlinable
+public func owsFormatLogMessage(_ logString: String,
+                    file: String = #file,
+                    function: String = #function,
+                    line: Int = #line) -> String {
+    let filename = (file as NSString).lastPathComponent
+    // We format the filename & line number in a format compatible
+    // with XCode's "Open Quickly..." feature.
+    return "[\(filename):\(line) \(function)]: \(logString)"
+}
+
+/**
+ * A minimal DDLog wrapper for swift.
+ */
+open class Logger: NSObject {
+
+    open class func verbose(_ logString: String,
+                            file: String = #file,
+                            function: String = #function,
+                            line: Int = #line) {
+        let message = owsFormatLogMessage(logString, file: file, function: function, line: line)
+        OWSLogger.verbose(message)
+    }
+
+    open class func debug(_ logString: String,
+                          file: String = #file,
+                          function: String = #function,
+                          line: Int = #line) {
+        let message = owsFormatLogMessage(logString, file: file, function: function, line: line)
+        OWSLogger.debug(message)
+    }
+
+    open class func info(_ logString: String,
+                         file: String = #file,
+                         function: String = #function,
+                         line: Int = #line) {
+        let message = owsFormatLogMessage(logString, file: file, function: function, line: line)
+        OWSLogger.info(message)
+    }
+
+    open class func warn(_ logString: String,
+                         file: String = #file,
+                         function: String = #function,
+                         line: Int = #line) {
+        let message = owsFormatLogMessage(logString, file: file, function: function, line: line)
+        OWSLogger.warn(message)
+    }
+
+    open class func error(_ logString: String,
+                          file: String = #file,
+                          function: String = #function,
+                          line: Int = #line) {
+        let message = owsFormatLogMessage(logString, file: file, function: function, line: line)
+        OWSLogger.error(message)
+    }
+
+    open class func flush() {
+        OWSLogger.flush()
+    }
+}

--- a/SignalServiceKit/src/Util/OWSLogger.swift
+++ b/SignalServiceKit/src/Util/OWSLogger.swift
@@ -21,20 +21,24 @@ public func owsFormatLogMessage(_ logString: String,
  */
 open class Logger: NSObject {
 
-    open class func verbose(_ logString: String,
+    open class func verbose(_ logString: @autoclosure () -> String,
                             file: String = #file,
                             function: String = #function,
                             line: Int = #line) {
-        let message = owsFormatLogMessage(logString, file: file, function: function, line: line)
+        #if DEBUG
+        let message = owsFormatLogMessage(logString(), file: file, function: function, line: line)
         OWSLogger.verbose(message)
+        #endif
     }
 
-    open class func debug(_ logString: String,
+    open class func debug(_ logString: @autoclosure () -> String,
                           file: String = #file,
                           function: String = #function,
                           line: Int = #line) {
-        let message = owsFormatLogMessage(logString, file: file, function: function, line: line)
+        #if DEBUG
+        let message = owsFormatLogMessage(logString(), file: file, function: function, line: line)
         OWSLogger.debug(message)
+        #endif
     }
 
     open class func info(_ logString: String,

--- a/SignalShareExtension/SAEFailedViewController.swift
+++ b/SignalShareExtension/SAEFailedViewController.swift
@@ -1,5 +1,5 @@
 //
-//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//  Copyright (c) 2018 Open Whisper Systems. All rights reserved.
 //
 
 import UIKit
@@ -89,7 +89,7 @@ class SAEFailedViewController: UIViewController {
 
     @objc func cancelPressed(sender: UIButton) {
         guard let delegate = delegate else {
-            owsFail("\(self.logTag) missing delegate")
+            owsFail("missing delegate")
             return
         }
         delegate.shareViewWasCancelled()

--- a/SignalShareExtension/SAELoadViewController.swift
+++ b/SignalShareExtension/SAELoadViewController.swift
@@ -1,5 +1,5 @@
 //
-//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//  Copyright (c) 2018 Open Whisper Systems. All rights reserved.
 //
 
 import UIKit
@@ -63,7 +63,7 @@ class SAELoadViewController: UIViewController {
 
         self.view.backgroundColor = UIColor.ows_signalBrandBlue
 
-        let activityIndicator = UIActivityIndicatorView(activityIndicatorStyle:.whiteLarge)
+        let activityIndicator = UIActivityIndicatorView(activityIndicatorStyle: .whiteLarge)
         self.activityIndicator = activityIndicator
         self.view.addSubview(activityIndicator)
         activityIndicator.autoCenterInSuperview()
@@ -103,7 +103,7 @@ class SAELoadViewController: UIViewController {
 
     @objc func cancelPressed(sender: UIButton) {
         guard let delegate = delegate else {
-            owsFail("\(self.logTag) missing delegate")
+            owsFail("missing delegate")
             return
         }
         delegate.shareViewWasCancelled()

--- a/SignalShareExtension/ShareViewController.swift
+++ b/SignalShareExtension/ShareViewController.swift
@@ -42,7 +42,7 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
             DebugLogger.shared().enableFileLogging()
         }
 
-        Logger.info("\(self.logTag) \(#function)")
+        Logger.info("")
 
         _ = AppVersion.sharedInstance()
 
@@ -79,11 +79,11 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
 
             guard let strongSelf = self else { return }
             guard strongSelf.presentedViewController == nil else {
-                Logger.debug("\(strongSelf.logTag) setup completed quickly, no need to present load view controller.")
+                Logger.debug("setup completed quickly, no need to present load view controller.")
                 return
             }
 
-            Logger.debug("\(strongSelf.logTag) setup is slow - showing loading screen")
+            Logger.debug("setup is slow - showing loading screen")
             strongSelf.showPrimaryViewController(loadViewController)
         }.retainUntilComplete()
 
@@ -126,13 +126,13 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
                                                name: .OWSApplicationDidEnterBackground,
                                                object: nil)
 
-        Logger.info("\(self.logTag) \(#function) completed.")
+        Logger.info("completed.")
 
         OWSAnalytics.appLaunchDidBegin()
     }
 
     deinit {
-        Logger.info("\(self.logTag) deinit")
+        Logger.info("deinit")
         NotificationCenter.default.removeObserver(self)
 
         // Share extensions reside in a process that may be reused between usages.
@@ -145,11 +145,11 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
     public func applicationDidEnterBackground() {
         AssertIsOnMainThread()
 
-        Logger.info("\(self.logTag) \(#function)")
+        Logger.info("")
 
         if OWSScreenLock.shared.isScreenLockEnabled() {
 
-            Logger.info("\(self.logTag) \(#function) dismissing.")
+            Logger.info("dismissing.")
 
             self.dismiss(animated: false) { [weak self] in
                 AssertIsOnMainThread()
@@ -162,7 +162,7 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
     private func activate() {
         AssertIsOnMainThread()
 
-        Logger.debug("\(self.logTag) \(#function)")
+        Logger.debug("")
 
         // We don't need to use "screen protection" in the SAE.
 
@@ -178,7 +178,7 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
             // Avoid blocking app launch by putting all further possible DB access in async block
             DispatchQueue.global().async { [weak self] in
                 guard let strongSelf = self else { return }
-                Logger.info("\(strongSelf.logTag) running post launch block for registered user: \(TSAccountManager.localNumber)")
+                Logger.info("running post launch block for registered user: \(TSAccountManager.localNumber)")
 
                 // We don't need to use OWSDisappearingMessagesJob in the SAE.
 
@@ -187,7 +187,7 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
                 // We don't need to use OWSFailedAttachmentDownloadsJob in the SAE.
             }
         } else {
-            Logger.info("\(self.logTag) running post launch block for unregistered user.")
+            Logger.info("running post launch block for unregistered user.")
 
             // We don't need to update the app icon badge number in the SAE.
 
@@ -197,7 +197,7 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
         if TSAccountManager.isRegistered() {
             DispatchQueue.main.async { [weak self] in
                 guard let strongSelf = self else { return }
-                Logger.info("\(strongSelf.logTag) running post launch block for registered user: \(TSAccountManager.localNumber)")
+                Logger.info("running post launch block for registered user: \(TSAccountManager.localNumber)")
 
                 // We don't need to use the TSSocketManager in the SAE.
 
@@ -214,7 +214,7 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
     func versionMigrationsDidComplete() {
         AssertIsOnMainThread()
 
-        Logger.debug("\(self.logTag) \(#function)")
+        Logger.debug("")
 
         areVersionMigrationsComplete = true
 
@@ -225,7 +225,7 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
     func storageIsReady() {
         AssertIsOnMainThread()
 
-        Logger.debug("\(self.logTag) \(#function)")
+        Logger.debug("")
 
         checkIsAppReady()
     }
@@ -246,7 +246,7 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
             return
         }
 
-        Logger.debug("\(self.logTag) \(#function)")
+        Logger.debug("")
 
         // TODO: Once "app ready" logic is moved into AppSetup, move this line there.
         OWSProfileManager.shared().ensureLocalProfileCached()
@@ -256,7 +256,7 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
         AppReadiness.setAppIsReady()
 
         if TSAccountManager.isRegistered() {
-            Logger.info("\(self.logTag) localNumber: \(TSAccountManager.localNumber)")
+            Logger.info("localNumber: \(TSAccountManager.localNumber)")
 
             // We don't need to use messageFetcherJob in the SAE.
 
@@ -288,10 +288,10 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
     func registrationStateDidChange() {
         AssertIsOnMainThread()
 
-        Logger.debug("\(self.logTag) \(#function)")
+        Logger.debug("")
 
         if TSAccountManager.isRegistered() {
-            Logger.info("\(self.logTag) localNumber: \(TSAccountManager.localNumber)")
+            Logger.info("localNumber: \(TSAccountManager.localNumber)")
 
             // We don't need to use ExperienceUpgradeFinder in the SAE.
 
@@ -304,7 +304,7 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
     private func ensureRootViewController() {
         AssertIsOnMainThread()
 
-        Logger.debug("\(self.logTag) \(#function)")
+        Logger.debug("")
 
         guard AppReadiness.isAppReady() else {
             return
@@ -314,7 +314,7 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
         }
         hasInitialRootViewController = true
 
-        Logger.info("\(logTag) Presenting initial root view controller")
+        Logger.info("Presenting initial root view controller")
 
         if OWSScreenLock.shared.isScreenLockEnabled() {
             presentScreenLock()
@@ -326,9 +326,9 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
     private func presentContentView() {
         AssertIsOnMainThread()
 
-        Logger.debug("\(self.logTag) \(#function)")
+        Logger.debug("")
 
-        Logger.info("\(logTag) Presenting content view")
+        Logger.info("Presenting content view")
 
         if !TSAccountManager.isRegistered() {
             showNotRegisteredView()
@@ -347,24 +347,24 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
     }
 
     func startupLogging() {
-        Logger.info("\(self.logTag) iOS Version: \(UIDevice.current.systemVersion)}")
+        Logger.info("iOS Version: \(UIDevice.current.systemVersion)}")
 
         let locale = NSLocale.current as NSLocale
         if let localeIdentifier = locale.object(forKey: NSLocale.Key.identifier) as? String,
             localeIdentifier.count > 0 {
-            Logger.info("\(self.logTag) Locale Identifier: \(localeIdentifier)")
+            Logger.info("Locale Identifier: \(localeIdentifier)")
         } else {
             owsFail("Locale Identifier: Unknown")
         }
         if let countryCode = locale.object(forKey: NSLocale.Key.countryCode) as? String,
             countryCode.count > 0 {
-            Logger.info("\(self.logTag) Country Code: \(countryCode)")
+            Logger.info("Country Code: \(countryCode)")
         } else {
             owsFail("Country Code: Unknown")
         }
         if let languageCode = locale.object(forKey: NSLocale.Key.languageCode) as? String,
             languageCode.count > 0 {
-            Logger.info("\(self.logTag) Language Code: \(languageCode)")
+            Logger.info("Language Code: \(languageCode)")
         } else {
             owsFail("Language Code: Unknown")
         }
@@ -404,7 +404,7 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
     override open func viewDidLoad() {
         super.viewDidLoad()
 
-        Logger.debug("\(self.logTag) \(#function)")
+        Logger.debug("")
 
         if isReadyForAppExtensions {
             AppReadiness.runNowOrWhenAppIsReady { [weak self] in
@@ -416,19 +416,19 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
     }
 
     override open func viewWillAppear(_ animated: Bool) {
-        Logger.debug("\(self.logTag) \(#function)")
+        Logger.debug("")
 
         super.viewWillAppear(animated)
     }
 
     override open func viewDidAppear(_ animated: Bool) {
-        Logger.debug("\(self.logTag) \(#function)")
+        Logger.debug("")
 
         super.viewDidAppear(animated)
     }
 
     override open func viewWillDisappear(_ animated: Bool) {
-        Logger.debug("\(self.logTag) \(#function)")
+        Logger.debug("")
 
         super.viewWillDisappear(animated)
 
@@ -436,7 +436,7 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
     }
 
     override open func viewDidDisappear(_ animated: Bool) {
-        Logger.debug("\(self.logTag) \(#function)")
+        Logger.debug("")
 
         super.viewDidDisappear(animated)
 
@@ -452,7 +452,7 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
     func owsApplicationWillEnterForeground() throws {
         AssertIsOnMainThread()
 
-        Logger.debug("\(self.logTag) \(#function)")
+        Logger.debug("")
 
         // If a user unregisters in the main app, the SAE should shut down
         // immediately.
@@ -474,13 +474,13 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
     // MARK: ShareViewDelegate, SAEFailedViewDelegate
 
     public func shareViewWasUnlocked() {
-        Logger.info("\(self.logTag) \(#function)")
+        Logger.info("")
 
         presentContentView()
     }
 
     public func shareViewWasCompleted() {
-        Logger.info("\(self.logTag) \(#function)")
+        Logger.info("")
 
         self.dismiss(animated: true) { [weak self] in
             AssertIsOnMainThread()
@@ -490,7 +490,7 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
     }
 
     public func shareViewWasCancelled() {
-        Logger.info("\(self.logTag) \(#function)")
+        Logger.info("")
 
         self.dismiss(animated: true) { [weak self] in
             AssertIsOnMainThread()
@@ -500,7 +500,7 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
     }
 
     public func shareViewFailed(error: Error) {
-        Logger.info("\(self.logTag) \(#function)")
+        Logger.info("")
 
         self.dismiss(animated: true) { [weak self] in
             AssertIsOnMainThread()
@@ -523,10 +523,10 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
 
         shareViewNavigationController.setViewControllers([viewController], animated: false)
         if self.presentedViewController == nil {
-            Logger.debug("\(self.logTag) presenting modally: \(viewController)")
+            Logger.debug("presenting modally: \(viewController)")
             self.present(shareViewNavigationController, animated: true)
         } else {
-            Logger.debug("\(self.logTag) modal already presented. swapping modal content for: \(viewController)")
+            Logger.debug("modal already presented. swapping modal content for: \(viewController)")
             assert(self.presentedViewController == shareViewNavigationController)
         }
     }
@@ -542,10 +542,10 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
             strongSelf.loadViewController = nil
 
             let conversationPicker = SharingThreadPickerViewController(shareViewDelegate: strongSelf)
-            Logger.debug("\(strongSelf.logTag) presentConversationPicker: \(conversationPicker)")
+            Logger.debug("presentConversationPicker: \(conversationPicker)")
             conversationPicker.attachment = attachment
             strongSelf.showPrimaryViewController(conversationPicker)
-            Logger.info("\(strongSelf.logTag) showing picker with attachment: \(attachment)")
+            Logger.info("showing picker with attachment: \(attachment)")
         }.catch {[weak self]  error in
             AssertIsOnMainThread()
             guard let strongSelf = self else { return }
@@ -557,7 +557,7 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
                                 buttonTitle: CommonStrings.cancelButton) { _ in
                                     strongSelf.shareViewWasCancelled()
             }
-            owsFail("\(strongSelf.logTag) building attachment failed with error: \(error)")
+            owsFail("building attachment failed with error: \(error)")
         }.retainUntilComplete()
     }
 
@@ -565,9 +565,9 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
         AssertIsOnMainThread()
 
         let screenLockUI = SAEScreenLockViewController(shareViewDelegate: self)
-        Logger.debug("\(self.logTag) presentScreenLock: \(screenLockUI)")
+        Logger.debug("presentScreenLock: \(screenLockUI)")
         showPrimaryViewController(screenLockUI)
-        Logger.info("\(self.logTag) showing screen lock")
+        Logger.info("showing screen lock")
     }
 
     private class func itemMatchesSpecificUtiType(itemProvider: NSItemProvider, utiType: String) -> Bool {
@@ -593,7 +593,7 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
     }
 
     private class func utiType(itemProvider: NSItemProvider) -> String? {
-        Logger.info("\(self.logTag) utiTypeForItem: \(itemProvider.registeredTypeIdentifiers)")
+        Logger.info("utiTypeForItem: \(itemProvider.registeredTypeIdentifiers)")
 
         if isUrlItem(itemProvider: itemProvider) {
             return kUTTypeURL as String
@@ -675,7 +675,7 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
             let error = ShareViewControllerError.assertionError(description: "No item provider in input item attachments")
             return Promise(error: error)
         }
-        Logger.info("\(self.logTag) attachment: \(itemProvider)")
+        Logger.info("attachment: \(itemProvider)")
 
         // We need to be very careful about which UTI type we use.
         //
@@ -690,7 +690,7 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
             let error = ShareViewControllerError.unsupportedMedia
             return Promise(error: error)
         }
-        Logger.debug("\(logTag) matched utiType: \(srcUtiType)")
+        Logger.debug("matched utiType: \(srcUtiType)")
 
         let (promise, fulfill, reject) = Promise<(itemUrl: URL, utiType: String)>.pending()
 
@@ -714,7 +714,7 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
                 return
             }
 
-            Logger.info("\(strongSelf.logTag) value type: \(type(of: value))")
+            Logger.info("value type: \(type(of: value))")
 
             if let data = value as? Data {
                 // Although we don't support contacts _yet_, when we do we'll want to make
@@ -726,7 +726,7 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
                     if Contact(vCardData: data) != nil {
                         isConvertibleToContactShare = true
                     } else {
-                        Logger.error("\(strongSelf.logTag) could not parse vcard.")
+                        Logger.error("could not parse vcard.")
                         let writeError = ShareViewControllerError.assertionError(description: "Could not parse vcard data.")
                         reject(writeError)
                         return
@@ -742,7 +742,7 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
                 let fileUrl = URL(fileURLWithPath: tempFilePath)
                 fulfill((itemUrl: fileUrl, utiType: srcUtiType))
             } else if let string = value as? String {
-                Logger.debug("\(strongSelf.logTag) string provider: \(string)")
+                Logger.debug("string provider: \(string)")
                 guard let data = string.filterStringForDisplay().data(using: String.Encoding.utf8) else {
                     let writeError = ShareViewControllerError.assertionError(description: "Error writing item data: \(String(describing: error))")
                     reject(writeError)
@@ -809,7 +809,7 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
                 }
             }()
 
-            Logger.debug("\(strongSelf.logTag) building DataSource with url: \(url), utiType: \(utiType)")
+            Logger.debug("building DataSource with url: \(url), utiType: \(utiType)")
 
             guard let dataSource = ShareViewController.createDataSource(utiType: utiType, url: url, customFileName: customFileName) else {
                 throw ShareViewControllerError.assertionError(description: "Unable to read attachment data")
@@ -824,7 +824,7 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
             } else if url.pathExtension.count > 0 {
                 // Determine a more specific utiType based on file extension
                 if let typeExtension = MIMETypeUtil.utiType(forFileExtension: url.pathExtension) {
-                    Logger.debug("\(strongSelf.logTag) utiType based on extension: \(typeExtension)")
+                    Logger.debug("utiType based on extension: \(typeExtension)")
                     specificUTIType = typeExtension
                 }
             }
@@ -857,10 +857,10 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
 
             let attachment = SignalAttachment.attachment(dataSource: dataSource, dataUTI: specificUTIType, imageQuality: .medium)
             if isConvertibleToContactShare {
-                Logger.info("\(strongSelf.logTag) isConvertibleToContactShare")
+                Logger.info("isConvertibleToContactShare")
                 attachment.isConvertibleToContactShare = isConvertibleToContactShare
             } else if isConvertibleToTextMessage {
-                Logger.info("\(strongSelf.logTag) isConvertibleToTextMessage")
+                Logger.info("isConvertibleToTextMessage")
                 attachment.isConvertibleToTextMessage = isConvertibleToTextMessage
             }
             return Promise(value: attachment)
@@ -890,14 +890,14 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
     private func isVideoNeedingRelocation(itemProvider: NSItemProvider, itemUrl: URL) -> Bool {
         let pathExtension = itemUrl.pathExtension
         guard pathExtension.count > 0 else {
-            Logger.verbose("\(self.logTag) in \(#function): item URL has no file extension: \(itemUrl).")
+            Logger.verbose("item URL has no file extension: \(itemUrl).")
             return false
         }
         guard let utiTypeForURL = MIMETypeUtil.utiType(forFileExtension: pathExtension) else {
-            Logger.verbose("\(self.logTag) in \(#function): item has unknown UTI type: \(itemUrl).")
+            Logger.verbose("item has unknown UTI type: \(itemUrl).")
             return false
         }
-        Logger.verbose("\(self.logTag) utiTypeForURL: \(utiTypeForURL)")
+        Logger.verbose("utiTypeForURL: \(utiTypeForURL)")
         guard utiTypeForURL == kUTTypeMPEG4 as String else {
             // Either it's not a video or it was a video which was not auto-converted to mp4.
             // Not affected by the issue.
@@ -946,7 +946,7 @@ private class ProgressPoller: NSObject {
             strongSelf.progress.completedUnitCount = completedUnitCount
 
             if completedUnitCount == strongSelf.progressTotalUnitCount {
-                Logger.debug("\(strongSelf.logTag) progress complete")
+                Logger.debug("progress complete")
                 timer.invalidate()
             }
         }


### PR DESCRIPTION
Streamlines Swift logging. 

* We should probably do something similar for Obj-C, e.g. replace `DDLogError()` with `OWSLogError()` which uses `__PRETTY_FUNCTION__`.

There's two (tiny) commits that have the real changes.  Everything else is "mechanical".

* https://github.com/signalapp/Signal-iOS/commit/89ee28721cd44cf13ef2a3c22c9dee0147ac8c45
* https://github.com/signalapp/Signal-iOS/commit/df2d3db27ccf899055c38569e5b26f3acd669d1e

PTAL @michaelkirk 