### PR TITLE
Treat failure to delete a non-existent password as success

### DIFF
--- a/SignalServiceKit/src/Storage/KeychainStorage.swift
+++ b/SignalServiceKit/src/Storage/KeychainStorage.swift
@@ -94,6 +94,10 @@ public class SSKDefaultKeychainStorage: NSObject, SSKKeychainStorage {
         var error: NSError?
         let result = SAMKeychain.deletePassword(forService: service, account: key, error: &error)
         if let error = error {
+            // If deletion failed because the specified item could not be found in the keychain, consider it success.
+            if error.code == errSecItemNotFound {
+                return
+            }
             throw KeychainStorageError.failure(description: "\(logTag) error removing data: \(error)")
         }
         guard result else {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone X (simulator), iOS 11.4 (15F79)
 * iPhone X, iOS 11.4.1 (15G77)

- - - - - - - - - -

### Description

If `SSKDefaultKeychainStorage.remove(service:key:)` fails to remove a keychain item because the specified item does not exist, treat the operation as having succeeded instead of throwing an error.

Fixes https://github.com/signalapp/Signal-iOS/issues/3876. With these changes, the app no longer crashes on launch when installed on a clean device and run for the first time.
