### PR TITLE
Charlesmchen/attachment downloads

### DIFF
--- a/Signal/src/Signal-Bridging-Header.h
+++ b/Signal/src/Signal-Bridging-Header.h
@@ -86,7 +86,6 @@
 #import <SignalServiceKit/NSTimer+OWS.h>
 #import <SignalServiceKit/OWSAnalytics.h>
 #import <SignalServiceKit/OWSAnalyticsEvents.h>
-#import <SignalServiceKit/OWSAttachmentsProcessor.h>
 #import <SignalServiceKit/OWSBackgroundTask.h>
 #import <SignalServiceKit/OWSCallMessageHandler.h>
 #import <SignalServiceKit/OWSContactsOutputStream.h>

--- a/Signal/src/ViewControllers/ConversationView/Cells/ConversationMediaView.swift
+++ b/Signal/src/ViewControllers/ConversationView/Cells/ConversationMediaView.swift
@@ -234,7 +234,6 @@ public class ConversationMediaView: UIView {
         AssertIsOnMainThread()
 
         guard let loadBlock = loadBlock else {
-            owsFailDebug("Missing loadBlock")
             return
         }
         loadBlock()
@@ -245,7 +244,6 @@ public class ConversationMediaView: UIView {
         AssertIsOnMainThread()
 
         guard let unloadBlock = unloadBlock else {
-            owsFailDebug("Missing unloadBlock")
             return
         }
         unloadBlock()

--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageBubbleView.h
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageBubbleView.h
@@ -39,8 +39,7 @@ extern const UIDataDetectorTypes kOWSAllowedDataDetectorTypes;
 
 - (void)didTapTruncatedTextMessage:(id<ConversationViewItem>)conversationItem;
 
-- (void)didTapFailedIncomingAttachment:(id<ConversationViewItem>)viewItem
-                     attachmentPointer:(TSAttachmentPointer *)attachmentPointer;
+- (void)didTapFailedIncomingAttachment:(id<ConversationViewItem>)viewItem;
 
 - (void)didTapConversationItem:(id<ConversationViewItem>)viewItem quotedReply:(OWSQuotedReplyModel *)quotedReply;
 - (void)didTapConversationItem:(id<ConversationViewItem>)viewItem

--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageBubbleView.m
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSMessageBubbleView.m
@@ -1402,7 +1402,7 @@ const UIDataDetectorTypes kOWSAllowedDataDetectorTypes
             OWSAssertDebug(attachmentPointer);
 
             if (attachmentPointer.state == TSAttachmentPointerStateFailed) {
-                [self.delegate didTapFailedIncomingAttachment:self.viewItem attachmentPointer:attachmentPointer];
+                [self.delegate didTapFailedIncomingAttachment:self.viewItem];
             }
             break;
         }

--- a/Signal/src/ViewControllers/MessageDetailViewController.swift
+++ b/Signal/src/ViewControllers/MessageDetailViewController.swift
@@ -694,7 +694,7 @@ class MessageDetailViewController: OWSViewController, MediaGalleryDataSourceDele
         navigationController.pushViewController(viewController, animated: true)
     }
 
-    func didTapFailedIncomingAttachment(_ viewItem: ConversationViewItem, attachmentPointer: TSAttachmentPointer) {
+    func didTapFailedIncomingAttachment(_ viewItem: ConversationViewItem) {
         // no - op
     }
 

--- a/SignalMessaging/environment/AppSetup.m
+++ b/SignalMessaging/environment/AppSetup.m
@@ -11,6 +11,7 @@
 #import <SignalMessaging/SignalMessaging-Swift.h>
 #import <SignalServiceKit/ContactDiscoveryService.h>
 #import <SignalServiceKit/OWS2FAManager.h>
+#import <SignalServiceKit/OWSAttachmentDownloads.h>
 #import <SignalServiceKit/OWSBackgroundTask.h>
 #import <SignalServiceKit/OWSBatchMessageProcessor.h>
 #import <SignalServiceKit/OWSBlockingManager.h>
@@ -86,6 +87,7 @@ NS_ASSUME_NONNULL_BEGIN
         OWSSyncManager *syncManager = [[OWSSyncManager alloc] initDefault];
         id<SSKReachabilityManager> reachabilityManager = [SSKReachabilityManagerImpl new];
         id<OWSTypingIndicators> typingIndicators = [[OWSTypingIndicatorsImpl alloc] init];
+        OWSAttachmentDownloads *attachmentDownloads = [[OWSAttachmentDownloads alloc] init];
 
         OWSAudioSession *audioSession = [OWSAudioSession new];
         OWSSounds *sounds = [[OWSSounds alloc] initWithPrimaryStorage:primaryStorage];
@@ -123,7 +125,8 @@ NS_ASSUME_NONNULL_BEGIN
                                                            outgoingReceiptManager:outgoingReceiptManager
                                                               reachabilityManager:reachabilityManager
                                                                       syncManager:syncManager
-                                                                 typingIndicators:typingIndicators]];
+                                                                 typingIndicators:typingIndicators
+                                                              attachmentDownloads:attachmentDownloads]];
 
         appSpecificSingletonBlock();
 

--- a/SignalServiceKit/src/Devices/OWSRecordTranscriptJob.h
+++ b/SignalServiceKit/src/Devices/OWSRecordTranscriptJob.h
@@ -5,24 +5,14 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class OWSIncomingSentMessageTranscript;
-@class OWSPrimaryStorage;
-@class OWSReadReceiptManager;
 @class TSAttachmentStream;
-@class TSNetworkManager;
 @class YapDatabaseReadWriteTransaction;
-
-@protocol ContactsManagerProtocol;
 
 // This job is used to process "outgoing message" notifications from linked devices.
 @interface OWSRecordTranscriptJob : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithIncomingSentMessageTranscript:(OWSIncomingSentMessageTranscript *)incomingSentMessageTranscript;
-- (instancetype)initWithIncomingSentMessageTranscript:(OWSIncomingSentMessageTranscript *)incomingSentMessageTranscript
-                                       networkManager:(TSNetworkManager *)networkManager
-                                       primaryStorage:(OWSPrimaryStorage *)primaryStorage
-                                   readReceiptManager:(OWSReadReceiptManager *)readReceiptManager
-                                      contactsManager:(id<ContactsManagerProtocol>)contactsManager
     NS_DESIGNATED_INITIALIZER;
 
 - (void)runWithAttachmentHandler:(void (^)(NSArray<TSAttachmentStream *> *attachmentStreams))attachmentHandler

--- a/SignalServiceKit/src/Messages/Attachments/OWSAttachmentDownloads.h
+++ b/SignalServiceKit/src/Messages/Attachments/OWSAttachmentDownloads.h
@@ -1,0 +1,46 @@
+//
+//  Copyright (c) 2018 Open Whisper Systems. All rights reserved.
+//
+
+NS_ASSUME_NONNULL_BEGIN
+
+extern NSString *const kAttachmentDownloadProgressNotification;
+extern NSString *const kAttachmentDownloadProgressKey;
+extern NSString *const kAttachmentDownloadAttachmentIDKey;
+
+@class SSKProtoAttachmentPointer;
+@class TSAttachment;
+@class TSAttachmentPointer;
+@class TSAttachmentStream;
+@class TSMessage;
+@class YapDatabaseReadTransaction;
+@class YapDatabaseReadWriteTransaction;
+
+#pragma mark -
+
+/**
+ * Given incoming attachment protos, determines which we support.
+ * It can download those that we support and notifies threads when it receives unsupported attachments.
+ */
+@interface OWSAttachmentDownloads : NSObject
+
+// This will try to download all un-downloaded attachments for a given message.
+// Any attachments for the message which are already downloaded are skipped BUT
+// they are included in the success callback.
+//
+// success/failure are always called on a worker queue.
+- (void)downloadAttachmentsForMessage:(TSMessage *)message
+                          transaction:(YapDatabaseReadTransaction *)transaction
+                              success:(void (^)(NSArray<TSAttachmentStream *> *attachmentStreams))success
+                              failure:(void (^)(NSError *error))failure;
+
+// This will try to download a single attachment.
+//
+// success/failure are always called on a worker queue.
+- (void)downloadAttachmentPointer:(TSAttachmentPointer *)attachmentPointer
+                          success:(void (^)(NSArray<TSAttachmentStream *> *attachmentStreams))success
+                          failure:(void (^)(NSError *error))failure;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/SignalServiceKit/src/Messages/Attachments/TSAttachmentPointer.m
+++ b/SignalServiceKit/src/Messages/Attachments/TSAttachmentPointer.m
@@ -107,6 +107,9 @@ NS_ASSUME_NONNULL_BEGIN
                                         (NSArray<SSKProtoAttachmentPointer *> *)attachmentProtos
                                                     albumMessage:(TSMessage *)albumMessage
 {
+    OWSAssertDebug(attachmentProtos);
+    OWSAssertDebug(albumMessage);
+
     NSMutableArray *attachmentPointers = [NSMutableArray new];
     for (SSKProtoAttachmentPointer *attachmentProto in attachmentProtos) {
         TSAttachmentPointer *_Nullable attachmentPointer =

--- a/SignalServiceKit/src/SSKEnvironment.h
+++ b/SignalServiceKit/src/SSKEnvironment.h
@@ -9,6 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class ContactDiscoveryService;
 @class ContactsUpdater;
 @class OWS2FAManager;
+@class OWSAttachmentDownloads;
 @class OWSBatchMessageProcessor;
 @class OWSBlockingManager;
 @class OWSDisappearingMessagesJob;
@@ -60,7 +61,8 @@ NS_ASSUME_NONNULL_BEGIN
                  outgoingReceiptManager:(OWSOutgoingReceiptManager *)outgoingReceiptManager
                     reachabilityManager:(id<SSKReachabilityManager>)reachabilityManager
                             syncManager:(id<OWSSyncManagerProtocol>)syncManager
-                       typingIndicators:(id<OWSTypingIndicators>)typingIndicators NS_DESIGNATED_INITIALIZER;
+                       typingIndicators:(id<OWSTypingIndicators>)typingIndicators
+                    attachmentDownloads:(OWSAttachmentDownloads *)attachmentDownloads NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)init NS_UNAVAILABLE;
 
@@ -97,6 +99,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) id<OWSSyncManagerProtocol> syncManager;
 @property (nonatomic, readonly) id<SSKReachabilityManager> reachabilityManager;
 @property (nonatomic, readonly) id<OWSTypingIndicators> typingIndicators;
+@property (nonatomic, readonly) OWSAttachmentDownloads *attachmentDownloads;
 
 // This property is configured after Environment is created.
 @property (atomic, nullable) id<OWSCallMessageHandler> callMessageHandler;

--- a/SignalServiceKit/src/SSKEnvironment.m
+++ b/SignalServiceKit/src/SSKEnvironment.m
@@ -35,6 +35,7 @@ static SSKEnvironment *sharedSSKEnvironment;
 @property (nonatomic) id<OWSSyncManagerProtocol> syncManager;
 @property (nonatomic) id<SSKReachabilityManager> reachabilityManager;
 @property (nonatomic) id<OWSTypingIndicators> typingIndicators;
+@property (nonatomic) OWSAttachmentDownloads *attachmentDownloads;
 
 @end
 
@@ -73,6 +74,7 @@ static SSKEnvironment *sharedSSKEnvironment;
                     reachabilityManager:(id<SSKReachabilityManager>)reachabilityManager
                             syncManager:(id<OWSSyncManagerProtocol>)syncManager
                        typingIndicators:(id<OWSTypingIndicators>)typingIndicators
+                    attachmentDownloads:(OWSAttachmentDownloads *)attachmentDownloads
 {
     self = [super init];
     if (!self) {
@@ -103,6 +105,7 @@ static SSKEnvironment *sharedSSKEnvironment;
     OWSAssertDebug(syncManager);
     OWSAssertDebug(reachabilityManager);
     OWSAssertDebug(typingIndicators);
+    OWSAssertDebug(attachmentDownloads);
 
     _contactsManager = contactsManager;
     _messageSender = messageSender;
@@ -128,6 +131,7 @@ static SSKEnvironment *sharedSSKEnvironment;
     _syncManager = syncManager;
     _reachabilityManager = reachabilityManager;
     _typingIndicators = typingIndicators;
+    _attachmentDownloads = attachmentDownloads;
 
     return self;
 }

--- a/SignalServiceKit/src/TestUtils/MockSSKEnvironment.m
+++ b/SignalServiceKit/src/TestUtils/MockSSKEnvironment.m
@@ -5,6 +5,7 @@
 #import "MockSSKEnvironment.h"
 #import "ContactDiscoveryService.h"
 #import "OWS2FAManager.h"
+#import "OWSAttachmentDownloads.h"
 #import "OWSBatchMessageProcessor.h"
 #import "OWSBlockingManager.h"
 #import "OWSDisappearingMessagesJob.h"
@@ -76,6 +77,7 @@ NS_ASSUME_NONNULL_BEGIN
     id<SSKReachabilityManager> reachabilityManager = [SSKReachabilityManagerImpl new];
     id<OWSSyncManagerProtocol> syncManager = [[OWSMockSyncManager alloc] init];
     id<OWSTypingIndicators> typingIndicators = [[OWSTypingIndicatorsImpl alloc] init];
+    OWSAttachmentDownloads *attachmentDownloads = [[OWSAttachmentDownloads alloc] init];
 
     self = [super initWithContactsManager:contactsManager
                             messageSender:messageSender
@@ -100,7 +102,8 @@ NS_ASSUME_NONNULL_BEGIN
                    outgoingReceiptManager:outgoingReceiptManager
                       reachabilityManager:reachabilityManager
                               syncManager:syncManager
-                         typingIndicators:typingIndicators];
+                         typingIndicators:typingIndicators
+                      attachmentDownloads:attachmentDownloads];
 
     if (!self) {
         return nil;


### PR DESCRIPTION
Replaces `OWSAttachmentsProcessor` with new singleton `OWSAttachmentDownloads`.  

* Handles multiple attachments per message.
* Enforces "max simultaneous attachments download" limit.
* Will (soon, not in this PR) provide a simple API for querying/observing the download status of any incoming attachment.
* IMO simpler, cleaner API.  For example, "initial download" and "retry failed downloads" now use the same code path.

PTAL @michaelkirk 

