### PR TITLE
Add public keyword to fix compilation for framework integration

### DIFF
--- a/SignalServiceKit/src/Contacts/OWSContactDiscoveryOperation.swift
+++ b/SignalServiceKit/src/Contacts/OWSContactDiscoveryOperation.swift
@@ -5,10 +5,10 @@
 import Foundation
 
 @objc(OWSLegacyContactDiscoveryOperation)
-class LegacyContactDiscoveryBatchOperation: OWSOperation {
+public class LegacyContactDiscoveryBatchOperation: OWSOperation {
 
     @objc
-    var registeredRecipientIds: Set<String>
+    public var registeredRecipientIds: Set<String>
 
     private let recipientIdsToLookup: [String]
     private var networkManager: TSNetworkManager {
@@ -18,7 +18,7 @@ class LegacyContactDiscoveryBatchOperation: OWSOperation {
     // MARK: Initializers
 
     @objc
-    required init(recipientIdsToLookup: [String]) {
+    public required init(recipientIdsToLookup: [String]) {
         self.recipientIdsToLookup = recipientIdsToLookup
         self.registeredRecipientIds = Set()
 
@@ -30,7 +30,7 @@ class LegacyContactDiscoveryBatchOperation: OWSOperation {
     // MARK: OWSOperation Overrides
 
     // Called every retry, this is where the bulk of the operation's work should go.
-    override func run() {
+    override public func run() {
         Logger.debug("")
 
         guard !isCancelled else {
@@ -82,7 +82,7 @@ class LegacyContactDiscoveryBatchOperation: OWSOperation {
     }
 
     // Called at most one time.
-    override func didSucceed() {
+    override public func didSucceed() {
         // Compare against new CDS service
         let modernCDSOperation = CDSOperation(recipientIdsToLookup: self.recipientIdsToLookup)
         let cdsFeedbackOperation = CDSFeedbackOperation(legacyRegisteredRecipientIds: self.registeredRecipientIds)

--- a/SignalServiceKit/src/Network/SSKWebSocket.swift
+++ b/SignalServiceKit/src/Network/SSKWebSocket.swift
@@ -32,7 +32,7 @@ public class SSKWebSocketError: NSObject, CustomNSError {
     // MARK: -
 
     @objc
-    static let kStatusCodeKey = "SSKWebSocketErrorStatusCode"
+    public static let kStatusCodeKey = "SSKWebSocketErrorStatusCode"
 
     let underlyingError: Starscream.WSError
 }

--- a/SignalServiceKit/src/TestUtils/FakeContactsManager.swift
+++ b/SignalServiceKit/src/TestUtils/FakeContactsManager.swift
@@ -3,42 +3,42 @@
 //
 
 @objc(OWSFakeContactsManager)
-class FakeContactsManager: NSObject, ContactsManagerProtocol {
-    func displayName(forPhoneIdentifier recipientId: String?) -> String {
+public class FakeContactsManager: NSObject, ContactsManagerProtocol {
+    public func displayName(forPhoneIdentifier recipientId: String?) -> String {
         return "Fake name"
     }
 
-    func displayName(forPhoneIdentifier recipientId: String?, transaction: YapDatabaseReadTransaction) -> String {
+    public func displayName(forPhoneIdentifier recipientId: String?, transaction: YapDatabaseReadTransaction) -> String {
         return self.displayName(forPhoneIdentifier: recipientId)
     }
 
-    func signalAccounts() -> [SignalAccount] {
+    public func signalAccounts() -> [SignalAccount] {
         return []
     }
 
-    func isSystemContact(_ recipientId: String) -> Bool {
+    public func isSystemContact(_ recipientId: String) -> Bool {
         return true
     }
 
-    func isSystemContact(withSignalAccount recipientId: String) -> Bool {
+    public func isSystemContact(withSignalAccount recipientId: String) -> Bool {
         return true
     }
 
-    func compare(signalAccount left: SignalAccount, with right: SignalAccount) -> ComparisonResult {
+    public func compare(signalAccount left: SignalAccount, with right: SignalAccount) -> ComparisonResult {
         // If this method ends up being used by the tests, we should provide a better implementation.
         assertionFailure("TODO")
         return ComparisonResult.orderedAscending
     }
 
-    func cnContact(withId contactId: String?) -> CNContact? {
+    public func cnContact(withId contactId: String?) -> CNContact? {
         return nil
     }
 
-    func avatarData(forCNContactId contactId: String?) -> Data? {
+    public func avatarData(forCNContactId contactId: String?) -> Data? {
         return nil
     }
 
-    func avatarImage(forCNContactId contactId: String?) -> UIImage? {
+    public func avatarImage(forCNContactId contactId: String?) -> UIImage? {
         return nil
     }
 }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [ ] I have tested my contribution on these devices:

by integrating it in my private project and getting it to compile
- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

This fixes https://github.com/signalapp/Signal-iOS/issues/4135 and other errors with integration of SignalServiceKit in third party Applications.
Since the Swift classes, functions and vars are not declared public usage of SignalServiceKit outside of Signal-iOS wouldn't work.
Signal-iOS doesn't run into it because SignalServiceKit is part of the iOS app and therefore the classes and vars are internally visible 