### PR TITLE
Fix crash due to empty authorId on old messages

### DIFF
--- a/SignalServiceKit/src/Contacts/Threads/TSContactThread.h
+++ b/SignalServiceKit/src/Contacts/Threads/TSContactThread.h
@@ -6,6 +6,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+extern NSString *const TSContactThreadPrefix;
+
 @interface TSContactThread : TSThread
 
 @property (nonatomic) BOOL hasDismissedOffers;

--- a/SignalServiceKit/src/Contacts/Threads/TSContactThread.m
+++ b/SignalServiceKit/src/Contacts/Threads/TSContactThread.m
@@ -13,7 +13,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-#define TSContactThreadPrefix @"c"
+NSString *const TSContactThreadPrefix = @"c";
 
 @implementation TSContactThread
 

--- a/SignalServiceKit/src/Messages/Interactions/TSIncomingMessage.h
+++ b/SignalServiceKit/src/Messages/Interactions/TSIncomingMessage.h
@@ -77,10 +77,7 @@ NS_ASSUME_NONNULL_BEGIN
 // This will be 0 for messages created before we were tracking sourceDeviceId
 @property (nonatomic, readonly) UInt32 sourceDeviceId;
 
-// NOTE: Use messageAuthorId instead wherever possible.
 @property (nonatomic, readonly) NSString *authorId;
-
-- (NSString *)messageAuthorId;
 
 // convenience method for expiring a message which was just read
 - (void)markAsReadNowWithSendReadReceipt:(BOOL)sendReadReceipt

--- a/SignalServiceKit/src/Messages/Interactions/TSIncomingMessage.m
+++ b/SignalServiceKit/src/Messages/Interactions/TSIncomingMessage.m
@@ -35,6 +35,11 @@ NS_ASSUME_NONNULL_BEGIN
         return self;
     }
 
+    if (_authorId == nil) {
+        OWSAssertDebug([self.uniqueThreadId hasPrefix:TSContactThreadPrefix]);
+        _authorId = [TSContactThread contactIdFromThreadId:self.uniqueThreadId];
+    }
+
     return self;
 }
 
@@ -88,10 +93,9 @@ NS_ASSUME_NONNULL_BEGIN
                                  if ([interaction isKindOfClass:[TSIncomingMessage class]]) {
                                      TSIncomingMessage *message = (TSIncomingMessage *)interaction;
 
-                                     NSString *messageAuthorId = message.messageAuthorId;
-                                     OWSAssertDebug(messageAuthorId.length > 0);
+                                     OWSAssertDebug(message.authorId > 0);
 
-                                     if ([messageAuthorId isEqualToString:authorId]) {
+                                     if ([message.authorId isEqualToString:authorId]) {
                                          foundMessage = message;
                                      }
                                  }
@@ -101,22 +105,6 @@ NS_ASSUME_NONNULL_BEGIN
     return foundMessage;
 }
 
-// TODO get rid of this method and instead populate authorId in initWithCoder:
-- (NSString *)messageAuthorId
-{
-    // authorId isn't set on all legacy messages, so we take
-    // extra measures to ensure we obtain a valid value.
-    NSString *messageAuthorId;
-    if (self.authorId) {
-        // Group Thread
-        messageAuthorId = self.authorId;
-    } else {
-        // Contact Thread
-        messageAuthorId = [TSContactThread contactIdFromThreadId:self.uniqueThreadId];
-    }
-    OWSAssertDebug(messageAuthorId.length > 0);
-    return messageAuthorId;
-}
 
 - (OWSInteractionType)interactionType
 {

--- a/SignalServiceKit/src/Messages/Interactions/TSQuotedMessage.m
+++ b/SignalServiceKit/src/Messages/Interactions/TSQuotedMessage.m
@@ -236,7 +236,7 @@ NS_ASSUME_NONNULL_BEGIN
 
                                if ([interaction isKindOfClass:[TSIncomingMessage class]]) {
                                    TSIncomingMessage *incomingMessage = (TSIncomingMessage *)interaction;
-                                   return [authorId isEqual:incomingMessage.messageAuthorId];
+                                   return [authorId isEqual:incomingMessage.authorId];
                                } else if ([interaction isKindOfClass:[TSOutgoingMessage class]]) {
                                    return [authorId isEqual:[TSAccountManager localNumber]];
                                } else {

--- a/SignalServiceKit/src/Messages/OWSDisappearingMessagesJob.m
+++ b/SignalServiceKit/src/Messages/OWSDisappearingMessagesJob.m
@@ -200,7 +200,7 @@ void AssertIsOnDisappearingMessagesQueue()
     if ([message isKindOfClass:[TSIncomingMessage class]]) {
         TSIncomingMessage *incomingMessage = (TSIncomingMessage *)message;
         remoteContactName =
-            [contactsManager displayNameForPhoneIdentifier:incomingMessage.messageAuthorId transaction:transaction];
+            [contactsManager displayNameForPhoneIdentifier:incomingMessage.authorId transaction:transaction];
     }
 
     [self becomeConsistentWithDisappearingDuration:message.expiresInSeconds

--- a/SignalServiceKit/src/Messages/OWSReadReceiptManager.m
+++ b/SignalServiceKit/src/Messages/OWSReadReceiptManager.m
@@ -268,7 +268,7 @@ NSString *const OWSReadReceiptManagerAreReadReceiptsEnabled = @"areReadReceiptsE
             NSString *threadUniqueId = message.uniqueThreadId;
             OWSAssertDebug(threadUniqueId.length > 0);
 
-            NSString *messageAuthorId = message.messageAuthorId;
+            NSString *messageAuthorId = message.authorId;
             OWSAssertDebug(messageAuthorId.length > 0);
 
             OWSLinkedDeviceReadReceipt *newReadReceipt =
@@ -286,7 +286,7 @@ NSString *const OWSReadReceiptManagerAreReadReceiptsEnabled = @"areReadReceiptsE
                 self.toLinkedDevicesReadReceiptMap[threadUniqueId] = newReadReceipt;
             }
 
-            if ([message.messageAuthorId isEqualToString:[TSAccountManager localNumber]]) {
+            if ([message.authorId isEqualToString:[TSAccountManager localNumber]]) {
                 OWSLogVerbose(@"Ignoring read receipt for self-sender.");
                 return;
             }
@@ -379,7 +379,7 @@ NSString *const OWSReadReceiptManagerAreReadReceiptsEnabled = @"areReadReceiptsE
     OWSAssertDebug(message);
     OWSAssertDebug(transaction);
 
-    NSString *senderId = message.messageAuthorId;
+    NSString *senderId = message.authorId;
     uint64_t timestamp = message.timestamp;
     if (senderId.length < 1 || timestamp < 1) {
         OWSFailDebug(@"Invalid incoming message: %@ %llu", senderId, timestamp);


### PR DESCRIPTION
Long ago authorId was only set on incoming **group** messages - the idea was that you should only ever use `messageAuthorId` which would derive the author's id if necessary.

In at least one case,  when getting author color, we were incorrectly using `authorId` instead of `messageAuthorId`.

So now, we migrate the data in initWithCode, and no longer have a method we shouldn't ever call.

PTAL @charlesmchen 