### PR TITLE
Fix check_diff_for_keywords in scripts

### DIFF
--- a/Scripts/precommit.py
+++ b/Scripts/precommit.py
@@ -391,7 +391,7 @@ def process_if_appropriate(filepath):
 
 def check_diff_for_keywords():
     objc_keywords = [
-        "OWSAbstractMethod\("
+        "OWSAbstractMethod\(",
         "OWSAssert\(", 
         "OWSCAssert\(", 
         "OWSFail\(", 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### Contributors checklist
I have signed the CLA and since this is a simple fix I haven't tested it.

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->


Fixes the `objc_keywords` list in `check_diff_for_keywords` in precommit.py Script.

This list stores strings and Python automagically concatenates strings if there is no comma between them.

As a result the first two items of the list: `OWSAbstractMethod\(` and `OWSAssert\(` were wrongly conacatenated into `"OWSAbstractMethod\(OWSAssert\("`.

This has been found with LGTM https://lgtm.com/projects/g/signalapp/Signal-iOS/snapshot/0ddaedbfad3ea18fd14416009dcd01351a536290/files/Scripts/precommit.py#x84c147336239d4b6:1:
![image](https://user-images.githubusercontent.com/10009354/61297054-b225aa00-a7db-11e9-9eaa-7c764b1501cd.png)
