### PR TITLE
Charlesmchen/fix ssk tests d

### DIFF
--- a/Signal/src/AppDelegate.m
+++ b/Signal/src/AppDelegate.m
@@ -44,11 +44,11 @@
 #import <SignalServiceKit/OWSMessageSender.h>
 #import <SignalServiceKit/OWSPrimaryStorage+Calling.h>
 #import <SignalServiceKit/OWSReadReceiptManager.h>
+#import <SignalServiceKit/SSKEnvironment.h>
 #import <SignalServiceKit/TSAccountManager.h>
 #import <SignalServiceKit/TSDatabaseView.h>
 #import <SignalServiceKit/TSPreKeyManager.h>
 #import <SignalServiceKit/TSSocketManager.h>
-#import <SignalServiceKit/TextSecureKitEnv.h>
 #import <YapDatabase/YapDatabaseCryptoUtils.h>
 #import <sys/sysctl.h>
 

--- a/Signal/src/AppDelegate.m
+++ b/Signal/src/AppDelegate.m
@@ -615,7 +615,7 @@ static NSTimeInterval launchStartedAt;
         // Avoid blocking app launch by putting all further possible DB access in async block
         dispatch_async(dispatch_get_main_queue(), ^{
             [TSSocketManager requestSocketOpen];
-            [[Environment current].contactsManager fetchSystemContactsOnceIfAlreadyAuthorized];
+            [Environment.shared.contactsManager fetchSystemContactsOnceIfAlreadyAuthorized];
             // This will fetch new messages, if we're using domain fronting.
             [[PushManager sharedManager] applicationDidBecomeActive];
 
@@ -1041,8 +1041,8 @@ static NSTimeInterval launchStartedAt;
 
     [AppVersion.sharedInstance mainAppLaunchDidComplete];
 
-    [Environment.current.contactsManager loadSignalAccountsFromCache];
-    [Environment.current.contactsManager startObserving];
+    [Environment.shared.contactsManager loadSignalAccountsFromCache];
+    [Environment.shared.contactsManager startObserving];
 
     // If there were any messages in our local queue which we hadn't yet processed.
     [[OWSMessageReceiver sharedInstance] handleAnyUnprocessedEnvelopesAsync];

--- a/Signal/src/Jobs/ConversationConfigurationSyncOperation.swift
+++ b/Signal/src/Jobs/ConversationConfigurationSyncOperation.swift
@@ -16,11 +16,11 @@ class ConversationConfigurationSyncOperation: OWSOperation {
     }
 
     private var messageSender: MessageSender {
-        return Environment.current().messageSender
+        return Environment.shared().messageSender
     }
 
     private var contactsManager: OWSContactsManager {
-        return Environment.current().contactsManager
+        return Environment.shared().contactsManager
     }
 
     private var profileManager: OWSProfileManager {

--- a/Signal/src/Jobs/ConversationConfigurationSyncOperation.swift
+++ b/Signal/src/Jobs/ConversationConfigurationSyncOperation.swift
@@ -16,11 +16,11 @@ class ConversationConfigurationSyncOperation: OWSOperation {
     }
 
     private var messageSender: MessageSender {
-        return Environment.shared().messageSender
+        return Environment.shared.messageSender
     }
 
     private var contactsManager: OWSContactsManager {
-        return Environment.shared().contactsManager
+        return Environment.shared.contactsManager
     }
 
     private var profileManager: OWSProfileManager {

--- a/Signal/src/UserInterface/Notifications/UserNotificationsAdaptee.swift
+++ b/Signal/src/UserInterface/Notifications/UserNotificationsAdaptee.swift
@@ -66,7 +66,7 @@ class UserNotificationsAdaptee: NSObject, OWSCallNotificationsAdaptee, UNUserNot
     private let center: UNUserNotificationCenter
 
     var previewType: NotificationType {
-        return Environment.shared().preferences.notificationPreviewType()
+        return Environment.shared.preferences.notificationPreviewType()
     }
 
     override init() {
@@ -117,7 +117,7 @@ class UserNotificationsAdaptee: NSObject, OWSCallNotificationsAdaptee, UNUserNot
             case .noNameNoPreview:
                 return CallStrings.missedCallNotificationBodyWithoutCallerName
             case .nameNoPreview, .namePreview:
-                return (Environment.shared().preferences.isCallKitPrivacyEnabled()
+                return (Environment.shared.preferences.isCallKitPrivacyEnabled()
                     ? CallStrings.missedCallNotificationBodyWithoutCallerName
                     : String(format: CallStrings.missedCallNotificationBodyWithCallerName, callerName))
         }}()
@@ -143,7 +143,7 @@ class UserNotificationsAdaptee: NSObject, OWSCallNotificationsAdaptee, UNUserNot
             case .noNameNoPreview:
                 return CallStrings.missedCallWithIdentityChangeNotificationBodyWithoutCallerName
             case .nameNoPreview, .namePreview:
-                return (Environment.shared().preferences.isCallKitPrivacyEnabled()
+                return (Environment.shared.preferences.isCallKitPrivacyEnabled()
                     ? CallStrings.missedCallWithIdentityChangeNotificationBodyWithoutCallerName
                     : String(format: CallStrings.missedCallWithIdentityChangeNotificationBodyWithCallerName, callerName))
             }}()
@@ -169,7 +169,7 @@ class UserNotificationsAdaptee: NSObject, OWSCallNotificationsAdaptee, UNUserNot
             case .noNameNoPreview:
                 return CallStrings.missedCallWithIdentityChangeNotificationBodyWithoutCallerName
             case .nameNoPreview, .namePreview:
-                return (Environment.shared().preferences.isCallKitPrivacyEnabled()
+                return (Environment.shared.preferences.isCallKitPrivacyEnabled()
                     ? CallStrings.missedCallWithIdentityChangeNotificationBodyWithoutCallerName
                     : String(format: CallStrings.missedCallWithIdentityChangeNotificationBodyWithCallerName, callerName))
             }}()

--- a/Signal/src/UserInterface/Notifications/UserNotificationsAdaptee.swift
+++ b/Signal/src/UserInterface/Notifications/UserNotificationsAdaptee.swift
@@ -66,7 +66,7 @@ class UserNotificationsAdaptee: NSObject, OWSCallNotificationsAdaptee, UNUserNot
     private let center: UNUserNotificationCenter
 
     var previewType: NotificationType {
-        return Environment.current().preferences.notificationPreviewType()
+        return Environment.shared().preferences.notificationPreviewType()
     }
 
     override init() {
@@ -117,7 +117,7 @@ class UserNotificationsAdaptee: NSObject, OWSCallNotificationsAdaptee, UNUserNot
             case .noNameNoPreview:
                 return CallStrings.missedCallNotificationBodyWithoutCallerName
             case .nameNoPreview, .namePreview:
-                return (Environment.current().preferences.isCallKitPrivacyEnabled()
+                return (Environment.shared().preferences.isCallKitPrivacyEnabled()
                     ? CallStrings.missedCallNotificationBodyWithoutCallerName
                     : String(format: CallStrings.missedCallNotificationBodyWithCallerName, callerName))
         }}()
@@ -143,7 +143,7 @@ class UserNotificationsAdaptee: NSObject, OWSCallNotificationsAdaptee, UNUserNot
             case .noNameNoPreview:
                 return CallStrings.missedCallWithIdentityChangeNotificationBodyWithoutCallerName
             case .nameNoPreview, .namePreview:
-                return (Environment.current().preferences.isCallKitPrivacyEnabled()
+                return (Environment.shared().preferences.isCallKitPrivacyEnabled()
                     ? CallStrings.missedCallWithIdentityChangeNotificationBodyWithoutCallerName
                     : String(format: CallStrings.missedCallWithIdentityChangeNotificationBodyWithCallerName, callerName))
             }}()
@@ -169,7 +169,7 @@ class UserNotificationsAdaptee: NSObject, OWSCallNotificationsAdaptee, UNUserNot
             case .noNameNoPreview:
                 return CallStrings.missedCallWithIdentityChangeNotificationBodyWithoutCallerName
             case .nameNoPreview, .namePreview:
-                return (Environment.current().preferences.isCallKitPrivacyEnabled()
+                return (Environment.shared().preferences.isCallKitPrivacyEnabled()
                     ? CallStrings.missedCallWithIdentityChangeNotificationBodyWithoutCallerName
                     : String(format: CallStrings.missedCallWithIdentityChangeNotificationBodyWithCallerName, callerName))
             }}()

--- a/Signal/src/ViewControllers/AddContactShareToExistingContactViewController.swift
+++ b/Signal/src/ViewControllers/AddContactShareToExistingContactViewController.swift
@@ -58,7 +58,7 @@ class AddContactShareToExistingContactViewController: ContactsPicker, ContactsPi
     func contactsPicker(_: ContactsPicker, didSelectContact oldContact: Contact) {
         Logger.debug("")
 
-        let contactsManager = Environment.shared().contactsManager
+        let contactsManager = Environment.shared.contactsManager
         guard let oldCNContact = contactsManager?.cnContact(withId: oldContact.cnContactId) else {
             owsFailDebug("could not load old CNContact.")
             return

--- a/Signal/src/ViewControllers/AddContactShareToExistingContactViewController.swift
+++ b/Signal/src/ViewControllers/AddContactShareToExistingContactViewController.swift
@@ -58,7 +58,7 @@ class AddContactShareToExistingContactViewController: ContactsPicker, ContactsPi
     func contactsPicker(_: ContactsPicker, didSelectContact oldContact: Contact) {
         Logger.debug("")
 
-        let contactsManager = Environment.current().contactsManager
+        let contactsManager = Environment.shared().contactsManager
         guard let oldCNContact = contactsManager?.cnContact(withId: oldContact.cnContactId) else {
             owsFailDebug("could not load old CNContact.")
             return

--- a/Signal/src/ViewControllers/AppSettings/AppSettingsViewController.m
+++ b/Signal/src/ViewControllers/AppSettings/AppSettingsViewController.m
@@ -51,7 +51,7 @@
         return self;
     }
 
-    _contactsManager = [Environment current].contactsManager;
+    _contactsManager = Environment.shared.contactsManager;
 
     return self;
 }
@@ -63,7 +63,7 @@
         return self;
     }
 
-    _contactsManager = [Environment current].contactsManager;
+    _contactsManager = Environment.shared.contactsManager;
 
     return self;
 }

--- a/Signal/src/ViewControllers/AppSettings/PrivacySettingsTableViewController.m
+++ b/Signal/src/ViewControllers/AppSettings/PrivacySettingsTableViewController.m
@@ -254,7 +254,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)didToggleEnableSystemCallLogSwitch:(UISwitch *)sender
 {
     OWSLogInfo(@"user toggled call kit preference: %@", (sender.isOn ? @"ON" : @"OFF"));
-    [[Environment current].preferences setIsSystemCallLogEnabled:sender.isOn];
+    [Environment.shared.preferences setIsSystemCallLogEnabled:sender.isOn];
 
     // rebuild callUIAdapter since CallKit configuration changed.
     [SignalApp.sharedApp.callService createCallUIAdapter];
@@ -263,7 +263,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)didToggleEnableCallKitSwitch:(UISwitch *)sender
 {
     OWSLogInfo(@"user toggled call kit preference: %@", (sender.isOn ? @"ON" : @"OFF"));
-    [[Environment current].preferences setIsCallKitEnabled:sender.isOn];
+    [Environment.shared.preferences setIsCallKitEnabled:sender.isOn];
 
     // rebuild callUIAdapter since CallKit vs not changed.
     [SignalApp.sharedApp.callService createCallUIAdapter];
@@ -275,7 +275,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)didToggleEnableCallKitPrivacySwitch:(UISwitch *)sender
 {
     OWSLogInfo(@"user toggled call kit privacy preference: %@", (sender.isOn ? @"ON" : @"OFF"));
-    [[Environment current].preferences setIsCallKitPrivacyEnabled:!sender.isOn];
+    [Environment.shared.preferences setIsCallKitPrivacyEnabled:!sender.isOn];
 
     // rebuild callUIAdapter since CallKit configuration changed.
     [SignalApp.sharedApp.callService createCallUIAdapter];

--- a/Signal/src/ViewControllers/CallViewController.swift
+++ b/Signal/src/ViewControllers/CallViewController.swift
@@ -140,7 +140,7 @@ class CallViewController: OWSViewController, CallObserver, CallServiceObserver, 
     }
 
     required init(call: SignalCall) {
-        contactsManager = Environment.shared().contactsManager
+        contactsManager = Environment.shared.contactsManager
         self.call = call
         self.thread = TSContactThread.getOrCreateThread(contactId: call.remotePhoneNumber)
         super.init(nibName: nil, bundle: nil)
@@ -942,7 +942,7 @@ class CallViewController: OWSViewController, CallObserver, CallServiceObserver, 
     private func markSettingsNagAsComplete() {
         Logger.info("")
 
-        let preferences = Environment.shared().preferences!
+        let preferences = Environment.shared.preferences!
 
         preferences.setIsCallKitEnabled(preferences.isCallKitEnabled())
         preferences.setIsCallKitPrivacyEnabled(preferences.isCallKitPrivacyEnabled())
@@ -1064,13 +1064,13 @@ class CallViewController: OWSViewController, CallObserver, CallServiceObserver, 
         } else if !ignoreNag &&
             call.direction == .incoming &&
             UIDevice.current.supportsCallKit &&
-            (!Environment.shared().preferences.isCallKitEnabled() ||
-                Environment.shared().preferences.isCallKitPrivacyEnabled()) {
+            (!Environment.shared.preferences.isCallKitEnabled() ||
+                Environment.shared.preferences.isCallKitPrivacyEnabled()) {
 
             isShowingSettingsNag = true
 
             // Update the nag view's copy to reflect the settings state.
-            if Environment.shared().preferences.isCallKitEnabled() {
+            if Environment.shared.preferences.isCallKitEnabled() {
                 settingsNagDescriptionLabel.text = NSLocalizedString("CALL_VIEW_SETTINGS_NAG_DESCRIPTION_PRIVACY",
                                                                      comment: "Reminder to the user of the benefits of disabling CallKit privacy.")
             } else {
@@ -1079,8 +1079,8 @@ class CallViewController: OWSViewController, CallObserver, CallServiceObserver, 
             }
             settingsNagDescriptionLabel.superview?.setNeedsLayout()
 
-            if Environment.shared().preferences.isCallKitEnabledSet() ||
-                Environment.shared().preferences.isCallKitPrivacySet() {
+            if Environment.shared.preferences.isCallKitEnabledSet() ||
+                Environment.shared.preferences.isCallKitPrivacySet() {
                 // User has already touched these preferences, only show
                 // the "fleeting" nag, not the "blocking" nag.
 

--- a/Signal/src/ViewControllers/CallViewController.swift
+++ b/Signal/src/ViewControllers/CallViewController.swift
@@ -140,7 +140,7 @@ class CallViewController: OWSViewController, CallObserver, CallServiceObserver, 
     }
 
     required init(call: SignalCall) {
-        contactsManager = Environment.current().contactsManager
+        contactsManager = Environment.shared().contactsManager
         self.call = call
         self.thread = TSContactThread.getOrCreateThread(contactId: call.remotePhoneNumber)
         super.init(nibName: nil, bundle: nil)
@@ -942,7 +942,7 @@ class CallViewController: OWSViewController, CallObserver, CallServiceObserver, 
     private func markSettingsNagAsComplete() {
         Logger.info("")
 
-        let preferences = Environment.current().preferences!
+        let preferences = Environment.shared().preferences!
 
         preferences.setIsCallKitEnabled(preferences.isCallKitEnabled())
         preferences.setIsCallKitPrivacyEnabled(preferences.isCallKitPrivacyEnabled())
@@ -1064,13 +1064,13 @@ class CallViewController: OWSViewController, CallObserver, CallServiceObserver, 
         } else if !ignoreNag &&
             call.direction == .incoming &&
             UIDevice.current.supportsCallKit &&
-            (!Environment.current().preferences.isCallKitEnabled() ||
-                Environment.current().preferences.isCallKitPrivacyEnabled()) {
+            (!Environment.shared().preferences.isCallKitEnabled() ||
+                Environment.shared().preferences.isCallKitPrivacyEnabled()) {
 
             isShowingSettingsNag = true
 
             // Update the nag view's copy to reflect the settings state.
-            if Environment.current().preferences.isCallKitEnabled() {
+            if Environment.shared().preferences.isCallKitEnabled() {
                 settingsNagDescriptionLabel.text = NSLocalizedString("CALL_VIEW_SETTINGS_NAG_DESCRIPTION_PRIVACY",
                                                                      comment: "Reminder to the user of the benefits of disabling CallKit privacy.")
             } else {
@@ -1079,8 +1079,8 @@ class CallViewController: OWSViewController, CallObserver, CallServiceObserver, 
             }
             settingsNagDescriptionLabel.superview?.setNeedsLayout()
 
-            if Environment.current().preferences.isCallKitEnabledSet() ||
-                Environment.current().preferences.isCallKitPrivacySet() {
+            if Environment.shared().preferences.isCallKitEnabledSet() ||
+                Environment.shared().preferences.isCallKitPrivacySet() {
                 // User has already touched these preferences, only show
                 // the "fleeting" nag, not the "blocking" nag.
 

--- a/Signal/src/ViewControllers/ContactViewController.swift
+++ b/Signal/src/ViewControllers/ContactViewController.swift
@@ -50,7 +50,7 @@ class ContactViewController: OWSViewController, ContactShareViewHelperDelegate {
 
     @objc
     required init(contactShare: ContactShareViewModel) {
-        contactsManager = Environment.current().contactsManager
+        contactsManager = Environment.shared().contactsManager
         self.contactShare = contactShare
         self.contactShareViewHelper = ContactShareViewHelper(contactsManager: contactsManager)
 

--- a/Signal/src/ViewControllers/ContactViewController.swift
+++ b/Signal/src/ViewControllers/ContactViewController.swift
@@ -50,7 +50,7 @@ class ContactViewController: OWSViewController, ContactShareViewHelperDelegate {
 
     @objc
     required init(contactShare: ContactShareViewModel) {
-        contactsManager = Environment.shared().contactsManager
+        contactsManager = Environment.shared.contactsManager
         self.contactShare = contactShare
         self.contactShareViewHelper = ContactShareViewHelper(contactsManager: contactsManager)
 

--- a/Signal/src/ViewControllers/ContactsPicker.swift
+++ b/Signal/src/ViewControllers/ContactsPicker.swift
@@ -36,7 +36,7 @@ public class ContactsPicker: OWSViewController, UITableViewDelegate, UITableView
     private let contactCellReuseIdentifier = "contactCellReuseIdentifier"
 
     private var contactsManager: OWSContactsManager {
-        return Environment.current().contactsManager
+        return Environment.shared().contactsManager
     }
 
     // HACK: Though we don't have an input accessory view, the VC we are presented above (ConversationVC) does.

--- a/Signal/src/ViewControllers/ContactsPicker.swift
+++ b/Signal/src/ViewControllers/ContactsPicker.swift
@@ -36,7 +36,7 @@ public class ContactsPicker: OWSViewController, UITableViewDelegate, UITableView
     private let contactCellReuseIdentifier = "contactCellReuseIdentifier"
 
     private var contactsManager: OWSContactsManager {
-        return Environment.shared().contactsManager
+        return Environment.shared.contactsManager
     }
 
     // HACK: Though we don't have an input accessory view, the VC we are presented above (ConversationVC) does.

--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSContactShareButtonsView.m
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSContactShareButtonsView.m
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (self) {
         _delegate = delegate;
         _contactShare = contactShare;
-        _contactsManager = [Environment current].contactsManager;
+        _contactsManager = Environment.shared.contactsManager;
 
         [self createContents];
     }
@@ -74,7 +74,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     OWSAssertDebug(contactShare);
 
-    OWSContactsManager *contactsManager = [Environment current].contactsManager;
+    OWSContactsManager *contactsManager = Environment.shared.contactsManager;
 
     return [self hasAnyButton:contactShare contactsManager:contactsManager];
 }

--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSContactShareView.m
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSContactShareView.m
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
         _contactShare = contactShare;
         _isIncoming = isIncoming;
         _conversationStyle = conversationStyle;
-        _contactsManager = [Environment current].contactsManager;
+        _contactsManager = Environment.shared.contactsManager;
     }
 
     return self;

--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSQuotedMessageView.m
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSQuotedMessageView.m
@@ -493,7 +493,7 @@ const CGFloat kRemotelySourcedContentRowSpacing = 3;
                 @"QUOTED_REPLY_AUTHOR_INDICATOR_YOU", @"message header label when someone else is quoting you");
         }
     } else {
-        OWSContactsManager *contactsManager = Environment.current.contactsManager;
+        OWSContactsManager *contactsManager = Environment.shared.contactsManager;
         NSString *quotedAuthor = [contactsManager contactOrProfileNameForPhoneIdentifier:self.quotedMessage.authorId];
         quotedAuthorText = [NSString
             stringWithFormat:

--- a/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
@@ -275,9 +275,9 @@ typedef enum : NSUInteger {
 {
 
     _viewControllerCreatedAt = CACurrentMediaTime();
-    _contactsManager = [Environment current].contactsManager;
-    _contactsUpdater = [Environment current].contactsUpdater;
-    _messageSender = [Environment current].messageSender;
+    _contactsManager = Environment.shared.contactsManager;
+    _contactsUpdater = Environment.shared.contactsUpdater;
+    _messageSender = Environment.shared.messageSender;
     _outboundCallInitiator = SignalApp.sharedApp.outboundCallInitiator;
     _primaryStorage = [OWSPrimaryStorage sharedManager];
     _networkManager = [TSNetworkManager sharedManager];

--- a/Signal/src/ViewControllers/ConversationView/ConversationViewItem.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewItem.m
@@ -583,8 +583,8 @@ NSString *NSStringForOWSMessageCellType(OWSMessageCellType cellType)
                 OWSVerificationStateChangeMessage *verificationMessage
                     = (OWSVerificationStateChangeMessage *)infoMessage;
                 BOOL isVerified = verificationMessage.verificationState == OWSVerificationStateVerified;
-                NSString *displayName = [[Environment current].contactsManager
-                    displayNameForPhoneIdentifier:verificationMessage.recipientId];
+                NSString *displayName =
+                    [Environment.shared.contactsManager displayNameForPhoneIdentifier:verificationMessage.recipientId];
                 NSString *titleFormat = (isVerified
                         ? (verificationMessage.isLocalChange
                                   ? NSLocalizedString(@"VERIFICATION_STATE_CHANGE_FORMAT_VERIFIED_LOCAL",

--- a/Signal/src/ViewControllers/DebugUI/DebugUICalling.swift
+++ b/Signal/src/ViewControllers/DebugUI/DebugUICalling.swift
@@ -11,7 +11,7 @@ class DebugUICalling: DebugUIPage {
     // MARK: Dependencies
 
     var messageSender: MessageSender {
-        return Environment.current().messageSender
+        return Environment.shared().messageSender
     }
 
     // MARK: Overrides 

--- a/Signal/src/ViewControllers/DebugUI/DebugUICalling.swift
+++ b/Signal/src/ViewControllers/DebugUI/DebugUICalling.swift
@@ -11,7 +11,7 @@ class DebugUICalling: DebugUIPage {
     // MARK: Dependencies
 
     var messageSender: MessageSender {
-        return Environment.shared().messageSender
+        return Environment.shared.messageSender
     }
 
     // MARK: Overrides 

--- a/Signal/src/ViewControllers/DebugUI/DebugUIMessages.m
+++ b/Signal/src/ViewControllers/DebugUI/DebugUIMessages.m
@@ -242,7 +242,7 @@ NS_ASSUME_NONNULL_BEGIN
                   OWSSyncGroupsRequestMessage *syncGroupsRequestMessage =
                       [[OWSSyncGroupsRequestMessage alloc] initWithThread:thread
                                                                   groupId:[Randomness generateRandomBytes:16]];
-                  [[Environment current].messageSender enqueueMessage:syncGroupsRequestMessage
+                  [Environment.shared.messageSender enqueueMessage:syncGroupsRequestMessage
                       success:^{
                           OWSLogWarn(@"Successfully sent Request Group Info message.");
                       }
@@ -326,7 +326,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     NSString *randomText = [self randomText];
     NSString *text = [[[@(counter) description] stringByAppendingString:@" "] stringByAppendingString:randomText];
-    OWSMessageSender *messageSender = [Environment current].messageSender;
+    OWSMessageSender *messageSender = Environment.shared.messageSender;
     TSOutgoingMessage *message =
         [ThreadUtil sendMessageWithText:text inThread:thread quotedReplyModel:nil messageSender:messageSender];
     OWSLogError(@"sendTextMessageInThread timestamp: %llu.", message.timestamp);
@@ -364,7 +364,7 @@ NS_ASSUME_NONNULL_BEGIN
     OWSAssertDebug(filePath);
     OWSAssertDebug(thread);
 
-    OWSMessageSender *messageSender = [Environment current].messageSender;
+    OWSMessageSender *messageSender = Environment.shared.messageSender;
     NSString *filename = [filePath lastPathComponent];
     NSString *utiType = [MIMETypeUtil utiTypeForFileExtension:filename.pathExtension];
     DataSource *_Nullable dataSource = [DataSourcePath dataSourceWithFilePath:filePath shouldDeleteOnDeallocation:NO];
@@ -1743,7 +1743,7 @@ NS_ASSUME_NONNULL_BEGIN
     OWSAssertDebug(thread);
 
     SignalAttachment *attachment = [self signalAttachmentForFilePath:filePath];
-    OWSMessageSender *messageSender = [Environment current].messageSender;
+    OWSMessageSender *messageSender = Environment.shared.messageSender;
     [ThreadUtil sendMessageWithAttachment:attachment
                                  inThread:thread
                          quotedReplyModel:nil
@@ -3150,7 +3150,7 @@ typedef OWSContact * (^OWSContactBlock)(YapDatabaseReadWriteTransaction *transac
             ActionFailureBlock failure) {
             OWSContact *contact = contactBlock(transaction);
             OWSLogVerbose(@"sending contact: %@", contact.debugDescription);
-            OWSMessageSender *messageSender = [Environment current].messageSender;
+            OWSMessageSender *messageSender = Environment.shared.messageSender;
             [ThreadUtil sendMessageWithContactShare:contact inThread:thread messageSender:messageSender completion:nil];
 
             success();
@@ -3342,7 +3342,7 @@ typedef OWSContact * (^OWSContactBlock)(YapDatabaseReadWriteTransaction *transac
 
 + (void)sendOversizeTextMessage:(TSThread *)thread
 {
-    OWSMessageSender *messageSender = [Environment current].messageSender;
+    OWSMessageSender *messageSender = Environment.shared.messageSender;
     NSString *message = [self randomOversizeText];
     DataSource *_Nullable dataSource = [DataSourceValue dataSourceWithOversizeText:message];
     SignalAttachment *attachment =
@@ -3374,7 +3374,7 @@ typedef OWSContact * (^OWSContactBlock)(YapDatabaseReadWriteTransaction *transac
 
 + (void)sendRandomAttachment:(TSThread *)thread uti:(NSString *)uti length:(NSUInteger)length
 {
-    OWSMessageSender *messageSender = [Environment current].messageSender;
+    OWSMessageSender *messageSender = Environment.shared.messageSender;
     DataSource *_Nullable dataSource =
         [DataSourceValue dataSourceWithData:[self createRandomNSDataOfSize:length] utiType:uti];
     SignalAttachment *attachment =
@@ -3860,7 +3860,7 @@ typedef OWSContact * (^OWSContactBlock)(YapDatabaseReadWriteTransaction *transac
         [TSOutgoingMessage outgoingMessageInThread:thread groupMetaMessage:TSGroupMetaMessageNew expiresInSeconds:0];
     [message updateWithCustomMessage:NSLocalizedString(@"GROUP_CREATED", nil)];
 
-    OWSMessageSender *messageSender = [Environment current].messageSender;
+    OWSMessageSender *messageSender = Environment.shared.messageSender;
     void (^completion)(void) = ^{
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)1.f * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
             [ThreadUtil sendMessageWithText:[@(counter) description]
@@ -4401,7 +4401,7 @@ typedef OWSContact * (^OWSContactBlock)(YapDatabaseReadWriteTransaction *transac
         }
         NSString *filename = filenames.lastObject;
         [filenames removeLastObject];
-        OWSMessageSender *messageSender = [Environment current].messageSender;
+        OWSMessageSender *messageSender = Environment.shared.messageSender;
         NSString *utiType = (NSString *)kUTTypeData;
         const NSUInteger kDataLength = 32;
         DataSource *_Nullable dataSource =

--- a/Signal/src/ViewControllers/DebugUI/DebugUIMisc.m
+++ b/Signal/src/ViewControllers/DebugUI/DebugUIMisc.m
@@ -134,7 +134,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     [items addObject:[OWSTableItem itemWithTitle:@"Fetch system contacts"
                                      actionBlock:^() {
-                                         [Environment.current.contactsManager requestSystemContactsOnce];
+                                         [Environment.shared.contactsManager requestSystemContactsOnce];
                                      }]];
 
     return [OWSTableSection sectionWithTitle:self.name items:items];
@@ -149,7 +149,7 @@ NS_ASSUME_NONNULL_BEGIN
         return;
     }
 
-    [[Environment current].preferences unsetRecordedAPNSTokens];
+    [Environment.shared.preferences unsetRecordedAPNSTokens];
 
     RegistrationViewController *viewController = [RegistrationViewController new];
     OWSNavigationController *navigationController =
@@ -230,7 +230,7 @@ NS_ASSUME_NONNULL_BEGIN
         return;
     }
 
-    OWSMessageSender *messageSender = [Environment current].messageSender;
+    OWSMessageSender *messageSender = Environment.shared.messageSender;
     NSString *utiType = [MIMETypeUtil utiTypeForFileExtension:fileName.pathExtension];
     DataSource *_Nullable dataSource = [DataSourcePath dataSourceWithFilePath:filePath shouldDeleteOnDeallocation:YES];
     [dataSource setSourceFilename:fileName];
@@ -259,7 +259,7 @@ NS_ASSUME_NONNULL_BEGIN
         return;
     }
 
-    OWSMessageSender *messageSender = [Environment current].messageSender;
+    OWSMessageSender *messageSender = Environment.shared.messageSender;
     NSString *utiType = [MIMETypeUtil utiTypeForFileExtension:fileName.pathExtension];
     DataSource *_Nullable dataSource = [DataSourcePath dataSourceWithFilePath:filePath shouldDeleteOnDeallocation:YES];
     [dataSource setSourceFilename:fileName];

--- a/Signal/src/ViewControllers/DebugUI/DebugUINotifications.swift
+++ b/Signal/src/ViewControllers/DebugUI/DebugUINotifications.swift
@@ -17,10 +17,10 @@ class DebugUINotifications: DebugUIPage {
         return SignalApp.shared().callService.notificationsAdapter
     }
     var messageSender: MessageSender {
-        return Environment.shared().messageSender
+        return Environment.shared.messageSender
     }
     var contactsManager: OWSContactsManager {
-        return Environment.shared().contactsManager
+        return Environment.shared.contactsManager
     }
 
     // MARK: Overrides

--- a/Signal/src/ViewControllers/DebugUI/DebugUINotifications.swift
+++ b/Signal/src/ViewControllers/DebugUI/DebugUINotifications.swift
@@ -17,10 +17,10 @@ class DebugUINotifications: DebugUIPage {
         return SignalApp.shared().callService.notificationsAdapter
     }
     var messageSender: MessageSender {
-        return Environment.current().messageSender
+        return Environment.shared().messageSender
     }
     var contactsManager: OWSContactsManager {
-        return Environment.current().contactsManager
+        return Environment.shared().contactsManager
     }
 
     // MARK: Overrides

--- a/Signal/src/ViewControllers/DebugUI/DebugUIProfile.swift
+++ b/Signal/src/ViewControllers/DebugUI/DebugUIProfile.swift
@@ -11,7 +11,7 @@ class DebugUIProfile: DebugUIPage {
     // MARK: Dependencies
 
     var messageSender: MessageSender {
-        return Environment.current().messageSender
+        return Environment.shared().messageSender
     }
     var profileManager: OWSProfileManager {
         return OWSProfileManager.shared()

--- a/Signal/src/ViewControllers/DebugUI/DebugUIProfile.swift
+++ b/Signal/src/ViewControllers/DebugUI/DebugUIProfile.swift
@@ -11,7 +11,7 @@ class DebugUIProfile: DebugUIPage {
     // MARK: Dependencies
 
     var messageSender: MessageSender {
-        return Environment.shared().messageSender
+        return Environment.shared.messageSender
     }
     var profileManager: OWSProfileManager {
         return OWSProfileManager.shared()

--- a/Signal/src/ViewControllers/DebugUI/DebugUISessionState.m
+++ b/Signal/src/ViewControllers/DebugUI/DebugUISessionState.m
@@ -70,7 +70,7 @@ NS_ASSUME_NONNULL_BEGIN
             [OWSTableItem itemWithTitle:@"Send session reset"
                             actionBlock:^{
                                 [OWSSessionResetJob runWithContactThread:thread
-                                                           messageSender:[Environment current].messageSender
+                                                           messageSender:Environment.shared.messageSender
                                                           primaryStorage:[OWSPrimaryStorage sharedManager]];
                             }],
         ]];

--- a/Signal/src/ViewControllers/DebugUI/DebugUIStress.m
+++ b/Signal/src/ViewControllers/DebugUI/DebugUIStress.m
@@ -471,7 +471,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     OWSAssertDebug(message);
 
-    OWSMessageSender *messageSender = [Environment current].messageSender;
+    OWSMessageSender *messageSender = Environment.shared.messageSender;
     [messageSender enqueueMessage:message
         success:^{
             OWSLogInfo(@"Successfully sent message.");

--- a/Signal/src/ViewControllers/DebugUI/DebugUISyncMessages.m
+++ b/Signal/src/ViewControllers/DebugUI/DebugUISyncMessages.m
@@ -64,12 +64,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (OWSMessageSender *)messageSender
 {
-    return [Environment current].messageSender;
+    return Environment.shared.messageSender;
 }
 
 + (OWSContactsManager *)contactsManager
 {
-    return [Environment current].contactsManager;
+    return Environment.shared.contactsManager;
 }
 
 + (OWSIdentityManager *)identityManager

--- a/Signal/src/ViewControllers/HomeView/ConversationSearchViewController.swift
+++ b/Signal/src/ViewControllers/HomeView/ConversationSearchViewController.swift
@@ -36,7 +36,7 @@ class ConversationSearchViewController: UITableViewController {
     }
 
     private var contactsManager: OWSContactsManager {
-        return Environment.current().contactsManager
+        return Environment.shared().contactsManager
     }
 
     enum SearchSection: Int {

--- a/Signal/src/ViewControllers/HomeView/ConversationSearchViewController.swift
+++ b/Signal/src/ViewControllers/HomeView/ConversationSearchViewController.swift
@@ -36,7 +36,7 @@ class ConversationSearchViewController: UITableViewController {
     }
 
     private var contactsManager: OWSContactsManager {
-        return Environment.shared().contactsManager
+        return Environment.shared.contactsManager
     }
 
     enum SearchSection: Int {

--- a/Signal/src/ViewControllers/HomeView/HomeViewController.m
+++ b/Signal/src/ViewControllers/HomeView/HomeViewController.m
@@ -146,8 +146,8 @@ NSString *const kArchivedConversationsReuseIdentifier = @"kArchivedConversations
 - (void)commonInit
 {
     _accountManager = SignalApp.sharedApp.accountManager;
-    _contactsManager = [Environment current].contactsManager;
-    _messageSender = [Environment current].messageSender;
+    _contactsManager = Environment.shared.contactsManager;
+    _messageSender = Environment.shared.messageSender;
     _blockingManager = [OWSBlockingManager sharedManager];
     _blockedPhoneNumberSet = [NSSet setWithArray:[_blockingManager blockedPhoneNumbers]];
     _threadViewModelCache = [NSCache new];

--- a/Signal/src/ViewControllers/MediaPageViewController.swift
+++ b/Signal/src/ViewControllers/MediaPageViewController.swift
@@ -562,7 +562,7 @@ class MediaPageViewController: UIPageViewController, UIPageViewControllerDataSou
     // MARK: Dynamic Header
 
     private var contactsManager: OWSContactsManager {
-        return Environment.shared().contactsManager
+        return Environment.shared.contactsManager
     }
 
     private func senderName(message: TSMessage) -> String {

--- a/Signal/src/ViewControllers/MediaPageViewController.swift
+++ b/Signal/src/ViewControllers/MediaPageViewController.swift
@@ -562,7 +562,7 @@ class MediaPageViewController: UIPageViewController, UIPageViewControllerDataSou
     // MARK: Dynamic Header
 
     private var contactsManager: OWSContactsManager {
-        return Environment.current().contactsManager
+        return Environment.shared().contactsManager
     }
 
     private func senderName(message: TSMessage) -> String {

--- a/Signal/src/ViewControllers/MessageDetailViewController.swift
+++ b/Signal/src/ViewControllers/MessageDetailViewController.swift
@@ -52,7 +52,7 @@ class MessageDetailViewController: OWSViewController, MediaGalleryDataSourceDele
 
     @objc
     required init(viewItem: ConversationViewItem, message: TSMessage, thread: TSThread, mode: MessageMetadataViewMode) {
-        self.contactsManager = Environment.shared().contactsManager
+        self.contactsManager = Environment.shared.contactsManager
         self.viewItem = viewItem
         self.message = message
         self.mode = mode
@@ -191,7 +191,7 @@ class MessageDetailViewController: OWSViewController, MediaGalleryDataSourceDele
         }
 
         var rows = [UIView]()
-        let contactsManager = Environment.shared().contactsManager!
+        let contactsManager = Environment.shared.contactsManager!
 
         // Content
         rows += contentRows()

--- a/Signal/src/ViewControllers/MessageDetailViewController.swift
+++ b/Signal/src/ViewControllers/MessageDetailViewController.swift
@@ -52,7 +52,7 @@ class MessageDetailViewController: OWSViewController, MediaGalleryDataSourceDele
 
     @objc
     required init(viewItem: ConversationViewItem, message: TSMessage, thread: TSThread, mode: MessageMetadataViewMode) {
-        self.contactsManager = Environment.current().contactsManager
+        self.contactsManager = Environment.shared().contactsManager
         self.viewItem = viewItem
         self.message = message
         self.mode = mode
@@ -191,7 +191,7 @@ class MessageDetailViewController: OWSViewController, MediaGalleryDataSourceDele
         }
 
         var rows = [UIView]()
-        let contactsManager = Environment.current().contactsManager!
+        let contactsManager = Environment.shared().contactsManager!
 
         // Content
         rows += contentRows()

--- a/Signal/src/ViewControllers/NewContactThreadViewController.m
+++ b/Signal/src/ViewControllers/NewContactThreadViewController.m
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSString *)stringForCollation
 {
-    OWSContactsManager *contactsManager = [Environment current].contactsManager;
+    OWSContactsManager *contactsManager = Environment.shared.contactsManager;
     return [contactsManager comparableNameForSignalAccount:self];
 }
 

--- a/Signal/src/ViewControllers/NewGroupViewController.m
+++ b/Signal/src/ViewControllers/NewGroupViewController.m
@@ -86,7 +86,7 @@ const NSUInteger kNewGroupViewControllerAvatarWidth = 68;
 
 - (void)commonInit
 {
-    _messageSender = [Environment current].messageSender;
+    _messageSender = Environment.shared.messageSender;
     _contactsViewHelper = [[ContactsViewHelper alloc] initWithDelegate:self];
     _avatarViewHelper = [AvatarViewHelper new];
     _avatarViewHelper.delegate = self;

--- a/Signal/src/ViewControllers/ThreadSettings/FingerprintViewController.m
+++ b/Signal/src/ViewControllers/ThreadSettings/FingerprintViewController.m
@@ -144,7 +144,7 @@ typedef void (^CustomLayoutBlock)(void);
 
     self.recipientId = recipientId;
 
-    OWSContactsManager *contactsManager = [Environment current].contactsManager;
+    OWSContactsManager *contactsManager = Environment.shared.contactsManager;
     self.contactName = [contactsManager displayNameForPhoneIdentifier:recipientId];
 
     OWSRecipientIdentity *_Nullable recipientIdentity =

--- a/Signal/src/ViewControllers/ThreadSettings/FingerprintViewScanController.m
+++ b/Signal/src/ViewControllers/ThreadSettings/FingerprintViewScanController.m
@@ -41,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
     self.recipientId = recipientId;
     self.accountManager = [TSAccountManager sharedInstance];
 
-    OWSContactsManager *contactsManager = [Environment current].contactsManager;
+    OWSContactsManager *contactsManager = Environment.shared.contactsManager;
     self.contactName = [contactsManager displayNameForPhoneIdentifier:recipientId];
 
     OWSRecipientIdentity *_Nullable recipientIdentity =

--- a/Signal/src/ViewControllers/ThreadSettings/OWSAddToContactViewController.m
+++ b/Signal/src/ViewControllers/ThreadSettings/OWSAddToContactViewController.m
@@ -63,7 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)commonInit
 {
-    _contactsManager = [Environment current].contactsManager;
+    _contactsManager = Environment.shared.contactsManager;
     _contactsViewHelper = [[ContactsViewHelper alloc] initWithDelegate:self];
 }
 

--- a/Signal/src/ViewControllers/ThreadSettings/OWSConversationSettingsViewController.m
+++ b/Signal/src/ViewControllers/ThreadSettings/OWSConversationSettingsViewController.m
@@ -103,8 +103,8 @@ const CGFloat kIconViewLength = 24;
 - (void)commonInit
 {
     _accountManager = [TSAccountManager sharedInstance];
-    _contactsManager = [Environment current].contactsManager;
-    _messageSender = [Environment current].messageSender;
+    _contactsManager = Environment.shared.contactsManager;
+    _messageSender = Environment.shared.messageSender;
     _blockingManager = [OWSBlockingManager sharedManager];
     _contactsViewHelper = [[ContactsViewHelper alloc] initWithDelegate:self];
 

--- a/Signal/src/ViewControllers/ThreadSettings/UpdateGroupViewController.m
+++ b/Signal/src/ViewControllers/ThreadSettings/UpdateGroupViewController.m
@@ -83,7 +83,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)commonInit
 {
-    _messageSender = [Environment current].messageSender;
+    _messageSender = Environment.shared.messageSender;
     _contactsViewHelper = [[ContactsViewHelper alloc] initWithDelegate:self];
     _avatarViewHelper = [AvatarViewHelper new];
     _avatarViewHelper.delegate = self;

--- a/Signal/src/call/CallService.swift
+++ b/Signal/src/call/CallService.swift
@@ -390,7 +390,7 @@ private class SignalCallData: NSObject {
                 throw CallError.assertionError(description: errorDescription)
             }
 
-            let useTurnOnly = Environment.current().preferences.doCallsHideIPAddress()
+            let useTurnOnly = Environment.shared().preferences.doCallsHideIPAddress()
 
             let peerConnectionClient = PeerConnectionClient(iceServers: iceServers, delegate: self, callDirection: .outgoing, useTurnOnly: useTurnOnly)
             Logger.debug("setting peerConnectionClient for call: \(call.identifiersForLogs)")
@@ -697,7 +697,7 @@ private class SignalCallData: NSObject {
             // a TURN connection, so as not to reveal any connectivity information (IP/port) to the caller.
             let isUnknownCaller = !self.contactsManager.hasSignalAccount(forRecipientId: thread.contactIdentifier())
 
-            let useTurnOnly = isUnknownCaller || Environment.current().preferences.doCallsHideIPAddress()
+            let useTurnOnly = isUnknownCaller || Environment.shared().preferences.doCallsHideIPAddress()
 
             Logger.debug("setting peerConnectionClient for: \(newCall.identifiersForLogs)")
             let peerConnectionClient = PeerConnectionClient(iceServers: iceServers, delegate: self, callDirection: .incoming, useTurnOnly: useTurnOnly)

--- a/Signal/src/call/CallService.swift
+++ b/Signal/src/call/CallService.swift
@@ -390,7 +390,7 @@ private class SignalCallData: NSObject {
                 throw CallError.assertionError(description: errorDescription)
             }
 
-            let useTurnOnly = Environment.shared().preferences.doCallsHideIPAddress()
+            let useTurnOnly = Environment.shared.preferences.doCallsHideIPAddress()
 
             let peerConnectionClient = PeerConnectionClient(iceServers: iceServers, delegate: self, callDirection: .outgoing, useTurnOnly: useTurnOnly)
             Logger.debug("setting peerConnectionClient for call: \(call.identifiersForLogs)")
@@ -697,7 +697,7 @@ private class SignalCallData: NSObject {
             // a TURN connection, so as not to reveal any connectivity information (IP/port) to the caller.
             let isUnknownCaller = !self.contactsManager.hasSignalAccount(forRecipientId: thread.contactIdentifier())
 
-            let useTurnOnly = isUnknownCaller || Environment.shared().preferences.doCallsHideIPAddress()
+            let useTurnOnly = isUnknownCaller || Environment.shared.preferences.doCallsHideIPAddress()
 
             Logger.debug("setting peerConnectionClient for: \(newCall.identifiersForLogs)")
             let peerConnectionClient = PeerConnectionClient(iceServers: iceServers, delegate: self, callDirection: .incoming, useTurnOnly: useTurnOnly)

--- a/Signal/src/call/UserInterface/CallUIAdapter.swift
+++ b/Signal/src/call/UserInterface/CallUIAdapter.swift
@@ -106,7 +106,7 @@ extension CallUIAdaptee {
             let useSystemCallLog = Environment.preferences().isSystemCallLogEnabled()
 
             adaptee = CallKitCallUIAdaptee(callService: callService, contactsManager: contactsManager, notificationsAdapter: notificationsAdapter, showNamesOnCallScreen: showNames, useSystemCallLog: useSystemCallLog)
-        } else if #available(iOS 10.0, *), Environment.current().preferences.isCallKitEnabled() {
+        } else if #available(iOS 10.0, *), Environment.shared().preferences.isCallKitEnabled() {
             Logger.info("choosing callkit adaptee for iOS10")
             let hideNames = Environment.preferences().isCallKitPrivacyEnabled() || Environment.preferences().notificationPreviewType() == .noNameNoPreview
             let showNames = !hideNames

--- a/Signal/src/call/UserInterface/CallUIAdapter.swift
+++ b/Signal/src/call/UserInterface/CallUIAdapter.swift
@@ -106,7 +106,7 @@ extension CallUIAdaptee {
             let useSystemCallLog = Environment.preferences().isSystemCallLogEnabled()
 
             adaptee = CallKitCallUIAdaptee(callService: callService, contactsManager: contactsManager, notificationsAdapter: notificationsAdapter, showNamesOnCallScreen: showNames, useSystemCallLog: useSystemCallLog)
-        } else if #available(iOS 10.0, *), Environment.shared().preferences.isCallKitEnabled() {
+        } else if #available(iOS 10.0, *), Environment.shared.preferences.isCallKitEnabled() {
             Logger.info("choosing callkit adaptee for iOS10")
             let hideNames = Environment.preferences().isCallKitPrivacyEnabled() || Environment.preferences().notificationPreviewType() == .noNameNoPreview
             let showNames = !hideNames

--- a/Signal/src/environment/NotificationsManager.m
+++ b/Signal/src/environment/NotificationsManager.m
@@ -12,11 +12,11 @@
 #import <SignalMessaging/OWSPreferences.h>
 #import <SignalMessaging/OWSSounds.h>
 #import <SignalServiceKit/NSString+SSK.h>
+#import <SignalServiceKit/SSKEnvironment.h>
 #import <SignalServiceKit/TSCall.h>
 #import <SignalServiceKit/TSContactThread.h>
 #import <SignalServiceKit/TSErrorMessage.h>
 #import <SignalServiceKit/TSIncomingMessage.h>
-#import <SignalServiceKit/TextSecureKitEnv.h>
 #import <SignalServiceKit/Threading.h>
 #import <YapDatabase/YapDatabaseTransaction.h>
 

--- a/Signal/src/environment/NotificationsManager.m
+++ b/Signal/src/environment/NotificationsManager.m
@@ -439,7 +439,7 @@
 
 - (NotificationType)notificationPreviewType
 {
-    OWSPreferences *prefs = [Environment current].preferences;
+    OWSPreferences *prefs = Environment.shared.preferences;
     return prefs.notificationPreviewType;
 }
 

--- a/Signal/src/environment/SignalApp.m
+++ b/Signal/src/environment/SignalApp.m
@@ -63,7 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
             _callMessageHandler =
                 [[OWSWebRTCCallMessageHandler alloc] initWithAccountManager:self.accountManager
                                                                 callService:self.callService
-                                                              messageSender:Environment.current.messageSender];
+                                                              messageSender:Environment.shared.messageSender];
         }
     }
 
@@ -76,13 +76,13 @@ NS_ASSUME_NONNULL_BEGIN
     {
         if (!_callService) {
             OWSAssertDebug(self.accountManager);
-            OWSAssertDebug(Environment.current.contactsManager);
-            OWSAssertDebug(Environment.current.messageSender);
+            OWSAssertDebug(Environment.shared.contactsManager);
+            OWSAssertDebug(Environment.shared.messageSender);
             [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didChangeCallLoggingPreference:) name:OWSPreferencesCallLoggingDidChangeNotification object:nil];
-            
+
             _callService = [[CallService alloc] initWithAccountManager:self.accountManager
-                                                       contactsManager:Environment.current.contactsManager
-                                                         messageSender:Environment.current.messageSender
+                                                       contactsManager:Environment.shared.contactsManager
+                                                         messageSender:Environment.shared.messageSender
                                                   notificationsAdapter:[OWSCallNotificationsAdapter new]];
         }
     }
@@ -100,11 +100,11 @@ NS_ASSUME_NONNULL_BEGIN
     @synchronized(self)
     {
         if (!_outboundCallInitiator) {
-            OWSAssertDebug(Environment.current.contactsManager);
-            OWSAssertDebug(Environment.current.contactsUpdater);
+            OWSAssertDebug(Environment.shared.contactsManager);
+            OWSAssertDebug(Environment.shared.contactsUpdater);
             _outboundCallInitiator =
-                [[OutboundCallInitiator alloc] initWithContactsManager:Environment.current.contactsManager
-                                                       contactsUpdater:Environment.current.contactsUpdater];
+                [[OutboundCallInitiator alloc] initWithContactsManager:Environment.shared.contactsManager
+                                                       contactsUpdater:Environment.shared.contactsUpdater];
         }
     }
 
@@ -118,7 +118,7 @@ NS_ASSUME_NONNULL_BEGIN
         if (!_messageFetcherJob) {
             _messageFetcherJob =
                 [[OWSMessageFetcherJob alloc] initWithMessageReceiver:[OWSMessageReceiver sharedInstance]
-                                                       networkManager:Environment.current.networkManager
+                                                       networkManager:Environment.shared.networkManager
                                                         signalService:[OWSSignalService sharedInstance]];
         }
     }
@@ -143,7 +143,7 @@ NS_ASSUME_NONNULL_BEGIN
     {
         if (!_accountManager) {
             _accountManager = [[AccountManager alloc] initWithTextSecureAccountManager:[TSAccountManager sharedInstance]
-                                                                           preferences:Environment.current.preferences];
+                                                                           preferences:Environment.shared.preferences];
         }
     }
 

--- a/Signal/src/network/PushManager.m
+++ b/Signal/src/network/PushManager.m
@@ -57,7 +57,7 @@ NSString *const Signal_Message_MarkAsRead_Identifier = @"Signal_Message_MarkAsRe
 {
     return [self initWithMessageFetcherJob:SignalApp.sharedApp.messageFetcherJob
                             primaryStorage:[OWSPrimaryStorage sharedManager]
-                             messageSender:[Environment current].messageSender
+                             messageSender:Environment.shared.messageSender
                       notificationsManager:SignalApp.sharedApp.notificationsManager];
 }
 

--- a/Signal/src/util/MainAppContext.m
+++ b/Signal/src/util/MainAppContext.m
@@ -226,7 +226,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     [MultiDeviceProfileKeyUpdateJob runWithProfileKey:profileKey
                                       identityManager:OWSIdentityManager.sharedManager
-                                        messageSender:Environment.current.messageSender
+                                        messageSender:Environment.shared.messageSender
                                        profileManager:OWSProfileManager.sharedManager];
 }
 

--- a/Signal/src/util/Pastelog.m
+++ b/Signal/src/util/Pastelog.m
@@ -520,7 +520,7 @@ typedef void (^DebugLogUploadFailure)(DebugLogUploader *uploader, NSError *error
         return;
     }
     NSString *recipientId = [TSAccountManager localNumber];
-    OWSMessageSender *messageSender = Environment.current.messageSender;
+    OWSMessageSender *messageSender = Environment.shared.messageSender;
 
     DispatchMainThreadSafe(^{
         __block TSThread *thread = nil;
@@ -549,7 +549,7 @@ typedef void (^DebugLogUploadFailure)(DebugLogUploader *uploader, NSError *error
     }];
     DispatchMainThreadSafe(^{
         if (thread) {
-            OWSMessageSender *messageSender = Environment.current.messageSender;
+            OWSMessageSender *messageSender = Environment.shared.messageSender;
             [ThreadUtil sendMessageWithText:url.absoluteString
                                    inThread:thread
                            quotedReplyModel:nil

--- a/Signal/src/util/RegistrationUtils.m
+++ b/Signal/src/util/RegistrationUtils.m
@@ -41,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
         return;
     }
 
-    [[Environment current].preferences unsetRecordedAPNSTokens];
+    [Environment.shared.preferences unsetRecordedAPNSTokens];
 
     [ModalActivityIndicatorViewController
         presentFromViewController:fromViewController

--- a/Signal/test/util/SearcherTest.swift
+++ b/Signal/test/util/SearcherTest.swift
@@ -118,7 +118,7 @@ class ConversationSearcherTest: XCTestCase {
         TSGroupThread.removeAllObjectsInCollection()
         TSMessage.removeAllObjectsInCollection()
 
-        originalEnvironment = SSKEnvironment.shared()
+        originalEnvironment = SSKEnvironment.shared
         assert(originalEnvironment != nil)
 
         let testEnvironment: StubbableEnvironment = StubbableEnvironment(proxy: originalEnvironment!)
@@ -375,7 +375,7 @@ class ConversationSearcherTest: XCTestCase {
     private func getResultSet(searchText: String) -> SearchResultSet {
         var results: SearchResultSet!
         self.dbConnection.read { transaction in
-            results = self.searcher.results(searchText: searchText, transaction: transaction, contactsManager: SSKEnvironment.shared().contactsManager)
+            results = self.searcher.results(searchText: searchText, transaction: transaction, contactsManager: SSKEnvironment.shared.contactsManager)
         }
         return results
     }

--- a/Signal/test/util/SearcherTest.swift
+++ b/Signal/test/util/SearcherTest.swift
@@ -7,10 +7,10 @@ import XCTest
 @testable import SignalMessaging
 
 @objc
-class StubbableEnvironment: TextSecureKitEnv {
-    let proxy: TextSecureKitEnv
+class StubbableEnvironment: SSKEnvironment {
+    let proxy: SSKEnvironment
 
-    init(proxy: TextSecureKitEnv) {
+    init(proxy: SSKEnvironment) {
         self.proxy = proxy
         super.init(callMessageHandler: proxy.callMessageHandler, contactsManager: proxy.contactsManager, messageSender: proxy.messageSender, notificationsManager: proxy.notificationsManager, profileManager: proxy.profileManager)
     }
@@ -101,12 +101,12 @@ class ConversationSearcherTest: XCTestCase {
 
     // MARK: - Test Life Cycle
 
-    var originalEnvironment: TextSecureKitEnv?
+    var originalEnvironment: SSKEnvironment?
 
     override func tearDown() {
         super.tearDown()
 
-        TextSecureKitEnv.setShared(originalEnvironment!)
+        SSKEnvironment.setShared(originalEnvironment!)
     }
 
     override func setUp() {
@@ -118,12 +118,12 @@ class ConversationSearcherTest: XCTestCase {
         TSGroupThread.removeAllObjectsInCollection()
         TSMessage.removeAllObjectsInCollection()
 
-        originalEnvironment = TextSecureKitEnv.shared()
+        originalEnvironment = SSKEnvironment.shared()
         assert(originalEnvironment != nil)
 
         let testEnvironment: StubbableEnvironment = StubbableEnvironment(proxy: originalEnvironment!)
         testEnvironment.stubbedContactsManager = FakeContactsManager()
-        TextSecureKitEnv.setShared(testEnvironment)
+        SSKEnvironment.setShared(testEnvironment)
 
         self.dbConnection.readWrite { transaction in
             let bookModel = TSGroupModel(title: "Book Club", memberIds: [aliceRecipientId, bobRecipientId], image: nil, groupId: Randomness.generateRandomBytes(16))
@@ -375,7 +375,7 @@ class ConversationSearcherTest: XCTestCase {
     private func getResultSet(searchText: String) -> SearchResultSet {
         var results: SearchResultSet!
         self.dbConnection.read { transaction in
-            results = self.searcher.results(searchText: searchText, transaction: transaction, contactsManager: TextSecureKitEnv.shared().contactsManager)
+            results = self.searcher.results(searchText: searchText, transaction: transaction, contactsManager: SSKEnvironment.shared().contactsManager)
         }
         return results
     }

--- a/SignalMessaging/ViewControllers/SharingThreadPickerViewController.m
+++ b/SignalMessaging/ViewControllers/SharingThreadPickerViewController.m
@@ -58,8 +58,8 @@ typedef void (^SendMessageBlock)(SendCompletionBlock completion);
 {
     [super loadView];
 
-    _contactsManager = [Environment current].contactsManager;
-    _messageSender = [Environment current].messageSender;
+    _contactsManager = Environment.shared.contactsManager;
+    _messageSender = Environment.shared.messageSender;
 
     _progressView = [[UIProgressView alloc] initWithProgressViewStyle:UIProgressViewStyleDefault];
     self.title = NSLocalizedString(@"SHARE_EXTENSION_VIEW_TITLE", @"Title for the 'share extension' view.");

--- a/SignalMessaging/Views/ContactsViewHelper.m
+++ b/SignalMessaging/Views/ContactsViewHelper.m
@@ -54,7 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
     _blockedPhoneNumbers = [_blockingManager blockedPhoneNumbers];
     _conversationSearcher = ConversationSearcher.shared;
 
-    _contactsManager = [Environment current].contactsManager;
+    _contactsManager = Environment.shared.contactsManager;
     _profileManager = [OWSProfileManager sharedManager];
 
     // We don't want to notify the delegate in the `updateContacts`.

--- a/SignalMessaging/contacts/OWSContactsSyncing.m
+++ b/SignalMessaging/contacts/OWSContactsSyncing.m
@@ -47,9 +47,9 @@ NSString *const kOWSPrimaryStorageOWSContactsSyncingLastMessageKey
 
 - (instancetype)initDefault
 {
-    return [self initWithContactsManager:Environment.current.contactsManager
+    return [self initWithContactsManager:Environment.shared.contactsManager
                          identityManager:OWSIdentityManager.sharedManager
-                           messageSender:Environment.current.messageSender
+                           messageSender:Environment.shared.messageSender
                           profileManager:OWSProfileManager.sharedManager];
 }
 

--- a/SignalMessaging/environment/AppSetup.m
+++ b/SignalMessaging/environment/AppSetup.m
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
         // Order matters here.
         [[OWSBackgroundTaskManager sharedManager] observeNotifications];
 
-        [Environment setCurrent:[Release releaseEnvironment]];
+        [Environment setShared:[Release releaseEnvironment]];
 
         id<OWSCallMessageHandler> callMessageHandler = callMessageHandlerBlock();
         id<NotificationsProtocol> notificationsManager = notificationsManagerBlock();

--- a/SignalMessaging/environment/AppSetup.m
+++ b/SignalMessaging/environment/AppSetup.m
@@ -12,7 +12,7 @@
 #import <SignalMessaging/SignalMessaging-Swift.h>
 #import <SignalServiceKit/OWSBackgroundTask.h>
 #import <SignalServiceKit/OWSStorage.h>
-#import <SignalServiceKit/TextSecureKitEnv.h>
+#import <SignalServiceKit/SSKEnvironment.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -39,13 +39,13 @@ NS_ASSUME_NONNULL_BEGIN
         id<OWSCallMessageHandler> callMessageHandler = callMessageHandlerBlock();
         id<NotificationsProtocol> notificationsManager = notificationsManagerBlock();
 
-        TextSecureKitEnv *sharedEnv =
-            [[TextSecureKitEnv alloc] initWithCallMessageHandler:callMessageHandler
-                                                 contactsManager:[Environment current].contactsManager
-                                                   messageSender:[Environment current].messageSender
-                                            notificationsManager:notificationsManager
-                                                  profileManager:OWSProfileManager.sharedManager];
-        [TextSecureKitEnv setSharedEnv:sharedEnv];
+        SSKEnvironment *sharedEnv =
+            [[SSKEnvironment alloc] initWithCallMessageHandler:callMessageHandler
+                                               contactsManager:[Environment current].contactsManager
+                                                 messageSender:[Environment current].messageSender
+                                          notificationsManager:notificationsManager
+                                                profileManager:OWSProfileManager.sharedManager];
+        [SSKEnvironment setSharedEnv:sharedEnv];
 
         // Register renamed classes.
         [NSKeyedUnarchiver setClass:[OWSUserProfile class] forClassName:[OWSUserProfile collection]];

--- a/SignalMessaging/environment/AppSetup.m
+++ b/SignalMessaging/environment/AppSetup.m
@@ -39,13 +39,12 @@ NS_ASSUME_NONNULL_BEGIN
         id<OWSCallMessageHandler> callMessageHandler = callMessageHandlerBlock();
         id<NotificationsProtocol> notificationsManager = notificationsManagerBlock();
 
-        SSKEnvironment *sharedEnv =
-            [[SSKEnvironment alloc] initWithCallMessageHandler:callMessageHandler
-                                               contactsManager:[Environment current].contactsManager
-                                                 messageSender:[Environment current].messageSender
-                                          notificationsManager:notificationsManager
-                                                profileManager:OWSProfileManager.sharedManager];
-        [SSKEnvironment setSharedEnv:sharedEnv];
+        SSKEnvironment *shared = [[SSKEnvironment alloc] initWithCallMessageHandler:callMessageHandler
+                                                                    contactsManager:Environment.shared.contactsManager
+                                                                      messageSender:Environment.shared.messageSender
+                                                               notificationsManager:notificationsManager
+                                                                     profileManager:OWSProfileManager.sharedManager];
+        [SSKEnvironment setShared:shared];
 
         // Register renamed classes.
         [NSKeyedUnarchiver setClass:[OWSUserProfile class] forClassName:[OWSUserProfile collection]];

--- a/SignalMessaging/environment/Environment.h
+++ b/SignalMessaging/environment/Environment.h
@@ -34,8 +34,9 @@
 @property (nonatomic, readonly) OWSMessageSender *messageSender;
 @property (nonatomic, readonly) OWSPreferences *preferences;
 
-+ (Environment *)current;
-+ (void)setCurrent:(Environment *)environment;
+@property (class, readonly, nonatomic) Environment *shared;
+
++ (void)setShared:(Environment *)environment;
 // Should only be called by tests.
 + (void)clearCurrentForTests;
 

--- a/SignalMessaging/environment/Environment.h
+++ b/SignalMessaging/environment/Environment.h
@@ -34,9 +34,8 @@
 @property (nonatomic, readonly) OWSMessageSender *messageSender;
 @property (nonatomic, readonly) OWSPreferences *preferences;
 
-@property (class, readonly, nonatomic) Environment *shared;
+@property (class, nonatomic) Environment *shared;
 
-+ (void)setShared:(Environment *)environment;
 // Should only be called by tests.
 + (void)clearCurrentForTests;
 

--- a/SignalMessaging/environment/Environment.m
+++ b/SignalMessaging/environment/Environment.m
@@ -29,14 +29,14 @@ static Environment *sharedEnvironment = nil;
 
 @implementation Environment
 
-+ (Environment *)current
++ (Environment *)shared
 {
     OWSAssertDebug(sharedEnvironment);
 
     return sharedEnvironment;
 }
 
-+ (void)setCurrent:(Environment *)environment
++ (void)setShared:(Environment *)environment
 {
     // The main app environment should only be set once.
     //
@@ -103,9 +103,9 @@ static Environment *sharedEnvironment = nil;
 
 + (OWSPreferences *)preferences
 {
-    OWSAssertDebug([Environment current].preferences);
+    OWSAssertDebug(Environment.shared.preferences);
 
-    return [Environment current].preferences;
+    return Environment.shared.preferences;
 }
 
 // TODO: Convert to singleton?

--- a/SignalMessaging/environment/VersionMigrations.m
+++ b/SignalMessaging/environment/VersionMigrations.m
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     // performUpdateCheck must be invoked after Environment has been initialized because
     // upgrade process may depend on Environment.
-    OWSAssertDebug([Environment current]);
+    OWSAssertDebug(Environment.shared);
     OWSAssertDebug(completion);
 
     NSString *previousVersion = AppVersion.sharedInstance.lastAppVersion;

--- a/SignalMessaging/environment/migrations/OWS106EnsureProfileComplete.swift
+++ b/SignalMessaging/environment/migrations/OWS106EnsureProfileComplete.swift
@@ -88,7 +88,7 @@ public class OWS106EnsureProfileComplete: OWSDatabaseMigration {
 
             let (promise, fulfill, reject) = Promise<Void>.pending()
 
-            guard let networkManager = Environment.shared().networkManager else {
+            guard let networkManager = Environment.shared.networkManager else {
                 return Promise(error: OWSErrorMakeAssertionError("network manager was unexpectedly not set"))
             }
 

--- a/SignalMessaging/environment/migrations/OWS106EnsureProfileComplete.swift
+++ b/SignalMessaging/environment/migrations/OWS106EnsureProfileComplete.swift
@@ -88,7 +88,7 @@ public class OWS106EnsureProfileComplete: OWSDatabaseMigration {
 
             let (promise, fulfill, reject) = Promise<Void>.pending()
 
-            guard let networkManager = Environment.current().networkManager else {
+            guard let networkManager = Environment.shared().networkManager else {
                 return Promise(error: OWSErrorMakeAssertionError("network manager was unexpectedly not set"))
             }
 

--- a/SignalMessaging/profiles/OWSProfileManager.m
+++ b/SignalMessaging/profiles/OWSProfileManager.m
@@ -79,8 +79,8 @@ const NSUInteger kOWSProfileManager_MaxAvatarDiameter = 640;
 - (instancetype)initDefault
 {
     OWSPrimaryStorage *primaryStorage = [OWSPrimaryStorage sharedManager];
-    OWSMessageSender *messageSender = [Environment current].messageSender;
-    TSNetworkManager *networkManager = [Environment current].networkManager;
+    OWSMessageSender *messageSender = Environment.shared.messageSender;
+    TSNetworkManager *networkManager = Environment.shared.networkManager;
 
     return [self initWithPrimaryStorage:primaryStorage messageSender:messageSender networkManager:networkManager];
 }

--- a/SignalMessaging/profiles/OWSProfileManager.m
+++ b/SignalMessaging/profiles/OWSProfileManager.m
@@ -20,12 +20,12 @@
 #import <SignalServiceKit/OWSProfileKeyMessage.h>
 #import <SignalServiceKit/OWSRequestBuilder.h>
 #import <SignalServiceKit/OWSSignalService.h>
+#import <SignalServiceKit/SSKEnvironment.h>
 #import <SignalServiceKit/TSAccountManager.h>
 #import <SignalServiceKit/TSGroupThread.h>
 #import <SignalServiceKit/TSNetworkManager.h>
 #import <SignalServiceKit/TSThread.h>
 #import <SignalServiceKit/TSYapDatabaseObject.h>
-#import <SignalServiceKit/TextSecureKitEnv.h>
 #import <SignalServiceKit/UIImage+OWS.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/SignalMessaging/utils/ConversationSearcher.swift
+++ b/SignalMessaging/utils/ConversationSearcher.swift
@@ -216,7 +216,7 @@ public class ConversationSearcher: NSObject {
     }
 
     private var contactsManager: OWSContactsManager {
-        return Environment.current().contactsManager
+        return Environment.shared().contactsManager
     }
 
     private func indexingString(recipientId: String) -> String {

--- a/SignalMessaging/utils/ConversationSearcher.swift
+++ b/SignalMessaging/utils/ConversationSearcher.swift
@@ -216,7 +216,7 @@ public class ConversationSearcher: NSObject {
     }
 
     private var contactsManager: OWSContactsManager {
-        return Environment.shared().contactsManager
+        return Environment.shared.contactsManager
     }
 
     private func indexingString(recipientId: String) -> String {

--- a/SignalServiceKit/src/Contacts/Contact.m
+++ b/SignalServiceKit/src/Contacts/Contact.m
@@ -7,9 +7,9 @@
 #import "NSString+SSK.h"
 #import "OWSPrimaryStorage.h"
 #import "PhoneNumber.h"
+#import "SSKEnvironment.h"
 #import "SignalRecipient.h"
 #import "TSAccountManager.h"
-#import "TextSecureKitEnv.h"
 
 @import Contacts;
 

--- a/SignalServiceKit/src/Contacts/Threads/TSContactThread.m
+++ b/SignalServiceKit/src/Contacts/Threads/TSContactThread.m
@@ -7,7 +7,7 @@
 #import "ContactsUpdater.h"
 #import "NotificationsProtocol.h"
 #import "OWSIdentityManager.h"
-#import "TextSecureKitEnv.h"
+#import "SSKEnvironment.h"
 #import <YapDatabase/YapDatabaseConnection.h>
 #import <YapDatabase/YapDatabaseTransaction.h>
 
@@ -80,7 +80,7 @@ NS_ASSUME_NONNULL_BEGIN
 // TODO deprecate this? seems weird to access the displayName in the DB model
 - (NSString *)name
 {
-    return [[TextSecureKitEnv sharedEnv].contactsManager displayNameForPhoneIdentifier:self.contactIdentifier];
+    return [[SSKEnvironment sharedEnv].contactsManager displayNameForPhoneIdentifier:self.contactIdentifier];
 }
 
 

--- a/SignalServiceKit/src/Contacts/Threads/TSContactThread.m
+++ b/SignalServiceKit/src/Contacts/Threads/TSContactThread.m
@@ -80,7 +80,7 @@ NS_ASSUME_NONNULL_BEGIN
 // TODO deprecate this? seems weird to access the displayName in the DB model
 - (NSString *)name
 {
-    return [[SSKEnvironment sharedEnv].contactsManager displayNameForPhoneIdentifier:self.contactIdentifier];
+    return [[SSKEnvironment shared].contactsManager displayNameForPhoneIdentifier:self.contactIdentifier];
 }
 
 

--- a/SignalServiceKit/src/Devices/OWSRecordTranscriptJob.m
+++ b/SignalServiceKit/src/Devices/OWSRecordTranscriptJob.m
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
                                         networkManager:TSNetworkManager.sharedManager
                                         primaryStorage:OWSPrimaryStorage.sharedManager
                                     readReceiptManager:OWSReadReceiptManager.sharedManager
-                                       contactsManager:[SSKEnvironment sharedEnv].contactsManager];
+                                       contactsManager:[SSKEnvironment shared].contactsManager];
 }
 
 - (instancetype)initWithIncomingSentMessageTranscript:(OWSIncomingSentMessageTranscript *)incomingSentMessageTranscript

--- a/SignalServiceKit/src/Devices/OWSRecordTranscriptJob.m
+++ b/SignalServiceKit/src/Devices/OWSRecordTranscriptJob.m
@@ -8,12 +8,12 @@
 #import "OWSIncomingSentMessageTranscript.h"
 #import "OWSPrimaryStorage+SessionStore.h"
 #import "OWSReadReceiptManager.h"
+#import "SSKEnvironment.h"
 #import "TSAttachmentPointer.h"
 #import "TSInfoMessage.h"
 #import "TSNetworkManager.h"
 #import "TSOutgoingMessage.h"
 #import "TSQuotedMessage.h"
-#import "TextSecureKitEnv.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
                                         networkManager:TSNetworkManager.sharedManager
                                         primaryStorage:OWSPrimaryStorage.sharedManager
                                     readReceiptManager:OWSReadReceiptManager.sharedManager
-                                       contactsManager:[TextSecureKitEnv sharedEnv].contactsManager];
+                                       contactsManager:[SSKEnvironment sharedEnv].contactsManager];
 }
 
 - (instancetype)initWithIncomingSentMessageTranscript:(OWSIncomingSentMessageTranscript *)incomingSentMessageTranscript

--- a/SignalServiceKit/src/Messages/DeviceSyncing/OWSSyncContactsMessage.m
+++ b/SignalServiceKit/src/Messages/DeviceSyncing/OWSSyncContactsMessage.m
@@ -81,7 +81,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable NSData *)buildPlainTextAttachmentDataWithTransaction:(YapDatabaseReadTransaction *)transaction
 {
-    id<ContactsManagerProtocol> contactsManager = SSKEnvironment.sharedEnv.contactsManager;
+    id<ContactsManagerProtocol> contactsManager = SSKEnvironment.shared.contactsManager;
 
     // TODO use temp file stream to avoid loading everything into memory at once
     // First though, we need to re-engineer our attachment process to accept streams (encrypting with stream,

--- a/SignalServiceKit/src/Messages/DeviceSyncing/OWSSyncContactsMessage.m
+++ b/SignalServiceKit/src/Messages/DeviceSyncing/OWSSyncContactsMessage.m
@@ -9,11 +9,11 @@
 #import "OWSContactsOutputStream.h"
 #import "OWSIdentityManager.h"
 #import "ProfileManagerProtocol.h"
+#import "SSKEnvironment.h"
 #import "SignalAccount.h"
 #import "TSAttachment.h"
 #import "TSAttachmentStream.h"
 #import "TSContactThread.h"
-#import "TextSecureKitEnv.h"
 #import <SignalServiceKit/SignalServiceKit-Swift.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -81,7 +81,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable NSData *)buildPlainTextAttachmentDataWithTransaction:(YapDatabaseReadTransaction *)transaction
 {
-    id<ContactsManagerProtocol> contactsManager = TextSecureKitEnv.sharedEnv.contactsManager;
+    id<ContactsManagerProtocol> contactsManager = SSKEnvironment.sharedEnv.contactsManager;
 
     // TODO use temp file stream to avoid loading everything into memory at once
     // First though, we need to re-engineer our attachment process to accept streams (encrypting with stream,

--- a/SignalServiceKit/src/Messages/Interactions/TSErrorMessage.m
+++ b/SignalServiceKit/src/Messages/Interactions/TSErrorMessage.m
@@ -125,7 +125,7 @@ NSUInteger TSErrorMessageSchemaVersion = 1;
                     @"Shown when signal users safety numbers changed, embeds the user's {{name or phone number}}");
 
                 NSString *recipientDisplayName =
-                    [[SSKEnvironment sharedEnv].contactsManager displayNameForPhoneIdentifier:self.recipientId];
+                    [[SSKEnvironment shared].contactsManager displayNameForPhoneIdentifier:self.recipientId];
                 return [NSString stringWithFormat:messageFormat, recipientDisplayName];
             } else {
                 // recipientId will be nil for legacy errors

--- a/SignalServiceKit/src/Messages/Interactions/TSErrorMessage.m
+++ b/SignalServiceKit/src/Messages/Interactions/TSErrorMessage.m
@@ -6,9 +6,9 @@
 #import "ContactsManagerProtocol.h"
 #import "NSDate+OWS.h"
 #import "OWSMessageManager.h"
+#import "SSKEnvironment.h"
 #import "TSContactThread.h"
 #import "TSErrorMessage_privateConstructor.h"
-#import "TextSecureKitEnv.h"
 #import <SignalServiceKit/SignalServiceKit-Swift.h>
 #import <YapDatabase/YapDatabaseConnection.h>
 
@@ -125,7 +125,7 @@ NSUInteger TSErrorMessageSchemaVersion = 1;
                     @"Shown when signal users safety numbers changed, embeds the user's {{name or phone number}}");
 
                 NSString *recipientDisplayName =
-                    [[TextSecureKitEnv sharedEnv].contactsManager displayNameForPhoneIdentifier:self.recipientId];
+                    [[SSKEnvironment sharedEnv].contactsManager displayNameForPhoneIdentifier:self.recipientId];
                 return [NSString stringWithFormat:messageFormat, recipientDisplayName];
             } else {
                 // recipientId will be nil for legacy errors

--- a/SignalServiceKit/src/Messages/Interactions/TSInfoMessage.m
+++ b/SignalServiceKit/src/Messages/Interactions/TSInfoMessage.m
@@ -5,7 +5,7 @@
 #import "TSInfoMessage.h"
 #import "ContactsManagerProtocol.h"
 #import "NSDate+OWS.h"
-#import "TextSecureKitEnv.h"
+#import "SSKEnvironment.h"
 #import <YapDatabase/YapDatabaseConnection.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -120,7 +120,7 @@ NSUInteger TSInfoMessageSchemaVersion = 1;
             return NSLocalizedString(@"UNSUPPORTED_ATTACHMENT", nil);
         case TSInfoMessageUserNotRegistered:
             if (self.unregisteredRecipientId.length > 0) {
-                id<ContactsManagerProtocol> contactsManager = [TextSecureKitEnv sharedEnv].contactsManager;
+                id<ContactsManagerProtocol> contactsManager = [SSKEnvironment sharedEnv].contactsManager;
                 NSString *recipientName = [contactsManager displayNameForPhoneIdentifier:self.unregisteredRecipientId];
                 return [NSString stringWithFormat:NSLocalizedString(@"ERROR_UNREGISTERED_USER_FORMAT",
                                                       @"Format string for 'unregistered user' error. Embeds {{the "

--- a/SignalServiceKit/src/Messages/Interactions/TSInfoMessage.m
+++ b/SignalServiceKit/src/Messages/Interactions/TSInfoMessage.m
@@ -120,7 +120,7 @@ NSUInteger TSInfoMessageSchemaVersion = 1;
             return NSLocalizedString(@"UNSUPPORTED_ATTACHMENT", nil);
         case TSInfoMessageUserNotRegistered:
             if (self.unregisteredRecipientId.length > 0) {
-                id<ContactsManagerProtocol> contactsManager = [SSKEnvironment sharedEnv].contactsManager;
+                id<ContactsManagerProtocol> contactsManager = [SSKEnvironment shared].contactsManager;
                 NSString *recipientName = [contactsManager displayNameForPhoneIdentifier:self.unregisteredRecipientId];
                 return [NSString stringWithFormat:NSLocalizedString(@"ERROR_UNREGISTERED_USER_FORMAT",
                                                       @"Format string for 'unregistered user' error. Embeds {{the "

--- a/SignalServiceKit/src/Messages/Interactions/TSOutgoingMessage.m
+++ b/SignalServiceKit/src/Messages/Interactions/TSOutgoingMessage.m
@@ -10,13 +10,13 @@
 #import "OWSOutgoingSyncMessage.h"
 #import "OWSPrimaryStorage.h"
 #import "ProtoUtils.h"
+#import "SSKEnvironment.h"
 #import "SignalRecipient.h"
 #import "TSAccountManager.h"
 #import "TSAttachmentStream.h"
 #import "TSContactThread.h"
 #import "TSGroupThread.h"
 #import "TSQuotedMessage.h"
-#import "TextSecureKitEnv.h"
 #import <SignalServiceKit/SignalServiceKit-Swift.h>
 #import <YapDatabase/YapDatabase.h>
 #import <YapDatabase/YapDatabaseTransaction.h>

--- a/SignalServiceKit/src/Messages/OWSBatchMessageProcessor.m
+++ b/SignalServiceKit/src/Messages/OWSBatchMessageProcessor.m
@@ -390,8 +390,8 @@ NSString *const OWSMessageContentJobFinderExtensionGroup = @"OWSMessageContentJo
                 YapDatabaseReadWriteTransaction *transaction) {
                 // TODO: Add analytics.
                 TSErrorMessage *errorMessage = [TSErrorMessage corruptedMessageInUnknownThread];
-                [[SSKEnvironment sharedEnv].notificationsManager notifyUserForThreadlessErrorMessage:errorMessage
-                                                                                         transaction:transaction];
+                [[SSKEnvironment shared].notificationsManager notifyUserForThreadlessErrorMessage:errorMessage
+                                                                                      transaction:transaction];
             };
 
             @try {

--- a/SignalServiceKit/src/Messages/OWSBatchMessageProcessor.m
+++ b/SignalServiceKit/src/Messages/OWSBatchMessageProcessor.m
@@ -13,10 +13,10 @@
 #import "OWSPrimaryStorage.h"
 #import "OWSQueues.h"
 #import "OWSStorage.h"
+#import "SSKEnvironment.h"
 #import "TSDatabaseView.h"
 #import "TSErrorMessage.h"
 #import "TSYapDatabaseObject.h"
-#import "TextSecureKitEnv.h"
 #import "Threading.h"
 #import <SignalServiceKit/SignalServiceKit-Swift.h>
 #import <YapDatabase/YapDatabaseAutoView.h>
@@ -390,8 +390,8 @@ NSString *const OWSMessageContentJobFinderExtensionGroup = @"OWSMessageContentJo
                 YapDatabaseReadWriteTransaction *transaction) {
                 // TODO: Add analytics.
                 TSErrorMessage *errorMessage = [TSErrorMessage corruptedMessageInUnknownThread];
-                [[TextSecureKitEnv sharedEnv].notificationsManager notifyUserForThreadlessErrorMessage:errorMessage
-                                                                                           transaction:transaction];
+                [[SSKEnvironment sharedEnv].notificationsManager notifyUserForThreadlessErrorMessage:errorMessage
+                                                                                         transaction:transaction];
             };
 
             @try {

--- a/SignalServiceKit/src/Messages/OWSBlockingManager.m
+++ b/SignalServiceKit/src/Messages/OWSBlockingManager.m
@@ -9,7 +9,7 @@
 #import "OWSBlockedPhoneNumbersMessage.h"
 #import "OWSMessageSender.h"
 #import "OWSPrimaryStorage.h"
-#import "TextSecureKitEnv.h"
+#import "SSKEnvironment.h"
 #import "YapDatabaseConnection+OWS.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -51,7 +51,7 @@ NSString *const kOWSBlockingManager_SyncedBlockedPhoneNumbersKey = @"kOWSBlockin
 - (instancetype)initDefault
 {
     OWSPrimaryStorage *primaryStorage = [OWSPrimaryStorage sharedManager];
-    OWSMessageSender *messageSender = [TextSecureKitEnv sharedEnv].messageSender;
+    OWSMessageSender *messageSender = [SSKEnvironment sharedEnv].messageSender;
 
     return [self initWithPrimaryStorage:primaryStorage messageSender:messageSender];
 }

--- a/SignalServiceKit/src/Messages/OWSBlockingManager.m
+++ b/SignalServiceKit/src/Messages/OWSBlockingManager.m
@@ -51,7 +51,7 @@ NSString *const kOWSBlockingManager_SyncedBlockedPhoneNumbersKey = @"kOWSBlockin
 - (instancetype)initDefault
 {
     OWSPrimaryStorage *primaryStorage = [OWSPrimaryStorage sharedManager];
-    OWSMessageSender *messageSender = [SSKEnvironment sharedEnv].messageSender;
+    OWSMessageSender *messageSender = [SSKEnvironment shared].messageSender;
 
     return [self initWithPrimaryStorage:primaryStorage messageSender:messageSender];
 }

--- a/SignalServiceKit/src/Messages/OWSIdentityManager.m
+++ b/SignalServiceKit/src/Messages/OWSIdentityManager.m
@@ -17,11 +17,11 @@
 #import "OWSRecipientIdentity.h"
 #import "OWSVerificationStateChangeMessage.h"
 #import "OWSVerificationStateSyncMessage.h"
+#import "SSKEnvironment.h"
 #import "TSAccountManager.h"
 #import "TSContactThread.h"
 #import "TSErrorMessage.h"
 #import "TSGroupThread.h"
-#import "TextSecureKitEnv.h"
 #import "YapDatabaseConnection+OWS.h"
 #import "YapDatabaseTransaction+OWS.h"
 #import <AxolotlKit/NSData+keyVersionByte.h>
@@ -79,7 +79,7 @@ NSString *const kNSNotificationName_IdentityStateDidChange = @"kNSNotificationNa
 - (instancetype)initDefault
 {
     OWSPrimaryStorage *primaryStorage = [OWSPrimaryStorage sharedManager];
-    OWSMessageSender *messageSender = [TextSecureKitEnv sharedEnv].messageSender;
+    OWSMessageSender *messageSender = [SSKEnvironment sharedEnv].messageSender;
 
     return [self initWithPrimaryStorage:primaryStorage messageSender:messageSender];
 }
@@ -540,9 +540,9 @@ NSString *const kNSNotificationName_IdentityStateDidChange = @"kNSNotificationNa
         [message saveWithTransaction:transaction];
     }
 
-    [[TextSecureKitEnv sharedEnv].notificationsManager notifyUserForErrorMessage:errorMessage
-                                                                          thread:contactThread
-                                                                     transaction:transaction];
+    [[SSKEnvironment sharedEnv].notificationsManager notifyUserForErrorMessage:errorMessage
+                                                                        thread:contactThread
+                                                                   transaction:transaction];
 }
 
 - (void)enqueueSyncMessageForVerificationStateForRecipientId:(NSString *)recipientId

--- a/SignalServiceKit/src/Messages/OWSIdentityManager.m
+++ b/SignalServiceKit/src/Messages/OWSIdentityManager.m
@@ -79,7 +79,7 @@ NSString *const kNSNotificationName_IdentityStateDidChange = @"kNSNotificationNa
 - (instancetype)initDefault
 {
     OWSPrimaryStorage *primaryStorage = [OWSPrimaryStorage sharedManager];
-    OWSMessageSender *messageSender = [SSKEnvironment sharedEnv].messageSender;
+    OWSMessageSender *messageSender = [SSKEnvironment shared].messageSender;
 
     return [self initWithPrimaryStorage:primaryStorage messageSender:messageSender];
 }
@@ -540,9 +540,9 @@ NSString *const kNSNotificationName_IdentityStateDidChange = @"kNSNotificationNa
         [message saveWithTransaction:transaction];
     }
 
-    [[SSKEnvironment sharedEnv].notificationsManager notifyUserForErrorMessage:errorMessage
-                                                                        thread:contactThread
-                                                                   transaction:transaction];
+    [[SSKEnvironment shared].notificationsManager notifyUserForErrorMessage:errorMessage
+                                                                     thread:contactThread
+                                                                transaction:transaction];
 }
 
 - (void)enqueueSyncMessageForVerificationStateForRecipientId:(NSString *)recipientId

--- a/SignalServiceKit/src/Messages/OWSMessageDecrypter.m
+++ b/SignalServiceKit/src/Messages/OWSMessageDecrypter.m
@@ -182,8 +182,8 @@ NS_ASSUME_NONNULL_BEGIN
         [[OWSPrimaryStorage.sharedManager newDatabaseConnection]
             readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
                 TSErrorMessage *errorMessage = [TSErrorMessage corruptedMessageInUnknownThread];
-                [[SSKEnvironment sharedEnv].notificationsManager notifyUserForThreadlessErrorMessage:errorMessage
-                                                                                         transaction:transaction];
+                [[SSKEnvironment shared].notificationsManager notifyUserForThreadlessErrorMessage:errorMessage
+                                                                                      transaction:transaction];
             }];
     }
 
@@ -323,9 +323,9 @@ NS_ASSUME_NONNULL_BEGIN
                       transaction:(YapDatabaseReadWriteTransaction *)transaction
 {
     TSThread *contactThread = [TSContactThread getOrCreateThreadWithContactId:envelope.source transaction:transaction];
-    [[SSKEnvironment sharedEnv].notificationsManager notifyUserForErrorMessage:errorMessage
-                                                                        thread:contactThread
-                                                                   transaction:transaction];
+    [[SSKEnvironment shared].notificationsManager notifyUserForErrorMessage:errorMessage
+                                                                     thread:contactThread
+                                                                transaction:transaction];
 }
 
 @end

--- a/SignalServiceKit/src/Messages/OWSMessageDecrypter.m
+++ b/SignalServiceKit/src/Messages/OWSMessageDecrypter.m
@@ -13,12 +13,12 @@
 #import "OWSPrimaryStorage+SessionStore.h"
 #import "OWSPrimaryStorage+SignedPreKeyStore.h"
 #import "OWSPrimaryStorage.h"
+#import "SSKEnvironment.h"
 #import "SignalRecipient.h"
 #import "TSAccountManager.h"
 #import "TSContactThread.h"
 #import "TSErrorMessage.h"
 #import "TSPreKeyManager.h"
-#import "TextSecureKitEnv.h"
 #import <AxolotlKit/AxolotlExceptions.h>
 #import <AxolotlKit/SessionCipher.h>
 #import <SignalServiceKit/SignalServiceKit-Swift.h>
@@ -182,8 +182,8 @@ NS_ASSUME_NONNULL_BEGIN
         [[OWSPrimaryStorage.sharedManager newDatabaseConnection]
             readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
                 TSErrorMessage *errorMessage = [TSErrorMessage corruptedMessageInUnknownThread];
-                [[TextSecureKitEnv sharedEnv].notificationsManager notifyUserForThreadlessErrorMessage:errorMessage
-                                                                                           transaction:transaction];
+                [[SSKEnvironment sharedEnv].notificationsManager notifyUserForThreadlessErrorMessage:errorMessage
+                                                                                         transaction:transaction];
             }];
     }
 
@@ -323,9 +323,9 @@ NS_ASSUME_NONNULL_BEGIN
                       transaction:(YapDatabaseReadWriteTransaction *)transaction
 {
     TSThread *contactThread = [TSContactThread getOrCreateThreadWithContactId:envelope.source transaction:transaction];
-    [[TextSecureKitEnv sharedEnv].notificationsManager notifyUserForErrorMessage:errorMessage
-                                                                          thread:contactThread
-                                                                     transaction:transaction];
+    [[SSKEnvironment sharedEnv].notificationsManager notifyUserForErrorMessage:errorMessage
+                                                                        thread:contactThread
+                                                                   transaction:transaction];
 }
 
 @end

--- a/SignalServiceKit/src/Messages/OWSMessageManager.m
+++ b/SignalServiceKit/src/Messages/OWSMessageManager.m
@@ -33,6 +33,7 @@
 #import "OWSSyncGroupsMessage.h"
 #import "OWSSyncGroupsRequestMessage.h"
 #import "ProfileManagerProtocol.h"
+#import "SSKEnvironment.h"
 #import "TSAccountManager.h"
 #import "TSAttachment.h"
 #import "TSAttachmentPointer.h"
@@ -46,7 +47,6 @@
 #import "TSNetworkManager.h"
 #import "TSOutgoingMessage.h"
 #import "TSQuotedMessage.h"
-#import "TextSecureKitEnv.h"
 #import <SignalServiceKit/SignalServiceKit-Swift.h>
 #import <YapDatabase/YapDatabase.h>
 
@@ -84,10 +84,10 @@ NS_ASSUME_NONNULL_BEGIN
 {
     TSNetworkManager *networkManager = [TSNetworkManager sharedManager];
     OWSPrimaryStorage *primaryStorage = [OWSPrimaryStorage sharedManager];
-    id<ContactsManagerProtocol> contactsManager = [TextSecureKitEnv sharedEnv].contactsManager;
-    id<OWSCallMessageHandler> callMessageHandler = [TextSecureKitEnv sharedEnv].callMessageHandler;
+    id<ContactsManagerProtocol> contactsManager = [SSKEnvironment sharedEnv].contactsManager;
+    id<OWSCallMessageHandler> callMessageHandler = [SSKEnvironment sharedEnv].callMessageHandler;
     OWSIdentityManager *identityManager = [OWSIdentityManager sharedManager];
-    OWSMessageSender *messageSender = [TextSecureKitEnv sharedEnv].messageSender;
+    OWSMessageSender *messageSender = [SSKEnvironment sharedEnv].messageSender;
 
 
     return [self initWithNetworkManager:networkManager
@@ -429,7 +429,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (id<ProfileManagerProtocol>)profileManager
 {
-    return [TextSecureKitEnv sharedEnv].profileManager;
+    return [SSKEnvironment sharedEnv].profileManager;
 }
 
 - (void)handleIncomingEnvelope:(SSKProtoEnvelope *)envelope
@@ -798,7 +798,7 @@ NS_ASSUME_NONNULL_BEGIN
         return;
     }
 
-    id<ProfileManagerProtocol> profileManager = [TextSecureKitEnv sharedEnv].profileManager;
+    id<ProfileManagerProtocol> profileManager = [SSKEnvironment sharedEnv].profileManager;
     [profileManager setProfileKeyData:profileKey forRecipientId:recipientId];
 }
 
@@ -1168,10 +1168,10 @@ NS_ASSUME_NONNULL_BEGIN
     // Update thread preview in inbox
     [thread touchWithTransaction:transaction];
 
-    [[TextSecureKitEnv sharedEnv].notificationsManager notifyUserForIncomingMessage:incomingMessage
-                                                                           inThread:thread
-                                                                    contactsManager:self.contactsManager
-                                                                        transaction:transaction];
+    [[SSKEnvironment sharedEnv].notificationsManager notifyUserForIncomingMessage:incomingMessage
+                                                                         inThread:thread
+                                                                  contactsManager:self.contactsManager
+                                                                      transaction:transaction];
 }
 
 #pragma mark - helpers

--- a/SignalServiceKit/src/Messages/OWSMessageManager.m
+++ b/SignalServiceKit/src/Messages/OWSMessageManager.m
@@ -84,10 +84,10 @@ NS_ASSUME_NONNULL_BEGIN
 {
     TSNetworkManager *networkManager = [TSNetworkManager sharedManager];
     OWSPrimaryStorage *primaryStorage = [OWSPrimaryStorage sharedManager];
-    id<ContactsManagerProtocol> contactsManager = [SSKEnvironment sharedEnv].contactsManager;
-    id<OWSCallMessageHandler> callMessageHandler = [SSKEnvironment sharedEnv].callMessageHandler;
+    id<ContactsManagerProtocol> contactsManager = [SSKEnvironment shared].contactsManager;
+    id<OWSCallMessageHandler> callMessageHandler = [SSKEnvironment shared].callMessageHandler;
     OWSIdentityManager *identityManager = [OWSIdentityManager sharedManager];
-    OWSMessageSender *messageSender = [SSKEnvironment sharedEnv].messageSender;
+    OWSMessageSender *messageSender = [SSKEnvironment shared].messageSender;
 
 
     return [self initWithNetworkManager:networkManager
@@ -429,7 +429,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (id<ProfileManagerProtocol>)profileManager
 {
-    return [SSKEnvironment sharedEnv].profileManager;
+    return [SSKEnvironment shared].profileManager;
 }
 
 - (void)handleIncomingEnvelope:(SSKProtoEnvelope *)envelope
@@ -798,7 +798,7 @@ NS_ASSUME_NONNULL_BEGIN
         return;
     }
 
-    id<ProfileManagerProtocol> profileManager = [SSKEnvironment sharedEnv].profileManager;
+    id<ProfileManagerProtocol> profileManager = [SSKEnvironment shared].profileManager;
     [profileManager setProfileKeyData:profileKey forRecipientId:recipientId];
 }
 
@@ -1168,10 +1168,10 @@ NS_ASSUME_NONNULL_BEGIN
     // Update thread preview in inbox
     [thread touchWithTransaction:transaction];
 
-    [[SSKEnvironment sharedEnv].notificationsManager notifyUserForIncomingMessage:incomingMessage
-                                                                         inThread:thread
-                                                                  contactsManager:self.contactsManager
-                                                                      transaction:transaction];
+    [[SSKEnvironment shared].notificationsManager notifyUserForIncomingMessage:incomingMessage
+                                                                      inThread:thread
+                                                               contactsManager:self.contactsManager
+                                                                   transaction:transaction];
 }
 
 #pragma mark - helpers

--- a/SignalServiceKit/src/Messages/OWSMessageReceiver.m
+++ b/SignalServiceKit/src/Messages/OWSMessageReceiver.m
@@ -13,10 +13,10 @@
 #import "OWSPrimaryStorage.h"
 #import "OWSQueues.h"
 #import "OWSStorage.h"
+#import "SSKEnvironment.h"
 #import "TSDatabaseView.h"
 #import "TSErrorMessage.h"
 #import "TSYapDatabaseObject.h"
-#import "TextSecureKitEnv.h"
 #import "Threading.h"
 #import <SignalServiceKit/SignalServiceKit-Swift.h>
 #import <YapDatabase/YapDatabaseAutoView.h>
@@ -335,8 +335,8 @@ NSString *const OWSMessageDecryptJobFinderExtensionGroup = @"OWSMessageProcessin
         [[OWSPrimaryStorage.sharedManager newDatabaseConnection]
             readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
                 TSErrorMessage *errorMessage = [TSErrorMessage corruptedMessageInUnknownThread];
-                [[TextSecureKitEnv sharedEnv].notificationsManager notifyUserForThreadlessErrorMessage:errorMessage
-                                                                                           transaction:transaction];
+                [[SSKEnvironment sharedEnv].notificationsManager notifyUserForThreadlessErrorMessage:errorMessage
+                                                                                         transaction:transaction];
             }];
 
         dispatch_async(self.serialQueue, ^{

--- a/SignalServiceKit/src/Messages/OWSMessageReceiver.m
+++ b/SignalServiceKit/src/Messages/OWSMessageReceiver.m
@@ -335,8 +335,8 @@ NSString *const OWSMessageDecryptJobFinderExtensionGroup = @"OWSMessageProcessin
         [[OWSPrimaryStorage.sharedManager newDatabaseConnection]
             readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
                 TSErrorMessage *errorMessage = [TSErrorMessage corruptedMessageInUnknownThread];
-                [[SSKEnvironment sharedEnv].notificationsManager notifyUserForThreadlessErrorMessage:errorMessage
-                                                                                         transaction:transaction];
+                [[SSKEnvironment shared].notificationsManager notifyUserForThreadlessErrorMessage:errorMessage
+                                                                                      transaction:transaction];
             }];
 
         dispatch_async(self.serialQueue, ^{

--- a/SignalServiceKit/src/Messages/OWSProfileKeyMessage.m
+++ b/SignalServiceKit/src/Messages/OWSProfileKeyMessage.m
@@ -5,7 +5,7 @@
 #import "OWSProfileKeyMessage.h"
 #import "ProfileManagerProtocol.h"
 #import "ProtoUtils.h"
-#import "TextSecureKitEnv.h"
+#import "SSKEnvironment.h"
 #import <SignalServiceKit/SignalServiceKit-Swift.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -57,7 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (recipientId.length > 0) {
         // Once we've shared our profile key with a user (perhaps due to being
         // a member of a whitelisted group), make sure they're whitelisted.
-        id<ProfileManagerProtocol> profileManager = [TextSecureKitEnv sharedEnv].profileManager;
+        id<ProfileManagerProtocol> profileManager = [SSKEnvironment sharedEnv].profileManager;
         [profileManager addUserToProfileWhitelist:recipientId];
     }
 

--- a/SignalServiceKit/src/Messages/OWSProfileKeyMessage.m
+++ b/SignalServiceKit/src/Messages/OWSProfileKeyMessage.m
@@ -57,7 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (recipientId.length > 0) {
         // Once we've shared our profile key with a user (perhaps due to being
         // a member of a whitelisted group), make sure they're whitelisted.
-        id<ProfileManagerProtocol> profileManager = [SSKEnvironment sharedEnv].profileManager;
+        id<ProfileManagerProtocol> profileManager = [SSKEnvironment shared].profileManager;
         [profileManager addUserToProfileWhitelist:recipientId];
     }
 

--- a/SignalServiceKit/src/Messages/OWSReadReceiptManager.m
+++ b/SignalServiceKit/src/Messages/OWSReadReceiptManager.m
@@ -13,11 +13,11 @@
 #import "OWSReadReceiptsForSenderMessage.h"
 #import "OWSStorage.h"
 #import "OWSSyncConfigurationMessage.h"
+#import "SSKEnvironment.h"
 #import "TSAccountManager.h"
 #import "TSContactThread.h"
 #import "TSDatabaseView.h"
 #import "TSIncomingMessage.h"
-#import "TextSecureKitEnv.h"
 #import "Threading.h"
 #import "YapDatabaseConnection+OWS.h"
 #import <SignalServiceKit/SignalServiceKit-Swift.h>
@@ -156,7 +156,7 @@ NSString *const OWSReadReceiptManagerAreReadReceiptsEnabled = @"areReadReceiptsE
 
 - (instancetype)initDefault
 {
-    OWSMessageSender *messageSender = [TextSecureKitEnv sharedEnv].messageSender;
+    OWSMessageSender *messageSender = [SSKEnvironment sharedEnv].messageSender;
     OWSPrimaryStorage *primaryStorage = [OWSPrimaryStorage sharedManager];
 
     return [self initWithMessageSender:messageSender primaryStorage:primaryStorage];

--- a/SignalServiceKit/src/Messages/OWSReadReceiptManager.m
+++ b/SignalServiceKit/src/Messages/OWSReadReceiptManager.m
@@ -156,7 +156,7 @@ NSString *const OWSReadReceiptManagerAreReadReceiptsEnabled = @"areReadReceiptsE
 
 - (instancetype)initDefault
 {
-    OWSMessageSender *messageSender = [SSKEnvironment sharedEnv].messageSender;
+    OWSMessageSender *messageSender = [SSKEnvironment shared].messageSender;
     OWSPrimaryStorage *primaryStorage = [OWSPrimaryStorage sharedManager];
 
     return [self initWithMessageSender:messageSender primaryStorage:primaryStorage];

--- a/SignalServiceKit/src/Network/WebSockets/TSSocketManager.m
+++ b/SignalServiceKit/src/Network/WebSockets/TSSocketManager.m
@@ -16,11 +16,11 @@
 #import "OWSPrimaryStorage.h"
 #import "OWSSignalService.h"
 #import "OWSWebsocketSecurityPolicy.h"
+#import "SSKEnvironment.h"
 #import "TSAccountManager.h"
 #import "TSConstants.h"
 #import "TSErrorMessage.h"
 #import "TSRequest.h"
-#import "TextSecureKitEnv.h"
 #import "Threading.h"
 #import <SignalServiceKit/SignalServiceKit-Swift.h>
 
@@ -749,8 +749,8 @@ NSString *const kNSNotification_SocketManagerStateDidChange = @"kNSNotification_
                 [[OWSPrimaryStorage.sharedManager newDatabaseConnection] readWriteWithBlock:^(
                     YapDatabaseReadWriteTransaction *transaction) {
                     TSErrorMessage *errorMessage = [TSErrorMessage corruptedMessageInUnknownThread];
-                    [[TextSecureKitEnv sharedEnv].notificationsManager notifyUserForThreadlessErrorMessage:errorMessage
-                                                                                               transaction:transaction];
+                    [[SSKEnvironment sharedEnv].notificationsManager notifyUserForThreadlessErrorMessage:errorMessage
+                                                                                             transaction:transaction];
                 }];
             }
 

--- a/SignalServiceKit/src/Network/WebSockets/TSSocketManager.m
+++ b/SignalServiceKit/src/Network/WebSockets/TSSocketManager.m
@@ -749,8 +749,8 @@ NSString *const kNSNotification_SocketManagerStateDidChange = @"kNSNotification_
                 [[OWSPrimaryStorage.sharedManager newDatabaseConnection] readWriteWithBlock:^(
                     YapDatabaseReadWriteTransaction *transaction) {
                     TSErrorMessage *errorMessage = [TSErrorMessage corruptedMessageInUnknownThread];
-                    [[SSKEnvironment sharedEnv].notificationsManager notifyUserForThreadlessErrorMessage:errorMessage
-                                                                                             transaction:transaction];
+                    [[SSKEnvironment shared].notificationsManager notifyUserForThreadlessErrorMessage:errorMessage
+                                                                                          transaction:transaction];
                 }];
             }
 

--- a/SignalServiceKit/src/Protocols/ProtoUtils.m
+++ b/SignalServiceKit/src/Protocols/ProtoUtils.m
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     OWSAssertDebug(thread);
 
-    id<ProfileManagerProtocol> profileManager = [SSKEnvironment sharedEnv].profileManager;
+    id<ProfileManagerProtocol> profileManager = [SSKEnvironment shared].profileManager;
 
     // For 1:1 threads, we want to include the profile key IFF the
     // contact is in the whitelist.
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (OWSAES256Key *)localProfileKey
 {
-    id<ProfileManagerProtocol> profileManager = [SSKEnvironment sharedEnv].profileManager;
+    id<ProfileManagerProtocol> profileManager = [SSKEnvironment shared].profileManager;
     return profileManager.localProfileKey;
 }
 
@@ -52,7 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
         if (recipientId.length > 0) {
             // Once we've shared our profile key with a user (perhaps due to being
             // a member of a whitelisted group), make sure they're whitelisted.
-            id<ProfileManagerProtocol> profileManager = [SSKEnvironment sharedEnv].profileManager;
+            id<ProfileManagerProtocol> profileManager = [SSKEnvironment shared].profileManager;
             // FIXME PERF avoid this dispatch. It's going to happen for *each* recipient in a group message.
             dispatch_async(dispatch_get_main_queue(), ^{
                 [profileManager addUserToProfileWhitelist:recipientId];
@@ -81,7 +81,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         // Once we've shared our profile key with a user (perhaps due to being
         // a member of a whitelisted group), make sure they're whitelisted.
-        id<ProfileManagerProtocol> profileManager = [SSKEnvironment sharedEnv].profileManager;
+        id<ProfileManagerProtocol> profileManager = [SSKEnvironment shared].profileManager;
         // FIXME PERF avoid this dispatch. It's going to happen for *each* recipient in a group message.
         dispatch_async(dispatch_get_main_queue(), ^{
             [profileManager addUserToProfileWhitelist:recipientId];

--- a/SignalServiceKit/src/Protocols/ProtoUtils.m
+++ b/SignalServiceKit/src/Protocols/ProtoUtils.m
@@ -5,8 +5,8 @@
 #import "ProtoUtils.h"
 #import "Cryptography.h"
 #import "ProfileManagerProtocol.h"
+#import "SSKEnvironment.h"
 #import "TSThread.h"
-#import "TextSecureKitEnv.h"
 #import <SignalServiceKit/SignalServiceKit-Swift.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     OWSAssertDebug(thread);
 
-    id<ProfileManagerProtocol> profileManager = [TextSecureKitEnv sharedEnv].profileManager;
+    id<ProfileManagerProtocol> profileManager = [SSKEnvironment sharedEnv].profileManager;
 
     // For 1:1 threads, we want to include the profile key IFF the
     // contact is in the whitelist.
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (OWSAES256Key *)localProfileKey
 {
-    id<ProfileManagerProtocol> profileManager = [TextSecureKitEnv sharedEnv].profileManager;
+    id<ProfileManagerProtocol> profileManager = [SSKEnvironment sharedEnv].profileManager;
     return profileManager.localProfileKey;
 }
 
@@ -52,7 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
         if (recipientId.length > 0) {
             // Once we've shared our profile key with a user (perhaps due to being
             // a member of a whitelisted group), make sure they're whitelisted.
-            id<ProfileManagerProtocol> profileManager = [TextSecureKitEnv sharedEnv].profileManager;
+            id<ProfileManagerProtocol> profileManager = [SSKEnvironment sharedEnv].profileManager;
             // FIXME PERF avoid this dispatch. It's going to happen for *each* recipient in a group message.
             dispatch_async(dispatch_get_main_queue(), ^{
                 [profileManager addUserToProfileWhitelist:recipientId];
@@ -81,7 +81,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         // Once we've shared our profile key with a user (perhaps due to being
         // a member of a whitelisted group), make sure they're whitelisted.
-        id<ProfileManagerProtocol> profileManager = [TextSecureKitEnv sharedEnv].profileManager;
+        id<ProfileManagerProtocol> profileManager = [SSKEnvironment sharedEnv].profileManager;
         // FIXME PERF avoid this dispatch. It's going to happen for *each* recipient in a group message.
         dispatch_async(dispatch_get_main_queue(), ^{
             [profileManager addUserToProfileWhitelist:recipientId];

--- a/SignalServiceKit/src/SSKEnvironment.h
+++ b/SignalServiceKit/src/SSKEnvironment.h
@@ -22,9 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 
-@property (class, readonly, nonatomic) SSKEnvironment *shared;
-
-+ (void)setShared:(SSKEnvironment *)env;
+@property (class, nonatomic) SSKEnvironment *shared;
 
 @property (nonatomic, readonly) id<OWSCallMessageHandler> callMessageHandler;
 @property (nonatomic, readonly) id<ContactsManagerProtocol> contactsManager;

--- a/SignalServiceKit/src/SSKEnvironment.h
+++ b/SignalServiceKit/src/SSKEnvironment.h
@@ -1,16 +1,18 @@
 //
-//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//  Copyright (c) 2018 Open Whisper Systems. All rights reserved.
 //
 
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol ContactsManagerProtocol;
+
 @class OWSMessageSender;
+
 @protocol NotificationsProtocol;
 @protocol OWSCallMessageHandler;
 @protocol ProfileManagerProtocol;
 
-@interface TextSecureKitEnv : NSObject
+@interface SSKEnvironment : NSObject
 
 - (instancetype)initWithCallMessageHandler:(id<OWSCallMessageHandler>)callMessageHandler
                            contactsManager:(id<ContactsManagerProtocol>)contactsManager
@@ -21,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init NS_UNAVAILABLE;
 
 + (instancetype)sharedEnv;
-+ (void)setSharedEnv:(TextSecureKitEnv *)env;
++ (void)setSharedEnv:(SSKEnvironment *)env;
 
 @property (nonatomic, readonly) id<OWSCallMessageHandler> callMessageHandler;
 @property (nonatomic, readonly) id<ContactsManagerProtocol> contactsManager;

--- a/SignalServiceKit/src/SSKEnvironment.h
+++ b/SignalServiceKit/src/SSKEnvironment.h
@@ -22,8 +22,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 
-+ (instancetype)sharedEnv;
-+ (void)setSharedEnv:(SSKEnvironment *)env;
+@property (class, readonly, nonatomic) SSKEnvironment *shared;
+
++ (void)setShared:(SSKEnvironment *)env;
 
 @property (nonatomic, readonly) id<OWSCallMessageHandler> callMessageHandler;
 @property (nonatomic, readonly) id<ContactsManagerProtocol> contactsManager;

--- a/SignalServiceKit/src/SSKEnvironment.m
+++ b/SignalServiceKit/src/SSKEnvironment.m
@@ -2,14 +2,14 @@
 //  Copyright (c) 2018 Open Whisper Systems. All rights reserved.
 //
 
-#import "TextSecureKitEnv.h"
+#import "SSKEnvironment.h"
 #import "AppContext.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-static TextSecureKitEnv *sharedTextSecureKitEnv;
+static SSKEnvironment *sharedSSKEnvironment;
 
-@interface TextSecureKitEnv ()
+@interface SSKEnvironment ()
 
 @property (nonatomic) id<OWSCallMessageHandler> callMessageHandler;
 @property (nonatomic) id<ContactsManagerProtocol> contactsManager;
@@ -21,7 +21,7 @@ static TextSecureKitEnv *sharedTextSecureKitEnv;
 
 #pragma mark -
 
-@implementation TextSecureKitEnv
+@implementation SSKEnvironment
 
 - (instancetype)initWithCallMessageHandler:(id<OWSCallMessageHandler>)callMessageHandler
                            contactsManager:(id<ContactsManagerProtocol>)contactsManager
@@ -51,17 +51,17 @@ static TextSecureKitEnv *sharedTextSecureKitEnv;
 
 + (instancetype)sharedEnv
 {
-    OWSAssertDebug(sharedTextSecureKitEnv);
+    OWSAssertDebug(sharedSSKEnvironment);
 
-    return sharedTextSecureKitEnv;
+    return sharedSSKEnvironment;
 }
 
-+ (void)setSharedEnv:(TextSecureKitEnv *)env
++ (void)setSharedEnv:(SSKEnvironment *)env
 {
     OWSAssertDebug(env);
-    OWSAssertDebug(!sharedTextSecureKitEnv || CurrentAppContext().isRunningTests);
+    OWSAssertDebug(!sharedSSKEnvironment || CurrentAppContext().isRunningTests);
 
-    sharedTextSecureKitEnv = env;
+    sharedSSKEnvironment = env;
 }
 
 @end

--- a/SignalServiceKit/src/SSKEnvironment.m
+++ b/SignalServiceKit/src/SSKEnvironment.m
@@ -49,14 +49,14 @@ static SSKEnvironment *sharedSSKEnvironment;
     return self;
 }
 
-+ (instancetype)sharedEnv
++ (instancetype)shared
 {
     OWSAssertDebug(sharedSSKEnvironment);
 
     return sharedSSKEnvironment;
 }
 
-+ (void)setSharedEnv:(SSKEnvironment *)env
++ (void)setShared:(SSKEnvironment *)env
 {
     OWSAssertDebug(env);
     OWSAssertDebug(!sharedSSKEnvironment || CurrentAppContext().isRunningTests);

--- a/SignalServiceKit/src/Storage/FullTextSearchFinder.swift
+++ b/SignalServiceKit/src/Storage/FullTextSearchFinder.swift
@@ -154,7 +154,7 @@ public class FullTextSearchFinder: NSObject {
     // MARK: - Index Building
 
     private class var contactsManager: ContactsManagerProtocol {
-        return SSKEnvironment.shared().contactsManager
+        return SSKEnvironment.shared.contactsManager
     }
 
     private static let groupThreadIndexer: SearchIndexer<TSGroupThread> = SearchIndexer { (groupThread: TSGroupThread, transaction: YapDatabaseReadTransaction) in

--- a/SignalServiceKit/src/Storage/FullTextSearchFinder.swift
+++ b/SignalServiceKit/src/Storage/FullTextSearchFinder.swift
@@ -154,7 +154,7 @@ public class FullTextSearchFinder: NSObject {
     // MARK: - Index Building
 
     private class var contactsManager: ContactsManagerProtocol {
-        return TextSecureKitEnv.shared().contactsManager
+        return SSKEnvironment.shared().contactsManager
     }
 
     private static let groupThreadIndexer: SearchIndexer<TSGroupThread> = SearchIndexer { (groupThread: TSGroupThread, transaction: YapDatabaseReadTransaction) in

--- a/SignalServiceKit/tests/Storage/TSStorageIdentityKeyStoreTests.m
+++ b/SignalServiceKit/tests/Storage/TSStorageIdentityKeyStoreTests.m
@@ -6,8 +6,8 @@
 #import "OWSPrimaryStorage.h"
 #import "OWSRecipientIdentity.h"
 #import "OWSUnitTestEnvironment.h"
+#import "SSKEnvironment.h"
 #import "SecurityUtils.h"
-#import "TextSecureKitEnv.h"
 #import <Curve25519Kit/Curve25519.h>
 #import <XCTest/XCTest.h>
 

--- a/SignalServiceKit/tests/TestSupport/Fakes/OWSUnitTestEnvironment.h
+++ b/SignalServiceKit/tests/TestSupport/Fakes/OWSUnitTestEnvironment.h
@@ -1,12 +1,12 @@
 //
-//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//  Copyright (c) 2018 Open Whisper Systems. All rights reserved.
 //
 
-#import "TextSecureKitEnv.h"
+#import "SSKEnvironment.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface OWSUnitTestEnvironment : TextSecureKitEnv
+@interface OWSUnitTestEnvironment : SSKEnvironment
 
 + (void)ensureSetup;
 - (instancetype)initDefault;

--- a/SignalServiceKit/tests/TestSupport/Fakes/OWSUnitTestEnvironment.m
+++ b/SignalServiceKit/tests/TestSupport/Fakes/OWSUnitTestEnvironment.m
@@ -1,5 +1,5 @@
 //
-//  Copyright (c) 2017 Open Whisper Systems. All rights reserved.
+//  Copyright (c) 2018 Open Whisper Systems. All rights reserved.
 //
 
 #import "OWSUnitTestEnvironment.h"
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        [self setSharedEnv:[[self alloc] initDefault]];
+        [self setShared:[[self alloc] initDefault]];
     });
 }
 

--- a/SignalShareExtension/ShareViewController.swift
+++ b/SignalShareExtension/ShareViewController.swift
@@ -201,7 +201,7 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
 
                 // We don't need to use the TSSocketManager in the SAE.
 
-                Environment.shared().contactsManager.fetchSystemContactsOnceIfAlreadyAuthorized()
+                Environment.shared.contactsManager.fetchSystemContactsOnceIfAlreadyAuthorized()
 
                 // We don't need to fetch messages in the SAE.
 
@@ -267,8 +267,8 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
 
         AppVersion.sharedInstance().saeLaunchDidComplete()
 
-        Environment.shared().contactsManager.loadSignalAccountsFromCache()
-        Environment.shared().contactsManager.startObserving()
+        Environment.shared.contactsManager.loadSignalAccountsFromCache()
+        Environment.shared.contactsManager.startObserving()
 
         ensureRootViewController()
 

--- a/SignalShareExtension/ShareViewController.swift
+++ b/SignalShareExtension/ShareViewController.swift
@@ -201,7 +201,7 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
 
                 // We don't need to use the TSSocketManager in the SAE.
 
-                Environment.current().contactsManager.fetchSystemContactsOnceIfAlreadyAuthorized()
+                Environment.shared().contactsManager.fetchSystemContactsOnceIfAlreadyAuthorized()
 
                 // We don't need to fetch messages in the SAE.
 
@@ -267,8 +267,8 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
 
         AppVersion.sharedInstance().saeLaunchDidComplete()
 
-        Environment.current().contactsManager.loadSignalAccountsFromCache()
-        Environment.current().contactsManager.startObserving()
+        Environment.shared().contactsManager.loadSignalAccountsFromCache()
+        Environment.shared().contactsManager.startObserving()
 
         ensureRootViewController()
 


### PR DESCRIPTION
Very mechanical changes.  


* Rename `TextSecureKitEnv` to `SSKEnvironment`.
* Modify environment accessors to use our 'shared' convention.

First steps towards making `Environment` and `SSKEnvironment` more consistent and consistent with our other code.

PTAL @michaelkirk 