### PR TITLE
Charlesmchen/app will become ready 

### DIFF
--- a/Signal/src/AppDelegate.m
+++ b/Signal/src/AppDelegate.m
@@ -1130,17 +1130,9 @@ static NSTimeInterval launchStartedAt;
 
     [AppVersion.sharedInstance mainAppLaunchDidComplete];
 
-    [Environment.shared.contactsManager setup];
-    [Environment.shared.contactsManager startObserving];
-
-    // If there were any messages in our local queue which we hadn't yet processed.
-    [SSKEnvironment.shared.messageReceiver handleAnyUnprocessedEnvelopesAsync];
-    [SSKEnvironment.shared.batchMessageProcessor handleAnyUnprocessedEnvelopesAsync];
     [Environment.shared.audioSession setup];
 
     [SSKEnvironment.shared.reachabilityManager setup];
-    [SSKEnvironment.shared.messageSenderJobQueue setup];
-    [AppEnvironment.shared.sessionResetJobQueue setup];
 
     if (!Environment.shared.preferences.hasGeneratedThumbnails) {
         [self.primaryStorage.newDatabaseConnection

--- a/Signal/src/AppDelegate.m
+++ b/Signal/src/AppDelegate.m
@@ -550,7 +550,7 @@ static NSTimeInterval launchStartedAt;
 
     if (!AppReadiness.isAppReady) {
         OWSLogWarn(@"Ignoring openURL: app not ready.");
-        // We don't need to use [AppReadiness runNowOrWhenAppIsReady:];
+        // We don't need to use [AppReadiness runNowOrWhenAppDidBecomeReady:];
         // the only URLs we handle in Signal iOS at the moment are used
         // for resuming the verification step of the registration flow.
         return NO;
@@ -596,7 +596,7 @@ static NSTimeInterval launchStartedAt;
 
     [self ensureRootViewController];
 
-    [AppReadiness runNowOrWhenAppIsReady:^{
+    [AppReadiness runNowOrWhenAppDidBecomeReady:^{
         [self handleActivation];
     }];
 
@@ -616,7 +616,7 @@ static NSTimeInterval launchStartedAt;
 
 - (void)enableBackgroundRefreshIfNecessary
 {
-    [AppReadiness runNowOrWhenAppIsReady:^{
+    [AppReadiness runNowOrWhenAppDidBecomeReady:^{
         if (OWS2FAManager.sharedManager.is2FAEnabled && [self.tsAccountManager isRegistered]) {
             // Ping server once a day to keep-alive 2FA clients.
             const NSTimeInterval kBackgroundRefreshInterval = 24 * 60 * 60;
@@ -732,7 +732,7 @@ static NSTimeInterval launchStartedAt;
     OWSAssertIsOnMainThread();
 
     [SignalApp clearAllNotifications];
-    [AppReadiness runNowOrWhenAppIsReady:^{
+    [AppReadiness runNowOrWhenAppDidBecomeReady:^{
         [OWSMessageUtils.sharedManager updateApplicationBadgeCount];
     }];
 }
@@ -747,7 +747,7 @@ static NSTimeInterval launchStartedAt;
         return;
     }
 
-    [AppReadiness runNowOrWhenAppIsReady:^{
+    [AppReadiness runNowOrWhenAppDidBecomeReady:^{
         if (![self.tsAccountManager isRegistered]) {
             UIAlertController *controller =
                 [UIAlertController alertControllerWithTitle:NSLocalizedString(@"REGISTER_CONTACTS_WELCOME", nil)
@@ -818,7 +818,7 @@ static NSTimeInterval launchStartedAt;
             return NO;
         }
 
-        [AppReadiness runNowOrWhenAppIsReady:^{
+        [AppReadiness runNowOrWhenAppDidBecomeReady:^{
             NSString *_Nullable phoneNumber = handle;
             if ([handle hasPrefix:CallKitCallManager.kAnonymousCallHandlePrefix]) {
                 phoneNumber = [self.primaryStorage phoneNumberForCallKitId:handle];
@@ -875,7 +875,7 @@ static NSTimeInterval launchStartedAt;
             return NO;
         }
 
-        [AppReadiness runNowOrWhenAppIsReady:^{
+        [AppReadiness runNowOrWhenAppDidBecomeReady:^{
             NSString *_Nullable phoneNumber = handle;
             if ([handle hasPrefix:CallKitCallManager.kAnonymousCallHandlePrefix]) {
                 phoneNumber = [self.primaryStorage phoneNumberForCallKitId:handle];
@@ -980,7 +980,7 @@ static NSTimeInterval launchStartedAt;
     }
 
     OWSLogInfo(@"%@", notification);
-    [AppReadiness runNowOrWhenAppIsReady:^{
+    [AppReadiness runNowOrWhenAppDidBecomeReady:^{
         [[PushManager sharedManager] application:application didReceiveLocalNotification:notification];
     }];
 }
@@ -1003,7 +1003,7 @@ static NSTimeInterval launchStartedAt;
     // later, after this method returns.
     //
     // https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623068-application?language=objc
-    [AppReadiness runNowOrWhenAppIsReady:^{
+    [AppReadiness runNowOrWhenAppDidBecomeReady:^{
         [[PushManager sharedManager] application:application
                       handleActionWithIdentifier:identifier
                             forLocalNotification:notification
@@ -1032,7 +1032,7 @@ static NSTimeInterval launchStartedAt;
     // later, after this method returns.
     //
     // https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623068-application?language=objc
-    [AppReadiness runNowOrWhenAppIsReady:^{
+    [AppReadiness runNowOrWhenAppDidBecomeReady:^{
         [[PushManager sharedManager] application:application
                       handleActionWithIdentifier:identifier
                             forLocalNotification:notification
@@ -1045,7 +1045,7 @@ static NSTimeInterval launchStartedAt;
     performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler
 {
     OWSLogInfo(@"performing background fetch");
-    [AppReadiness runNowOrWhenAppIsReady:^{
+    [AppReadiness runNowOrWhenAppDidBecomeReady:^{
         __block AnyPromise *job = [AppEnvironment.shared.messageFetcherJob run].then(^{
             // HACK: Call completion handler after n seconds.
             //

--- a/Signal/src/Jobs/SessionResetJob.swift
+++ b/Signal/src/Jobs/SessionResetJob.swift
@@ -24,6 +24,15 @@ public class SessionResetJobQueue: NSObject, JobQueue {
     public var runningOperations: [SessionResetOperation] = []
 
     @objc
+    public override init() {
+        super.init()
+
+        AppReadiness.runNowOrWhenAppWillBecomeReady {
+            self.setup()
+        }
+    }
+
+    @objc
     public func setup() {
         defaultSetup()
     }

--- a/Signal/src/network/PushManager.m
+++ b/Signal/src/network/PushManager.m
@@ -105,13 +105,13 @@ NSString *const Signal_Message_MarkAsRead_Identifier = @"Signal_Message_MarkAsRe
 {
     OWSLogInfo(@"received remote notification");
 
-    [AppReadiness runNowOrWhenAppIsReady:^{
+    [AppReadiness runNowOrWhenAppDidBecomeReady:^{
         [self.messageFetcherJob run];
     }];
 }
 
 - (void)applicationDidBecomeActive {
-    [AppReadiness runNowOrWhenAppIsReady:^{
+    [AppReadiness runNowOrWhenAppDidBecomeReady:^{
         [self.messageFetcherJob run];
     }];
 }
@@ -130,7 +130,7 @@ NSString *const Signal_Message_MarkAsRead_Identifier = @"Signal_Message_MarkAsRe
     // If we want to re-introduce silent pushes we can remove this assert.
     OWSFailDebug(@"Unexpected content-available push.");
 
-    [AppReadiness runNowOrWhenAppIsReady:^{
+    [AppReadiness runNowOrWhenAppDidBecomeReady:^{
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 20 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
             completionHandler(UIBackgroundFetchResultNewData);
         });

--- a/Signal/src/util/OWSScreenLockUI.m
+++ b/Signal/src/util/OWSScreenLockUI.m
@@ -138,7 +138,7 @@ NS_ASSUME_NONNULL_BEGIN
     //
     // It's not safe to access OWSScreenLock.isScreenLockEnabled
     // until the app is ready.
-    [AppReadiness runNowOrWhenAppIsReady:^{
+    [AppReadiness runNowOrWhenAppWillBecomeReady:^{
         self.isScreenLockLocked = OWSScreenLock.sharedManager.isScreenLockEnabled;
         
         [self ensureUI];
@@ -251,7 +251,7 @@ NS_ASSUME_NONNULL_BEGIN
     OWSAssertIsOnMainThread();
 
     if (!AppReadiness.isAppReady) {
-        [AppReadiness runNowOrWhenAppIsReady:^{
+        [AppReadiness runNowOrWhenAppWillBecomeReady:^{
             [self ensureUI];
         }];
         return;

--- a/SignalMessaging/contacts/OWSContactsManager.h
+++ b/SignalMessaging/contacts/OWSContactsManager.h
@@ -25,8 +25,6 @@ extern NSString *const OWSContactsManagerSignalAccountsDidChangeNotification;
 
 - (id)initWithPrimaryStorage:(OWSPrimaryStorage *)primaryStorage;
 
-- (void)startObserving;
-
 #pragma mark - Accessors
 
 @property (nonnull, readonly) ImageCache *avatarCache;
@@ -43,8 +41,6 @@ extern NSString *const OWSContactsManagerSignalAccountsDidChangeNotification;
 // This will always return an instance of SignalAccount.
 - (SignalAccount *)fetchOrBuildSignalAccountForRecipientId:(NSString *)recipientId;
 - (BOOL)hasSignalAccountForRecipientId:(NSString *)recipientId;
-
-- (void)setup;
 
 #pragma mark - System Contact Fetching
 

--- a/SignalMessaging/contacts/OWSContactsManager.m
+++ b/SignalMessaging/contacts/OWSContactsManager.m
@@ -82,6 +82,13 @@ NSString *const OWSContactsManagerKeyNextFullIntersectionDate = @"OWSContactsMan
 
     OWSSingletonAssert();
 
+    [AppReadiness runNowOrWhenAppWillBecomeReady:^{
+        [self setup];
+    }];
+    [AppReadiness runNowOrWhenAppDidBecomeReady:^{
+        [self startObserving];
+    }];
+
     return self;
 }
 

--- a/SignalMessaging/contacts/OWSContactsManager.m
+++ b/SignalMessaging/contacts/OWSContactsManager.m
@@ -84,8 +84,7 @@ NSString *const OWSContactsManagerKeyNextFullIntersectionDate = @"OWSContactsMan
 
     [AppReadiness runNowOrWhenAppWillBecomeReady:^{
         [self setup];
-    }];
-    [AppReadiness runNowOrWhenAppDidBecomeReady:^{
+
         [self startObserving];
     }];
 
@@ -409,10 +408,12 @@ NSString *const OWSContactsManagerKeyNextFullIntersectionDate = @"OWSContactsMan
 {
     OWSAssertIsOnMainThread();
 
-    NSString *recipientId = notification.userInfo[kNSNotificationKey_ProfileRecipientId];
-    OWSAssertDebug(recipientId.length > 0);
+    [AppReadiness runNowOrWhenAppDidBecomeReady:^{
+        NSString *recipientId = notification.userInfo[kNSNotificationKey_ProfileRecipientId];
+        OWSAssertDebug(recipientId.length > 0);
 
-    [self.avatarCache removeAllImagesForKey:recipientId];
+        [self.avatarCache removeAllImagesForKey:recipientId];
+    }];
 }
 
 - (void)updateWithContacts:(NSArray<Contact *> *)contacts

--- a/SignalMessaging/contacts/OWSSyncManager.m
+++ b/SignalMessaging/contacts/OWSSyncManager.m
@@ -214,7 +214,7 @@ NSString *const kSyncManagerLastContactSyncKey = @"kTSStorageManagerOWSSyncManag
 }
 
 - (void)sendConfigurationSyncMessage {
-    [AppReadiness runNowOrWhenAppIsReady:^{
+    [AppReadiness runNowOrWhenAppDidBecomeReady:^{
         [self sendConfigurationSyncMessage_AppReady];
     }];
 }

--- a/SignalMessaging/contacts/SystemContactsFetcher.swift
+++ b/SignalMessaging/contacts/SystemContactsFetcher.swift
@@ -64,7 +64,7 @@ class ContactsFrameworkContactStoreAdaptee: NSObject, ContactStoreAdaptee {
 
     @objc
     func didBecomeActive() {
-        AppReadiness.runNowOrWhenAppIsReady {
+        AppReadiness.runNowOrWhenAppDidBecomeReady {
             let currentSortOrder = CNContactsUserDefaults.shared().sortOrder
 
             guard currentSortOrder != self.lastSortOrder else {

--- a/SignalMessaging/profiles/OWSProfileManager.m
+++ b/SignalMessaging/profiles/OWSProfileManager.m
@@ -94,7 +94,7 @@ typedef void (^ProfileManagerFailureBlock)(NSError *error);
 
     OWSSingletonAssert();
 
-    [AppReadiness runNowOrWhenAppIsReady:^{
+    [AppReadiness runNowOrWhenAppDidBecomeReady:^{
         [self rotateLocalProfileKeyIfNecessary];
     }];
 
@@ -1479,7 +1479,7 @@ typedef void (^ProfileManagerFailureBlock)(NSError *error);
 - (void)blockListDidChange:(NSNotification *)notification {
     OWSAssertIsOnMainThread();
 
-    [AppReadiness runNowOrWhenAppIsReady:^{
+    [AppReadiness runNowOrWhenAppDidBecomeReady:^{
         [self rotateLocalProfileKeyIfNecessary];
     }];
 }

--- a/SignalServiceKit/src/Account/TSAccountManager.m
+++ b/SignalServiceKit/src/Account/TSAccountManager.m
@@ -85,7 +85,7 @@ NSString *const TSAccountManager_NeedsAccountAttributesUpdateKey = @"TSAccountMa
                                                    object:nil];
     }
 
-    [AppReadiness runNowOrWhenAppIsReady:^{
+    [AppReadiness runNowOrWhenAppDidBecomeReady:^{
         [self updateAccountAttributesIfNecessary];
     }];
 
@@ -683,7 +683,7 @@ NSString *const TSAccountManager_NeedsAccountAttributesUpdateKey = @"TSAccountMa
 - (void)reachabilityChanged {
     OWSAssertIsOnMainThread();
 
-    [AppReadiness runNowOrWhenAppIsReady:^{
+    [AppReadiness runNowOrWhenAppDidBecomeReady:^{
         [self updateAccountAttributesIfNecessary];
     }];
 }

--- a/SignalServiceKit/src/Messages/OWSBatchMessageProcessor.h
+++ b/SignalServiceKit/src/Messages/OWSBatchMessageProcessor.h
@@ -24,8 +24,6 @@ NS_ASSUME_NONNULL_BEGIN
               plaintextData:(NSData *_Nullable)plaintextData
                 transaction:(YapDatabaseReadWriteTransaction *)transaction;
 
-- (void)handleAnyUnprocessedEnvelopesAsync;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/SignalServiceKit/src/Messages/OWSBatchMessageProcessor.m
+++ b/SignalServiceKit/src/Messages/OWSBatchMessageProcessor.m
@@ -458,6 +458,12 @@ NSString *const OWSMessageContentJobFinderExtensionGroup = @"OWSMessageContentJo
 
     _processingQueue = processingQueue;
 
+    [AppReadiness runNowOrWhenAppDidBecomeReady:^{
+        if (CurrentAppContext().isMainApp) {
+            [self.processingQueue drainQueue];
+        }
+    }];
+
     return self;
 }
 
@@ -474,11 +480,6 @@ NSString *const OWSMessageContentJobFinderExtensionGroup = @"OWSMessageContentJo
 }
 
 #pragma mark - instance methods
-
-- (void)handleAnyUnprocessedEnvelopesAsync
-{
-    [self.processingQueue drainQueue];
-}
 
 - (void)enqueueEnvelopeData:(NSData *)envelopeData
               plaintextData:(NSData *_Nullable)plaintextData

--- a/SignalServiceKit/src/Messages/OWSBatchMessageProcessor.m
+++ b/SignalServiceKit/src/Messages/OWSBatchMessageProcessor.m
@@ -269,7 +269,7 @@ NSString *const OWSMessageContentJobFinderExtensionGroup = @"OWSMessageContentJo
                                                object:nil];
 
     // Start processing.
-    [AppReadiness runNowOrWhenAppIsReady:^{
+    [AppReadiness runNowOrWhenAppDidBecomeReady:^{
         [self drainQueue];
     }];
 

--- a/SignalServiceKit/src/Messages/OWSBatchMessageProcessor.m
+++ b/SignalServiceKit/src/Messages/OWSBatchMessageProcessor.m
@@ -270,7 +270,9 @@ NSString *const OWSMessageContentJobFinderExtensionGroup = @"OWSMessageContentJo
 
     // Start processing.
     [AppReadiness runNowOrWhenAppDidBecomeReady:^{
-        [self drainQueue];
+        if (CurrentAppContext().isMainApp) {
+            [self drainQueue];
+        }
     }];
 
     return self;

--- a/SignalServiceKit/src/Messages/OWSBlockingManager.m
+++ b/SignalServiceKit/src/Messages/OWSBlockingManager.m
@@ -422,7 +422,7 @@ NSString *const kOWSBlockingManager_SyncedBlockedGroupIdsKey = @"kOWSBlockingMan
 {
     OWSAssertIsOnMainThread();
 
-    [AppReadiness runNowOrWhenAppIsReady:^{
+    [AppReadiness runNowOrWhenAppDidBecomeReady:^{
         @synchronized(self)
         {
             [self syncBlockListIfNecessary];

--- a/SignalServiceKit/src/Messages/OWSDisappearingMessagesJob.m
+++ b/SignalServiceKit/src/Messages/OWSDisappearingMessagesJob.m
@@ -69,7 +69,7 @@ void AssertIsOnDisappearingMessagesQueue()
 
     // suspenders in case a deletion schedule is missed.
     NSTimeInterval kFallBackTimerInterval = 5 * kMinuteInterval;
-    [AppReadiness runNowOrWhenAppIsReady:^{
+    [AppReadiness runNowOrWhenAppDidBecomeReady:^{
         if (CurrentAppContext().isMainApp) {
             self.fallbackTimer = [NSTimer weakScheduledTimerWithTimeInterval:kFallBackTimerInterval
                                                                       target:self
@@ -405,7 +405,7 @@ void AssertIsOnDisappearingMessagesQueue()
 {
     OWSAssertIsOnMainThread();
 
-    [AppReadiness runNowOrWhenAppIsReady:^{
+    [AppReadiness runNowOrWhenAppDidBecomeReady:^{
         dispatch_async(OWSDisappearingMessagesJob.serialQueue, ^{
             [self runLoop];
         });

--- a/SignalServiceKit/src/Messages/OWSIdentityManager.m
+++ b/SignalServiceKit/src/Messages/OWSIdentityManager.m
@@ -569,7 +569,7 @@ NSString *const kNSNotificationName_IdentityStateDidChange = @"kNSNotificationNa
 {
     OWSAssertIsOnMainThread();
 
-    [AppReadiness runNowOrWhenAppIsReady:^{
+    [AppReadiness runNowOrWhenAppDidBecomeReady:^{
         [self syncQueuedVerificationStates];
     }];
 }

--- a/SignalServiceKit/src/Messages/OWSMessageManager.m
+++ b/SignalServiceKit/src/Messages/OWSMessageManager.m
@@ -185,7 +185,7 @@ NS_ASSUME_NONNULL_BEGIN
     } else {
         static dispatch_once_t onceToken;
         dispatch_once(&onceToken, ^{
-            [AppReadiness runNowOrWhenAppIsReady:^{
+            [AppReadiness runNowOrWhenAppDidBecomeReady:^{
                 [OWSMessageUtils.sharedManager updateApplicationBadgeCount];
             }];
         });

--- a/SignalServiceKit/src/Messages/OWSMessageReceiver.h
+++ b/SignalServiceKit/src/Messages/OWSMessageReceiver.h
@@ -20,7 +20,6 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)asyncRegisterDatabaseExtension:(OWSStorage *)storage;
 
 - (void)handleReceivedEnvelopeData:(NSData *)envelopeData;
-- (void)handleAnyUnprocessedEnvelopesAsync;
 
 @end
 

--- a/SignalServiceKit/src/Messages/OWSMessageReceiver.m
+++ b/SignalServiceKit/src/Messages/OWSMessageReceiver.m
@@ -248,7 +248,7 @@ NSString *const OWSMessageDecryptJobFinderExtensionGroup = @"OWSMessageProcessin
     _finder = finder;
     _isDrainingQueue = NO;
 
-    [AppReadiness runNowOrWhenAppIsReady:^{
+    [AppReadiness runNowOrWhenAppDidBecomeReady:^{
         [self drainQueue];
     }];
 

--- a/SignalServiceKit/src/Messages/OWSMessageReceiver.m
+++ b/SignalServiceKit/src/Messages/OWSMessageReceiver.m
@@ -414,6 +414,12 @@ NSString *const OWSMessageDecryptJobFinderExtensionGroup = @"OWSMessageProcessin
 
     _processingQueue = processingQueue;
 
+    [AppReadiness runNowOrWhenAppDidBecomeReady:^{
+        if (CurrentAppContext().isMainApp) {
+            [self.processingQueue drainQueue];
+        }
+    }];
+
     return self;
 }
 
@@ -430,11 +436,6 @@ NSString *const OWSMessageDecryptJobFinderExtensionGroup = @"OWSMessageProcessin
 }
 
 #pragma mark - instance methods
-
-- (void)handleAnyUnprocessedEnvelopesAsync
-{
-    [self.processingQueue drainQueue];
-}
 
 - (void)handleReceivedEnvelopeData:(NSData *)envelopeData
 {

--- a/SignalServiceKit/src/Messages/OWSMessageReceiver.m
+++ b/SignalServiceKit/src/Messages/OWSMessageReceiver.m
@@ -249,7 +249,9 @@ NSString *const OWSMessageDecryptJobFinderExtensionGroup = @"OWSMessageProcessin
     _isDrainingQueue = NO;
 
     [AppReadiness runNowOrWhenAppDidBecomeReady:^{
-        [self drainQueue];
+        if (CurrentAppContext().isMainApp) {
+            [self drainQueue];
+        }
     }];
 
     return self;

--- a/SignalServiceKit/src/Messages/OWSOutgoingReceiptManager.m
+++ b/SignalServiceKit/src/Messages/OWSOutgoingReceiptManager.m
@@ -65,7 +65,7 @@ NSString *const kOutgoingReadReceiptManagerCollection = @"kOutgoingReadReceiptMa
                                                object:nil];
 
     // Start processing.
-    [AppReadiness runNowOrWhenAppIsReady:^{
+    [AppReadiness runNowOrWhenAppDidBecomeReady:^{
         [self process];
     }];
 

--- a/SignalServiceKit/src/Messages/OWSReadReceiptManager.m
+++ b/SignalServiceKit/src/Messages/OWSReadReceiptManager.m
@@ -157,7 +157,7 @@ NSString *const OWSReadReceiptManagerAreReadReceiptsEnabled = @"areReadReceiptsE
     OWSSingletonAssert();
 
     // Start processing.
-    [AppReadiness runNowOrWhenAppIsReady:^{
+    [AppReadiness runNowOrWhenAppDidBecomeReady:^{
         [self scheduleProcessing];
     }];
 

--- a/SignalServiceKit/src/Messages/UD/OWSUDManager.swift
+++ b/SignalServiceKit/src/Messages/UD/OWSUDManager.swift
@@ -122,7 +122,7 @@ public class OWSUDManagerImpl: NSObject, OWSUDManager {
     }
 
     @objc public func setup() {
-        AppReadiness.runNowOrWhenAppIsReady {
+        AppReadiness.runNowOrWhenAppDidBecomeReady {
             guard TSAccountManager.isRegistered() else {
                 return
             }

--- a/SignalServiceKit/src/Network/MessageSenderJobQueue.swift
+++ b/SignalServiceKit/src/Network/MessageSenderJobQueue.swift
@@ -25,6 +25,15 @@ import Foundation
 @objc(SSKMessageSenderJobQueue)
 public class MessageSenderJobQueue: NSObject, JobQueue {
 
+    @objc
+    public override init() {
+        super.init()
+
+        AppReadiness.runNowOrWhenAppWillBecomeReady {
+            self.setup()
+        }
+    }
+
     // MARK: 
 
     @objc(addMessage:transaction:)

--- a/SignalServiceKit/src/Network/MessageSenderJobQueue.swift
+++ b/SignalServiceKit/src/Network/MessageSenderJobQueue.swift
@@ -65,6 +65,8 @@ public class MessageSenderJobQueue: NSObject, JobQueue {
     }
 
     private func add(message: TSOutgoingMessage, removeMessageAfterSending: Bool, transaction: YapDatabaseReadWriteTransaction) {
+        assert(AppReadiness.isAppReady())
+
         let jobRecord: SSKMessageSenderJobRecord
         do {
             jobRecord = try SSKMessageSenderJobRecord(message: message, removeMessageAfterSending: false, label: self.jobRecordLabel)

--- a/SignalServiceKit/src/Network/WebSockets/OWSWebSocket.m
+++ b/SignalServiceKit/src/Network/WebSockets/OWSWebSocket.m
@@ -1048,7 +1048,7 @@ NSString *NSStringFromOWSWebSocketType(OWSWebSocketType type)
     if (!AppReadiness.isAppReady) {
         static dispatch_once_t onceToken;
         dispatch_once(&onceToken, ^{
-            [AppReadiness runNowOrWhenAppIsReady:^{
+            [AppReadiness runNowOrWhenAppDidBecomeReady:^{
                 [self applyDesiredSocketState];
             }];
         });

--- a/SignalServiceKit/src/Util/AppReadiness.h
+++ b/SignalServiceKit/src/Util/AppReadiness.h
@@ -21,13 +21,14 @@ typedef void (^AppReadyBlock)(void);
 //
 // This method should only be called on the main thread.
 // The block will always be called on the main thread.
-+ (void)runNowOrWhenAppWillBecomeReady:(AppReadyBlock)block NS_SWIFT_NAME(runNowOrWhenAppWillBecomeReady(_:));
-
-// If the app is ready, the block is called immediately;
-// otherwise it is called when the app becomes ready.
 //
-// This method should only be called on the main thread.
-// The block will always be called on the main thread.
+// * The "will become ready" blocks are called before the "did become ready" blocks.
+// * The "will become ready" blocks should be used for internal setup of components
+//   so that they are ready to interact with other components of the system.
+// * The "did become ready" blocks should be used for any work that should be done
+//   on app launch, especially work that uses other components.
+// * We should usually use "did become ready" blocks since they are safer.
++ (void)runNowOrWhenAppWillBecomeReady:(AppReadyBlock)block NS_SWIFT_NAME(runNowOrWhenAppWillBecomeReady(_:));
 + (void)runNowOrWhenAppDidBecomeReady:(AppReadyBlock)block NS_SWIFT_NAME(runNowOrWhenAppDidBecomeReady(_:));
 
 @end

--- a/SignalServiceKit/src/Util/AppReadiness.h
+++ b/SignalServiceKit/src/Util/AppReadiness.h
@@ -21,7 +21,14 @@ typedef void (^AppReadyBlock)(void);
 //
 // This method should only be called on the main thread.
 // The block will always be called on the main thread.
-+ (void)runNowOrWhenAppIsReady:(AppReadyBlock)block NS_SWIFT_NAME(runNowOrWhenAppIsReady(_:));
++ (void)runNowOrWhenAppWillBecomeReady:(AppReadyBlock)block NS_SWIFT_NAME(runNowOrWhenAppWillBecomeReady(_:));
+
+// If the app is ready, the block is called immediately;
+// otherwise it is called when the app becomes ready.
+//
+// This method should only be called on the main thread.
+// The block will always be called on the main thread.
++ (void)runNowOrWhenAppDidBecomeReady:(AppReadyBlock)block NS_SWIFT_NAME(runNowOrWhenAppDidBecomeReady(_:));
 
 @end
 

--- a/SignalServiceKit/src/Util/AppReadiness.m
+++ b/SignalServiceKit/src/Util/AppReadiness.m
@@ -64,8 +64,7 @@ NS_ASSUME_NONNULL_BEGIN
     OWSAssertDebug(block);
 
     if (CurrentAppContext().isRunningTests) {
-        // We don't need to an any "on app ready" work
-        // in the tests.
+        // We don't need to do any "on app ready" work in the tests.
         return;
     }
 
@@ -90,8 +89,7 @@ NS_ASSUME_NONNULL_BEGIN
     OWSAssertDebug(block);
 
     if (CurrentAppContext().isRunningTests) {
-        // We don't need to an any "on app ready" work
-        // in the tests.
+        // We don't need to do any "on app ready" work in the tests.
         return;
     }
 

--- a/SignalServiceKit/src/Util/JobQueue.swift
+++ b/SignalServiceKit/src/Util/JobQueue.swift
@@ -106,6 +106,7 @@ public extension JobQueue {
 
     func add(jobRecord: JobRecordType, transaction: YapDatabaseReadWriteTransaction) {
         assert(jobRecord.status == .ready)
+
         jobRecord.save(with: transaction)
 
         transaction.addCompletionQueue(.global()) {

--- a/SignalServiceKit/src/Util/TypingIndicators.swift
+++ b/SignalServiceKit/src/Util/TypingIndicators.swift
@@ -56,7 +56,7 @@ public class TypingIndicatorsImpl: NSObject, TypingIndicators {
     public override init() {
         super.init()
 
-        AppReadiness.runNowOrWhenAppIsReady {
+        AppReadiness.runNowOrWhenAppWillBecomeReady {
             self.setup()
         }
     }

--- a/SignalShareExtension/ShareViewController.swift
+++ b/SignalShareExtension/ShareViewController.swift
@@ -402,7 +402,7 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
         Logger.debug("")
 
         if isReadyForAppExtensions {
-            AppReadiness.runNowOrWhenAppIsReady { [weak self] in
+            AppReadiness.runNowOrWhenAppDidBecomeReady { [weak self] in
                 AssertIsOnMainThread()
                 guard let strongSelf = self else { return }
                 strongSelf.activate()

--- a/SignalShareExtension/ShareViewController.swift
+++ b/SignalShareExtension/ShareViewController.swift
@@ -262,9 +262,6 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
 
         AppVersion.sharedInstance().saeLaunchDidComplete()
 
-        Environment.shared.contactsManager.setup()
-        Environment.shared.contactsManager.startObserving()
-
         ensureRootViewController()
 
         // We don't need to use OWSMessageReceiver in the SAE.


### PR DESCRIPTION
I've wanted to do something like this for a while, but I'm doing it now to resolve a real race on startup around the new durable message queues.

The proposal is to avoid races on startup by distinguishing "will become ready" (which doesn't depend on any other components except primary storage) and "did become ready" (which might use other components) work.  

After the "will" blocks, all of the components in the system should be ready to interact with other components - they can ensure that with a "will" block.  

```
// If the app is ready, the block is called immediately;
// otherwise it is called when the app becomes ready.
//
// This method should only be called on the main thread.
// The block will always be called on the main thread.
//
// * The "will become ready" blocks are called before the "did become ready" blocks.
// * The "will become ready" blocks should be used for internal setup of components
//   so that they are ready to interact with other components of the system.
// * The "did become ready" blocks should be used for any work that should be done
//   on app launch, especially work that uses other components.
// * We should usually use "did become ready" blocks since they are safer.
+ (void)runNowOrWhenAppWillBecomeReady:(AppReadyBlock)block NS_SWIFT_NAME(runNowOrWhenAppWillBecomeReady(_:));
+ (void)runNowOrWhenAppDidBecomeReady:(AppReadyBlock)block NS_SWIFT_NAME(runNowOrWhenAppDidBecomeReady(_:));
```

It also lets us gather concerns.

PTAL @michaelkirk 