### PR TITLE
Only escape % signs in notifications on iOS 9

### DIFF
--- a/Signal/src/UserInterface/Notifications/AppNotifications.swift
+++ b/Signal/src/UserInterface/Notifications/AppNotifications.swift
@@ -352,12 +352,7 @@ public class NotificationPresenter: NSObject, NotificationsProtocol {
         // While batch processing, some of the necessary changes have not been commited.
         let rawMessageText = incomingMessage.previewText(with: transaction)
 
-        // iOS strips anything that looks like a printf formatting character from
-        // the notification body, so if we want to dispay a literal "%" in a notification
-        // it must be escaped.
-        // see https://developer.apple.com/documentation/uikit/uilocalnotification/1616646-alertbody
-        // for more details.
-        let messageText = DisplayableText.filterNotificationText(rawMessageText)
+        let messageText = rawMessageText.filterStringForDisplay()
 
         let senderName = contactsManager.displayName(forPhoneIdentifier: incomingMessage.authorId)
 

--- a/Signal/src/UserInterface/Notifications/LegacyNotificationsAdaptee.swift
+++ b/Signal/src/UserInterface/Notifications/LegacyNotificationsAdaptee.swift
@@ -154,12 +154,19 @@ extension LegacyNotificationPresenterAdaptee: NotificationPresenterAdaptee {
             return
         }
 
+        // UILocalNotification strips anything that looks like a printf
+        // formatting character from the notification body, so if we want to
+        // display a literal "%" in a notification it must be escaped.
+        // see https://developer.apple.com/documentation/uikit/uilocalnotification/1616646-alertbody
+        // for more details.
+        let escapedBody = body.replacingOccurrences(of: "%", with: "%%")
+
         let alertBody: String
         if let title = title {
             // TODO - Make this a format string for better l10n
-            alertBody = title.rtlSafeAppend(":").rtlSafeAppend(" ").rtlSafeAppend(body)
+            alertBody = title.rtlSafeAppend(":").rtlSafeAppend(" ").rtlSafeAppend(escapedBody)
         } else {
-            alertBody = body
+            alertBody = escapedBody
         }
 
         let notification = UILocalNotification()

--- a/SignalMessaging/utils/DisplayableText.swift
+++ b/SignalMessaging/utils/DisplayableText.swift
@@ -263,20 +263,6 @@ extension String {
     // MARK: Filter Methods
 
     @objc
-    public class func filterNotificationText(_ text: String?) -> String? {
-        guard let text = text?.filterStringForDisplay() else {
-            return nil
-        }
-
-        // iOS strips anything that looks like a printf formatting character from
-        // the notification body, so if we want to dispay a literal "%" in a notification
-        // it must be escaped.
-        // see https://developer.apple.com/documentation/uikit/uilocalnotification/1616646-alertbody
-        // for more details.
-        return text.replacingOccurrences(of: "%", with: "%%")
-    }
-
-    @objc
     public class func displayableText(_ rawText: String) -> DisplayableText {
         // Only show up to N characters of text.
         let kMaxTextDisplayLength = 512


### PR DESCRIPTION
Fixes #4195

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone X, iOS 12.3.1

- - - - - - - - - -

### Description
`UILocalNotification` (used on iOS 9) requires literal percent signs to be escaped, while `UNUserNotifications` (used on 10+) does not. Don't have an iOS 9 device to test on, but behavior there should be unchanged