### PR TITLE
New resolutions for call banner, rename to accommodate multiple X dev…

### DIFF
--- a/SignalMessaging/categories/UIDevice+featureSupport.swift
+++ b/SignalMessaging/categories/UIDevice+featureSupport.swift
@@ -11,7 +11,7 @@ public extension UIDevice {
     }
 
     @objc
-    public var isIPhoneX: Bool {
+    public var hasIPhoneXNotch: Bool {
         switch UIScreen.main.nativeBounds.height {
         case 960:
             //  iPad in iPhone compatibility mode (using old iPhone 4 screen size)
@@ -22,10 +22,17 @@ public extension UIDevice {
         case 1334:
             // iPhone 6/6S/7/8
             return false
+        case 1792:
+            // iPhone XR
+            return true
         case 1920, 2208:
             // iPhone 6+/6S+/7+/8+//
             return false
         case 2436:
+            // iPhone X, iPhone XS
+            return true
+        case 2688:
+            // iPhone X Max
             return true
         default:
             // Verify all our IOS_DEVICE_CONSTANT tags make sense when adding a new device size.

--- a/SignalMessaging/utils/OWSWindowManager.m
+++ b/SignalMessaging/utils/OWSWindowManager.m
@@ -14,16 +14,23 @@ NSString *const OWSWindowManagerCallDidChangeNotification = @"OWSWindowManagerCa
 
 const CGFloat OWSWindowManagerCallBannerHeight(void)
 {
-    if ([UIDevice currentDevice].isIPhoneX) {
-        // On an iPhoneX, the system return-to-call banner has been replaced by a much subtler green
-        // circle behind the system clock. Instead, we mimic the old system call banner as on older devices,
-        // but it has to be taller to fit beneath the notch.
-        // IOS_DEVICE_CONSTANT, we'll want to revisit this when new device dimensions are introduced.
-        return 64;
-    } else {
-
+    if (@available(iOS 11.4, *)) {
         return CurrentAppContext().statusBarHeight + 20;
     }
+
+
+    if (![UIDevice currentDevice].hasIPhoneXNotch) {
+        return CurrentAppContext().statusBarHeight + 20;
+    }
+
+    // Hardcode CallBanner height for iPhone X's on older iOS.
+    //
+    // As of iOS11.4 and iOS12, this no longer seems to be an issue, but previously statusBarHeight returned
+    // something like 20pts (IIRC), meaning our call banner did not extend sufficiently past the iPhone X notch.
+    //
+    // Before noticing that this behavior changed, I actually assumed that notch height was intentionally excluded from
+    // the statusBarHeight, and that this was not a bug, else I'd have taken better notes.
+    return 64;
 }
 
 // Behind everything, especially the root window.


### PR DESCRIPTION
…ices.

Only apply work-around to legacy versions where required.
 PTAL @charlesmchen 