### PR TITLE
 tryParsePhoneNumber instead of fromE164 to support phone numbers Phone.app

### DIFF
--- a/Signal/src/call/OutboundCallInitiator.swift
+++ b/Signal/src/call/OutboundCallInitiator.swift
@@ -35,7 +35,7 @@ import SignalMessaging
     @discardableResult @objc public func initiateCall(handle: String) -> Bool {
         Logger.info("with handle: \(handle)")
 
-        guard let recipientId = PhoneNumber(fromE164: handle)?.toE164() else {
+        guard let recipientId = PhoneNumber.tryParsePhoneNumber(fromUserSpecifiedText: handle)?.toE164() else {
             Logger.warn("unable to parse signalId from phone number: \(handle)")
             return false
         }

--- a/Signal/test/call/OutboundCallInitiatorTest.swift
+++ b/Signal/test/call/OutboundCallInitiatorTest.swift
@@ -18,14 +18,50 @@ class FakeOutboundCallInitiator: OutboundCallInitiator {
 class OutboundCallInitiatorTest: SignalBaseTest {
 
     func testMissingCountryCode() {
+        let testNumber = "5555555555"
         let fakeOutboundCallInitiator = FakeOutboundCallInitiator()
-        fakeOutboundCallInitiator.initiateCall(handle: "555555555")
+        fakeOutboundCallInitiator.initiateCall(handle: testNumber)
         XCTAssertNotNil(fakeOutboundCallInitiator.passedRecipientId)
+        XCTAssertEqual(fakeOutboundCallInitiator.passedRecipientId, "+15555555555")
+    }
+
+    func testMissingCountryCodeWithFormat() {
+        let testNumber = "(555) 555-5555"
+        let fakeOutboundCallInitiator = FakeOutboundCallInitiator()
+        fakeOutboundCallInitiator.initiateCall(handle: testNumber)
+        XCTAssertNotNil(fakeOutboundCallInitiator.passedRecipientId)
+        XCTAssertEqual(fakeOutboundCallInitiator.passedRecipientId, "+15555555555")
     }
 
     func testE164Number() {
+        let testNumber = "+15555555555"
         let fakeOutboundCallInitiator = FakeOutboundCallInitiator()
-        fakeOutboundCallInitiator.initiateCall(handle: "+1555555555")
+        fakeOutboundCallInitiator.initiateCall(handle: testNumber)
         XCTAssertNotNil(fakeOutboundCallInitiator.passedRecipientId)
+        XCTAssertEqual(fakeOutboundCallInitiator.passedRecipientId, testNumber)
+    }
+
+    func testE164BrazilNumber() {
+        let testNumber = "+553212345678"
+        let fakeOutboundCallInitiator = FakeOutboundCallInitiator()
+        fakeOutboundCallInitiator.initiateCall(handle: testNumber)
+        XCTAssertNotNil(fakeOutboundCallInitiator.passedRecipientId)
+        XCTAssertEqual(fakeOutboundCallInitiator.passedRecipientId, testNumber)
+    }
+
+    func testFranceWithoutPlus() {
+        let testNumber = "33 1 70 39 38 00"
+        let fakeOutboundCallInitiator = FakeOutboundCallInitiator()
+        fakeOutboundCallInitiator.initiateCall(handle: testNumber)
+        XCTAssertNotNil(fakeOutboundCallInitiator.passedRecipientId)
+        XCTAssertEqual(fakeOutboundCallInitiator.passedRecipientId, "+133170393800")
+    }
+
+    func testE164NumberWithFormat() {
+        let testNumber = "+1 (555) 555-5555"
+        let fakeOutboundCallInitiator = FakeOutboundCallInitiator()
+        fakeOutboundCallInitiator.initiateCall(handle: testNumber)
+        XCTAssertNotNil(fakeOutboundCallInitiator.passedRecipientId)
+        XCTAssertEqual(fakeOutboundCallInitiator.passedRecipientId, "+15555555555")
     }
 }

--- a/Signal/test/call/OutboundCallInitiatorTest.swift
+++ b/Signal/test/call/OutboundCallInitiatorTest.swift
@@ -13,7 +13,6 @@ class FakeOutboundCallInitiator: OutboundCallInitiator {
         passedRecipientId = recipientId
         return true
     }
-    
 }
 
 class OutboundCallInitiatorTest: SignalBaseTest {
@@ -29,5 +28,4 @@ class OutboundCallInitiatorTest: SignalBaseTest {
         fakeOutboundCallInitiator.initiateCall(handle: "+1555555555")
         XCTAssertNotNil(fakeOutboundCallInitiator.passedRecipientId)
     }
-    
 }

--- a/Signal/test/call/OutboundCallInitiatorTest.swift
+++ b/Signal/test/call/OutboundCallInitiatorTest.swift
@@ -1,0 +1,33 @@
+//
+//  Copyright (c) 2018 Open Whisper Systems. All rights reserved.
+// 
+
+import XCTest
+@testable import Signal
+
+class FakeOutboundCallInitiator: OutboundCallInitiator {
+    var passedRecipientId : String?
+    
+    override public func initiateCall(recipientId: String,
+                                      isVideo: Bool) -> Bool {
+        passedRecipientId = recipientId
+        return true
+    }
+    
+}
+
+class OutboundCallInitiatorTest: SignalBaseTest {
+    
+    func testMissingCountryCode() {
+        let fakeOutboundCallInitiator = FakeOutboundCallInitiator()
+        fakeOutboundCallInitiator.initiateCall(handle: "555555555")
+        XCTAssertNotNil(fakeOutboundCallInitiator.passedRecipientId)
+    }
+    
+    func testE164Number() {
+        let fakeOutboundCallInitiator = FakeOutboundCallInitiator()
+        fakeOutboundCallInitiator.initiateCall(handle: "+1555555555")
+        XCTAssertNotNil(fakeOutboundCallInitiator.passedRecipientId)
+    }
+    
+}

--- a/Signal/test/call/OutboundCallInitiatorTest.swift
+++ b/Signal/test/call/OutboundCallInitiatorTest.swift
@@ -1,13 +1,13 @@
 //
 //  Copyright (c) 2018 Open Whisper Systems. All rights reserved.
-// 
+//
 
 import XCTest
 @testable import Signal
 
 class FakeOutboundCallInitiator: OutboundCallInitiator {
     var passedRecipientId : String?
-    
+
     override public func initiateCall(recipientId: String,
                                       isVideo: Bool) -> Bool {
         passedRecipientId = recipientId
@@ -16,13 +16,13 @@ class FakeOutboundCallInitiator: OutboundCallInitiator {
 }
 
 class OutboundCallInitiatorTest: SignalBaseTest {
-    
+
     func testMissingCountryCode() {
         let fakeOutboundCallInitiator = FakeOutboundCallInitiator()
         fakeOutboundCallInitiator.initiateCall(handle: "555555555")
         XCTAssertNotNil(fakeOutboundCallInitiator.passedRecipientId)
     }
-    
+
     func testE164Number() {
         let fakeOutboundCallInitiator = FakeOutboundCallInitiator()
         fakeOutboundCallInitiator.initiateCall(handle: "+1555555555")


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 5SE, iOS 12.1.4

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

Phone.app passes user entered phone numbers. If the phone number does not contain a country code, initiating a call fails. Using tryParsePhoneNumber will handle the lack of country code.

fixes #4152 
