### PR TITLE
Fix #3844: Incorrect voice messages duration

### DIFF
--- a/SignalMessaging/utils/OWSAudioPlayer.m
+++ b/SignalMessaging/utils/OWSAudioPlayer.m
@@ -135,7 +135,7 @@ NS_ASSUME_NONNULL_BEGIN
             self.audioPlayer.numberOfLoops = -1;
         }
     }
-
+    [self.audioPlayer prepareToPlay];
     [self.audioPlayer play];
     [self.audioPlayerPoller invalidate];
     self.audioPlayerPoller = [NSTimer weakScheduledTimerWithTimeInterval:.05f

--- a/SignalServiceKit/src/Messages/Attachments/TSAttachment.m
+++ b/SignalServiceKit/src/Messages/Attachments/TSAttachment.m
@@ -9,7 +9,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-NSUInteger const TSAttachmentSchemaVersion = 4;
+NSUInteger const TSAttachmentSchemaVersion = 5;
 
 @interface TSAttachment ()
 

--- a/SignalServiceKit/src/Messages/Attachments/TSAttachmentStream.m
+++ b/SignalServiceKit/src/Messages/Attachments/TSAttachmentStream.m
@@ -136,7 +136,11 @@ typedef void (^OWSLoadedThumbnailSuccess)(OWSLoadedThumbnail *loadedThumbnail);
     if (attachmentSchemaVersion < 5) {
         // Older audio attachments could have incorrect durations due
         // to weirdness in AVAudioPlayer.
-        self.cachedAudioDurationSeconds = nil;
+        // Per comments on cachedAudioDurationSeconds, we should only update
+        // this on the main thread.
+        if ([NSThread isMainThread]) {
+            self.cachedAudioDurationSeconds = nil;
+        }
     }
 }
 

--- a/SignalServiceKit/src/Messages/Attachments/TSAttachmentStream.m
+++ b/SignalServiceKit/src/Messages/Attachments/TSAttachmentStream.m
@@ -132,6 +132,12 @@ typedef void (^OWSLoadedThumbnailSuccess)(OWSLoadedThumbnail *loadedThumbnail);
             self.cachedImageHeight = nil;
         }
     }
+
+    if (attachmentSchemaVersion < 5) {
+        // Older audio attachments could have incorrect durations due
+        // to weirdness in AVAudioPlayer.
+        self.cachedAudioDurationSeconds = nil;
+    }
 }
 
 - (void)ensureFilePath

--- a/SignalServiceKit/src/Messages/Attachments/TSAttachmentStream.m
+++ b/SignalServiceKit/src/Messages/Attachments/TSAttachmentStream.m
@@ -579,6 +579,7 @@ typedef void (^OWSLoadedThumbnailSuccess)(OWSLoadedThumbnail *loadedThumbnail);
 
     NSError *error;
     AVAudioPlayer *audioPlayer = [[AVAudioPlayer alloc] initWithContentsOfURL:self.originalMediaURL error:&error];
+    [audioPlayer prepareToPlay];
     if (error && [error.domain isEqualToString:NSOSStatusErrorDomain]
         && (error.code == kAudioFileInvalidFileError || error.code == kAudioFileStreamError_InvalidFile)) {
         // Ignore "invalid audio file" errors.


### PR DESCRIPTION
… by telling AVAudioPlayer that we REALLY, seriously intend to play this file

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
_This section was deleted, so sure, I'm following a blank check?_
- [?] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 6, iOS 12.0.1


- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->
Fixes #3844 and related #3086. Tested by sending test audio file to iPhone 6 running debug version of this with fixes, and then sending same file to iPhone SE running Signal 2.20.2.16. See #3844 for instructions and test audio.