### PR TITLE
Simplify OWSPreferences access.

### DIFF
--- a/Signal/src/AppDelegate.m
+++ b/Signal/src/AppDelegate.m
@@ -627,7 +627,7 @@ static NSTimeInterval launchStartedAt;
                 // restart the app, so we check every activation for users who haven't yet registered.
                 __unused AnyPromise *promise =
                     [OWSSyncPushTokensJob runWithAccountManager:SignalApp.sharedApp.accountManager
-                                                    preferences:[Environment preferences]];
+                                                    preferences:Environment.shared.preferences];
             }
 
             if ([OWS2FAManager sharedManager].isDueForReminder) {
@@ -1034,7 +1034,7 @@ static NSTimeInterval launchStartedAt;
         // This should happen at any launch, background or foreground.
         __unused AnyPromise *pushTokenpromise =
             [OWSSyncPushTokensJob runWithAccountManager:SignalApp.sharedApp.accountManager
-                                            preferences:[Environment preferences]];
+                                            preferences:Environment.shared.preferences];
     }
 
     [DeviceSleepManager.sharedInstance removeBlockWithBlockObject:self];
@@ -1048,7 +1048,7 @@ static NSTimeInterval launchStartedAt;
     [[OWSMessageReceiver sharedInstance] handleAnyUnprocessedEnvelopesAsync];
     [[OWSBatchMessageProcessor sharedInstance] handleAnyUnprocessedEnvelopesAsync];
 
-    if (!Environment.preferences.hasGeneratedThumbnails) {
+    if (!Environment.shared.preferences.hasGeneratedThumbnails) {
         [OWSPrimaryStorage.sharedManager.newDatabaseConnection
             asyncReadWithBlock:^(YapDatabaseReadTransaction *_Nonnull transaction) {
                 [TSAttachmentStream enumerateCollectionObjectsUsingBlock:^(id _Nonnull obj, BOOL *_Nonnull stop){
@@ -1056,7 +1056,7 @@ static NSTimeInterval launchStartedAt;
                 }];
             }
             completionBlock:^{
-                [Environment.preferences setHasGeneratedThumbnails:YES];
+                [Environment.shared.preferences setHasGeneratedThumbnails:YES];
             }];
     }
 

--- a/Signal/src/ViewControllers/AppSettings/AboutTableViewController.m
+++ b/Signal/src/ViewControllers/AppSettings/AboutTableViewController.m
@@ -128,7 +128,7 @@
 
     [contents addSection:debugSection];
 
-    OWSPreferences *preferences = [Environment preferences];
+    OWSPreferences *preferences = Environment.shared.preferences;
     NSString *_Nullable pushToken = [preferences getPushToken];
     NSString *_Nullable voipToken = [preferences getVoipToken];
     [debugSection

--- a/Signal/src/ViewControllers/AppSettings/AdvancedSettingsTableViewController.m
+++ b/Signal/src/ViewControllers/AppSettings/AdvancedSettingsTableViewController.m
@@ -251,7 +251,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)syncPushTokens
 {
     OWSSyncPushTokensJob *job = [[OWSSyncPushTokensJob alloc] initWithAccountManager:SignalApp.sharedApp.accountManager
-                                                                         preferences:[Environment preferences]];
+                                                                         preferences:Environment.shared.preferences];
     job.uploadOnlyIfStale = NO;
     [job run]
         .then(^{

--- a/Signal/src/ViewControllers/AppSettings/NotificationSettingsOptionsViewController.m
+++ b/Signal/src/ViewControllers/AppSettings/NotificationSettingsOptionsViewController.m
@@ -27,7 +27,7 @@
     OWSTableSection *section = [OWSTableSection new];
     section.footerTitle = NSLocalizedString(@"NOTIFICATIONS_FOOTER_WARNING", nil);
 
-    OWSPreferences *prefs = [Environment preferences];
+    OWSPreferences *prefs = Environment.shared.preferences;
     NotificationType selectedNotifType = [prefs notificationPreviewType];
     for (NSNumber *option in
         @[ @(NotificationNamePreview), @(NotificationNameNoPreview), @(NotificationNoNameNoPreview) ]) {
@@ -53,7 +53,7 @@
 
 - (void)setNotificationType:(NotificationType)notificationType
 {
-    [Environment.preferences setNotificationPreviewType:notificationType];
+    [Environment.shared.preferences setNotificationPreviewType:notificationType];
 
     // rebuild callUIAdapter since notification configuration changed.
     [SignalApp.sharedApp.callService createCallUIAdapter];

--- a/Signal/src/ViewControllers/AppSettings/NotificationSettingsViewController.m
+++ b/Signal/src/ViewControllers/AppSettings/NotificationSettingsViewController.m
@@ -35,7 +35,7 @@
 
     __weak NotificationSettingsViewController *weakSelf = self;
 
-    OWSPreferences *prefs = [Environment preferences];
+    OWSPreferences *prefs = Environment.shared.preferences;
 
     // Sounds section.
 
@@ -83,7 +83,7 @@
 
 - (void)didToggleSoundNotificationsSwitch:(UISwitch *)sender
 {
-    [Environment.preferences setSoundInForeground:sender.on];
+    [Environment.shared.preferences setSoundInForeground:sender.on];
 }
 
 @end

--- a/Signal/src/ViewControllers/AppSettings/PrivacySettingsTableViewController.m
+++ b/Signal/src/ViewControllers/AppSettings/PrivacySettingsTableViewController.m
@@ -113,10 +113,11 @@ NS_ASSUME_NONNULL_BEGIN
     OWSTableSection *screenSecuritySection = [OWSTableSection new];
     screenSecuritySection.headerTitle = NSLocalizedString(@"SETTINGS_SECURITY_TITLE", @"Section header");
     screenSecuritySection.footerTitle = NSLocalizedString(@"SETTINGS_SCREEN_SECURITY_DETAIL", nil);
-    [screenSecuritySection addItem:[OWSTableItem switchItemWithText:NSLocalizedString(@"SETTINGS_SCREEN_SECURITY", @"")
-                                                               isOn:[Environment.preferences screenSecurityIsEnabled]
-                                                             target:weakSelf
-                                                           selector:@selector(didToggleScreenSecuritySwitch:)]];
+    [screenSecuritySection
+        addItem:[OWSTableItem switchItemWithText:NSLocalizedString(@"SETTINGS_SCREEN_SECURITY", @"")
+                                            isOn:[Environment.shared.preferences screenSecurityIsEnabled]
+                                          target:weakSelf
+                                        selector:@selector(didToggleScreenSecuritySwitch:)]];
     [contents addSection:screenSecuritySection];
     
     // Allow calls to connect directly vs. using TURN exclusively
@@ -128,7 +129,7 @@ NS_ASSUME_NONNULL_BEGIN
     [callingSection addItem:[OWSTableItem switchItemWithText:NSLocalizedString(
                                                                  @"SETTINGS_CALLING_HIDES_IP_ADDRESS_PREFERENCE_TITLE",
                                                                  @"Table cell label")
-                                                        isOn:[Environment.preferences doCallsHideIPAddress]
+                                                        isOn:[Environment.shared.preferences doCallsHideIPAddress]
                                                       target:weakSelf
                                                     selector:@selector(didToggleCallsHideIPAddressSwitch:)]];
     [contents addSection:callingSection];
@@ -139,7 +140,7 @@ NS_ASSUME_NONNULL_BEGIN
             addItem:[OWSTableItem switchItemWithText:NSLocalizedString(
                                                          @"SETTINGS_PRIVACY_CALLKIT_SYSTEM_CALL_LOG_PREFERENCE_TITLE",
                                                          @"Short table cell label")
-                                                isOn:[Environment.preferences isSystemCallLogEnabled]
+                                                isOn:[Environment.shared.preferences isSystemCallLogEnabled]
                                               target:weakSelf
                                             selector:@selector(didToggleEnableSystemCallLogSwitch:)]];
         callKitSection.footerTitle = NSLocalizedString(
@@ -151,14 +152,14 @@ NS_ASSUME_NONNULL_BEGIN
             = NSLocalizedString(@"SETTINGS_SECTION_CALL_KIT_DESCRIPTION", @"Settings table section footer.");
         [callKitSection addItem:[OWSTableItem switchItemWithText:NSLocalizedString(@"SETTINGS_PRIVACY_CALLKIT_TITLE",
                                                                      @"Short table cell label")
-                                                            isOn:[Environment.preferences isCallKitEnabled]
+                                                            isOn:[Environment.shared.preferences isCallKitEnabled]
                                                           target:weakSelf
                                                         selector:@selector(didToggleEnableCallKitSwitch:)]];
-        if (Environment.preferences.isCallKitEnabled) {
+        if (Environment.shared.preferences.isCallKitEnabled) {
             [callKitSection
                 addItem:[OWSTableItem switchItemWithText:NSLocalizedString(@"SETTINGS_PRIVACY_CALLKIT_PRIVACY_TITLE",
                                                              @"Label for 'CallKit privacy' preference")
-                                                    isOn:![Environment.preferences isCallKitPrivacyEnabled]
+                                                    isOn:![Environment.shared.preferences isCallKitPrivacyEnabled]
                                                   target:weakSelf
                                                 selector:@selector(didToggleEnableCallKitPrivacySwitch:)]];
         }
@@ -234,7 +235,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     BOOL enabled = sender.isOn;
     OWSLogInfo(@"toggled screen security: %@", enabled ? @"ON" : @"OFF");
-    [Environment.preferences setScreenSecurity:enabled];
+    [Environment.shared.preferences setScreenSecurity:enabled];
 }
 
 - (void)didToggleReadReceiptsSwitch:(UISwitch *)sender
@@ -248,7 +249,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     BOOL enabled = sender.isOn;
     OWSLogInfo(@"toggled callsHideIPAddress: %@", enabled ? @"ON" : @"OFF");
-    [Environment.preferences setDoCallsHideIPAddress:enabled];
+    [Environment.shared.preferences setDoCallsHideIPAddress:enabled];
 }
 
 - (void)didToggleEnableSystemCallLogSwitch:(UISwitch *)sender

--- a/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
@@ -2796,10 +2796,10 @@ typedef enum : NSUInteger {
     [self clearUnreadMessagesIndicator];
     self.inputToolbar.quotedReply = nil;
 
-    if (!Environment.preferences.hasSentAMessage) {
-        [Environment.preferences setHasSentAMessage:YES];
+    if (!Environment.shared.preferences.hasSentAMessage) {
+        [Environment.shared.preferences setHasSentAMessage:YES];
     }
-    if ([Environment.preferences soundInForeground]) {
+    if ([Environment.shared.preferences soundInForeground]) {
         SystemSoundID soundId = [OWSSounds systemSoundIDForSound:OWSSound_MessageSent quiet:YES];
         AudioServicesPlaySystemSound(soundId);
     }

--- a/Signal/src/ViewControllers/HomeView/HomeViewController.m
+++ b/Signal/src/ViewControllers/HomeView/HomeViewController.m
@@ -1435,7 +1435,7 @@ NSString *const kArchivedConversationsReuseIdentifier = @"kArchivedConversations
     NSString *secondLine = @"";
 
     if (self.homeViewMode == HomeViewMode_Inbox) {
-        if ([Environment.preferences hasSentAMessage]) {
+        if ([Environment.shared.preferences hasSentAMessage]) {
             firstLine = NSLocalizedString(
                 @"EMPTY_INBOX_TITLE", @"Header text an existing user sees when viewing an empty inbox");
             secondLine = NSLocalizedString(
@@ -1477,7 +1477,7 @@ NSString *const kArchivedConversationsReuseIdentifier = @"kArchivedConversations
 // If the user hasn't sent a message, we don't want to ask them for a review yet.
 - (void)requestReviewIfAppropriate
 {
-    if (self.hasEverAppeared && Environment.preferences.hasSentAMessage) {
+    if (self.hasEverAppeared && Environment.shared.preferences.hasSentAMessage) {
         OWSLogDebug(@"requesting review");
         if (@available(iOS 10, *)) {
             // In Debug this pops up *every* time, which is helpful, but annoying.

--- a/Signal/src/ViewControllers/NewContactThreadViewController.m
+++ b/Signal/src/ViewControllers/NewContactThreadViewController.m
@@ -676,7 +676,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)hideBackgroundView
 {
-    [[Environment preferences] setHasDeclinedNoContactsView:YES];
+    [Environment.shared.preferences setHasDeclinedNoContactsView:YES];
 
     [self showContactAppropriateViews];
 }
@@ -693,7 +693,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self.contactsViewHelper.contactsManager.isSystemContactsAuthorized) {
         if (self.contactsViewHelper.hasUpdatedContactsAtLeastOnce && self.contactsViewHelper.signalAccounts.count < 1
-            && ![[Environment preferences] hasDeclinedNoContactsView]) {
+            && ![Environment.shared.preferences hasDeclinedNoContactsView]) {
             self.isNoContactsModeActive = YES;
         } else {
             self.isNoContactsModeActive = NO;

--- a/Signal/src/call/UserInterface/CallUIAdapter.swift
+++ b/Signal/src/call/UserInterface/CallUIAdapter.swift
@@ -102,13 +102,13 @@ extension CallUIAdaptee {
             adaptee = NonCallKitCallUIAdaptee(callService: callService, notificationsAdapter: notificationsAdapter)
         } else if #available(iOS 11, *) {
             Logger.info("choosing callkit adaptee for iOS11+")
-            let showNames = Environment.preferences().notificationPreviewType() != .noNameNoPreview
-            let useSystemCallLog = Environment.preferences().isSystemCallLogEnabled()
+            let showNames = Environment.shared.preferences.notificationPreviewType() != .noNameNoPreview
+            let useSystemCallLog = Environment.shared.preferences.isSystemCallLogEnabled()
 
             adaptee = CallKitCallUIAdaptee(callService: callService, contactsManager: contactsManager, notificationsAdapter: notificationsAdapter, showNamesOnCallScreen: showNames, useSystemCallLog: useSystemCallLog)
         } else if #available(iOS 10.0, *), Environment.shared.preferences.isCallKitEnabled() {
             Logger.info("choosing callkit adaptee for iOS10")
-            let hideNames = Environment.preferences().isCallKitPrivacyEnabled() || Environment.preferences().notificationPreviewType() == .noNameNoPreview
+            let hideNames = Environment.shared.preferences.isCallKitPrivacyEnabled() || Environment.shared.preferences.notificationPreviewType() == .noNameNoPreview
             let showNames = !hideNames
 
             // All CallKit calls use the system call log on iOS10

--- a/Signal/src/environment/NotificationsManager.m
+++ b/Signal/src/environment/NotificationsManager.m
@@ -248,7 +248,7 @@
 
                    [[PushManager sharedManager] presentNotification:notification checkForCancel:NO];
                } else {
-                   if (shouldPlaySound && [Environment.preferences soundInForeground]) {
+                   if (shouldPlaySound && [Environment.shared.preferences soundInForeground]) {
                        OWSSound sound = [OWSSounds notificationSoundForThread:thread];
                        SystemSoundID soundId = [OWSSounds systemSoundIDForSound:sound quiet:YES];
                        // Vibrate, respect silent switch, respect "Alert" volume, not media volume.
@@ -282,7 +282,7 @@
 
                    [[PushManager sharedManager] presentNotification:notification checkForCancel:NO];
                } else {
-                   if (shouldPlaySound && [Environment.preferences soundInForeground]) {
+                   if (shouldPlaySound && [Environment.shared.preferences soundInForeground]) {
                        OWSSound sound = [OWSSounds globalNotificationSound];
                        SystemSoundID soundId = [OWSSounds systemSoundIDForSound:sound quiet:YES];
                        // Vibrate, respect silent switch, respect "Alert" volume, not media volume.
@@ -389,7 +389,7 @@
 
             [[PushManager sharedManager] presentNotification:notification checkForCancel:YES];
         } else {
-            if (shouldPlaySound && [Environment.preferences soundInForeground]) {
+            if (shouldPlaySound && [Environment.shared.preferences soundInForeground]) {
                 OWSSound sound = [OWSSounds notificationSoundForThread:thread];
                 SystemSoundID soundId = [OWSSounds systemSoundIDForSound:sound quiet:YES];
                 // Vibrate, respect silent switch, respect "Alert" volume, not media volume.

--- a/Signal/src/environment/SignalApp.m
+++ b/Signal/src/environment/SignalApp.m
@@ -236,7 +236,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     [OWSStorage resetAllStorage];
     [OWSUserProfile resetProfileStorage];
-    [Environment.preferences clear];
+    [Environment.shared.preferences clear];
 
     [self clearAllNotifications];
 

--- a/Signal/src/util/OWSScreenLockUI.m
+++ b/Signal/src/util/OWSScreenLockUI.m
@@ -348,7 +348,7 @@ NS_ASSUME_NONNULL_BEGIN
         return ScreenLockUIStateNone;
     }
 
-    if (Environment.preferences.screenSecurityIsEnabled) {
+    if (Environment.shared.preferences.screenSecurityIsEnabled) {
         OWSLogVerbose(@"desiredUIState: screen protection 4.");
         return ScreenLockUIStateScreenProtection;
     } else {

--- a/Signal/src/util/RegistrationUtils.m
+++ b/Signal/src/util/RegistrationUtils.m
@@ -6,6 +6,7 @@
 #import "CodeVerificationViewController.h"
 #import "OWSNavigationController.h"
 #import <SignalMessaging/Environment.h>
+#import <SignalMessaging/OWSPreferences.h>
 #import <SignalMessaging/SignalMessaging-Swift.h>
 #import <SignalServiceKit/TSAccountManager.h>
 

--- a/SignalMessaging/SignalMessaging.h
+++ b/SignalMessaging/SignalMessaging.h
@@ -34,6 +34,7 @@ FOUNDATION_EXPORT const unsigned char SignalMessagingVersionString[];
 #import <SignalMessaging/OWSGroupAvatarBuilder.h>
 #import <SignalMessaging/OWSMath.h>
 #import <SignalMessaging/OWSNavigationController.h>
+#import <SignalMessaging/OWSPreferences.h>
 #import <SignalMessaging/OWSProfileManager.h>
 #import <SignalMessaging/OWSQuotedReplyModel.h>
 #import <SignalMessaging/OWSSearchBar.h>

--- a/SignalMessaging/Views/OWSAlerts.swift
+++ b/SignalMessaging/Views/OWSAlerts.swift
@@ -100,7 +100,7 @@ import Foundation
             return
         }
 
-        if let iOSUpgradeNagDate = Environment.preferences().iOSUpgradeNagDate() {
+        if let iOSUpgradeNagDate = Environment.shared.preferences.iOSUpgradeNagDate() {
             // Nag no more than once every three days.
             let kNagFrequencySeconds = 3 * kDayInterval
             guard fabs(iOSUpgradeNagDate.timeIntervalSinceNow) > kNagFrequencySeconds else {
@@ -108,7 +108,7 @@ import Foundation
             }
         }
 
-        Environment.preferences().setIOSUpgradeNagDate(Date())
+        Environment.shared.preferences.setIOSUpgradeNagDate(Date())
 
         OWSAlerts.showAlert(title: NSLocalizedString("UPGRADE_IOS_ALERT_TITLE",
                                                         comment: "Title for the alert indicating that user should upgrade iOS."),

--- a/SignalMessaging/environment/Environment.h
+++ b/SignalMessaging/environment/Environment.h
@@ -2,7 +2,6 @@
 //  Copyright (c) 2018 Open Whisper Systems. All rights reserved.
 //
 
-#import "OWSPreferences.h"
 #import <SignalServiceKit/TSStorageHeaders.h>
 
 /**
@@ -17,6 +16,7 @@
 @class OWSContactsManager;
 @class OWSMessageSender;
 @class OWSNavigationController;
+@class OWSPreferences;
 @class TSGroupThread;
 @class TSNetworkManager;
 @class TSThread;
@@ -38,7 +38,5 @@
 
 // Should only be called by tests.
 + (void)clearCurrentForTests;
-
-+ (OWSPreferences *)preferences;
 
 @end

--- a/SignalMessaging/environment/Environment.m
+++ b/SignalMessaging/environment/Environment.m
@@ -4,6 +4,7 @@
 
 #import "Environment.h"
 #import "DebugLogger.h"
+#import "OWSPreferences.h"
 #import "SignalKeyingStorage.h"
 #import <SignalServiceKit/AppContext.h>
 #import <SignalServiceKit/ContactsUpdater.h>
@@ -99,13 +100,6 @@ static Environment *sharedEnvironment = nil;
     OWSAssertDebug(_messageSender);
 
     return _messageSender;
-}
-
-+ (OWSPreferences *)preferences
-{
-    OWSAssertDebug(Environment.shared.preferences);
-
-    return Environment.shared.preferences;
 }
 
 // TODO: Convert to singleton?

--- a/SignalMessaging/environment/migrations/OWS108CallLoggingPreference.m
+++ b/SignalMessaging/environment/migrations/OWS108CallLoggingPreference.m
@@ -23,7 +23,7 @@ static NSString *const OWS108CallLoggingPreferenceId = @"108";
 {
     OWSAssertDebug(transaction);
 
-    [[Environment preferences] applyCallLoggingSettingsForLegacyUsersWithTransaction:transaction];
+    [Environment.shared.preferences applyCallLoggingSettingsForLegacyUsersWithTransaction:transaction];
 }
 
 @end


### PR DESCRIPTION
We should access `preferences` like the other singletons that hang on `Environment` - via `Environment.shared`.

PTAL @michaelkirk 