### PR TITLE
Photolibrary performance

### DIFF
--- a/Signal/src/ViewControllers/Photos/ImagePickerController.swift
+++ b/Signal/src/ViewControllers/Photos/ImagePickerController.swift
@@ -225,7 +225,7 @@ class ImagePickerGridController: UICollectionViewController, PhotoLibraryDelegat
         let cellSize = collectionViewFlowLayout.itemSize
         photoMediaSize.thumbnailSize = CGSize(width: cellSize.width * scale, height: cellSize.height * scale)
 
-        reloadDataAndRestoreSelection()
+        reloadData()
         if !hasEverAppeared {
             scrollToBottom(animated: false)
         }
@@ -318,7 +318,7 @@ class ImagePickerGridController: UICollectionViewController, PhotoLibraryDelegat
         }
     }
 
-    public func reloadDataAndRestoreSelection() {
+    public func reloadData() {
         guard let collectionView = collectionView else {
             owsFailDebug("Missing collectionView.")
             return
@@ -409,7 +409,7 @@ class ImagePickerGridController: UICollectionViewController, PhotoLibraryDelegat
 
     func photoLibraryDidChange(_ photoLibrary: PhotoLibrary) {
         photoCollectionContents = photoCollection.contents()
-        reloadDataAndRestoreSelection()
+        reloadData()
     }
 
     // MARK: - PhotoCollectionPicker Presentation
@@ -476,7 +476,7 @@ class ImagePickerGridController: UICollectionViewController, PhotoLibraryDelegat
         photoCollectionContents = photoCollection.contents()
 
         // Any selections are invalid as they refer to indices in a different collection
-        reloadDataAndRestoreSelection()
+        reloadData()
 
         titleView.text = photoCollection.localizedTitle()
 

--- a/Signal/src/ViewControllers/Photos/ImagePickerController.swift
+++ b/Signal/src/ViewControllers/Photos/ImagePickerController.swift
@@ -55,7 +55,7 @@ class ImagePickerGridController: UICollectionViewController, PhotoLibraryDelegat
             owsFailDebug("collectionView was unexpectedly nil")
             return
         }
-
+        clearsSelectionOnViewWillAppear = false
         collectionView.register(PhotoGridViewCell.self, forCellWithReuseIdentifier: PhotoGridViewCell.reuseIdentifier)
 
         // ensure images at the end of the list can be scrolled above the bottom buttons
@@ -332,15 +332,6 @@ class ImagePickerGridController: UICollectionViewController, PhotoLibraryDelegat
 
         collectionView.reloadData()
         collectionView.layoutIfNeeded()
-
-        let count = photoCollectionContents.assetCount
-        for index in 0..<count {
-            let asset = photoCollectionContents.asset(at: index)
-            if delegate.imagePicker(self, isAssetSelected: asset) {
-                collectionView.selectItem(at: IndexPath(row: index, section: 0),
-                                          animated: false, scrollPosition: [])
-            }
-        }
     }
 
     // MARK: - Actions

--- a/Signal/src/ViewControllers/Photos/ImagePickerController.swift
+++ b/Signal/src/ViewControllers/Photos/ImagePickerController.swift
@@ -55,7 +55,6 @@ class ImagePickerGridController: UICollectionViewController, PhotoLibraryDelegat
             owsFailDebug("collectionView was unexpectedly nil")
             return
         }
-        clearsSelectionOnViewWillAppear = false
         collectionView.register(PhotoGridViewCell.self, forCellWithReuseIdentifier: PhotoGridViewCell.reuseIdentifier)
 
         // ensure images at the end of the list can be scrolled above the bottom buttons
@@ -550,9 +549,9 @@ class ImagePickerGridController: UICollectionViewController, PhotoLibraryDelegat
         let assetItem = photoCollectionContents.assetItem(at: indexPath.item, photoMediaSize: photoMediaSize)
         let isSelected = delegate.imagePicker(self, isAssetSelected: assetItem.asset)
         if isSelected {
-			collectionView.selectItem(at: indexPath, animated: false, scrollPosition: [])
+            collectionView.selectItem(at: indexPath, animated: false, scrollPosition: [])
         } else {
-        	collectionView.deselectItem(at: indexPath, animated: false)
+            collectionView.deselectItem(at: indexPath, animated: false)
         }
         photoGridViewCell.isSelected = isSelected
         photoGridViewCell.allowsMultipleSelection = collectionView.allowsMultipleSelection

--- a/Signal/src/ViewControllers/Photos/ImagePickerController.swift
+++ b/Signal/src/ViewControllers/Photos/ImagePickerController.swift
@@ -325,11 +325,6 @@ class ImagePickerGridController: UICollectionViewController, PhotoLibraryDelegat
             return
         }
 
-        guard let delegate = delegate else {
-            owsFailDebug("delegate was unexpectedly nil")
-            return
-        }
-
         collectionView.reloadData()
         collectionView.layoutIfNeeded()
     }
@@ -553,7 +548,13 @@ class ImagePickerGridController: UICollectionViewController, PhotoLibraryDelegat
             return
         }
         let assetItem = photoCollectionContents.assetItem(at: indexPath.item, photoMediaSize: photoMediaSize)
-        photoGridViewCell.isSelected = delegate.imagePicker(self, isAssetSelected: assetItem.asset)
+        let isSelected = delegate.imagePicker(self, isAssetSelected: assetItem.asset)
+        if isSelected {
+			collectionView.selectItem(at: indexPath, animated: false, scrollPosition: [])
+        } else {
+        	collectionView.deselectItem(at: indexPath, animated: false)
+        }
+        photoGridViewCell.isSelected = isSelected
         photoGridViewCell.allowsMultipleSelection = collectionView.allowsMultipleSelection
     }
 

--- a/Signal/src/ViewControllers/Photos/PhotoLibrary.swift
+++ b/Signal/src/ViewControllers/Photos/PhotoLibrary.swift
@@ -244,6 +244,10 @@ class PhotoCollection {
 
         return PhotoCollectionContents(fetchResult: fetchResult, localizedTitle: localizedTitle())
     }
+    
+    var isEmpty: Bool {
+    	return collection.estimatedAssetCount == 0
+    }
 }
 
 extension PhotoCollection: Equatable {
@@ -307,7 +311,7 @@ class PhotoLibrary: NSObject, PHPhotoLibraryChangeObserver {
                 return
             }
             let photoCollection = PhotoCollection(collection: assetCollection)
-            guard !hideIfEmpty || photoCollection.contents().assetCount > 0 else {
+            guard !hideIfEmpty || !photoCollection.isEmpty else {
                 return
             }
 

--- a/Signal/src/ViewControllers/Photos/SendMediaNavigationController.swift
+++ b/Signal/src/ViewControllers/Photos/SendMediaNavigationController.swift
@@ -318,7 +318,7 @@ extension SendMediaNavigationController: UINavigationControllerDelegate {
         case is ImagePickerGridController:
             if attachmentDraftCollection.count == 1 && !isInBatchSelectMode {
                 isInBatchSelectMode = true
-                mediaLibraryViewController.reloadDataAndRestoreSelection()
+                mediaLibraryViewController.reloadData()
             }
         default:
             break


### PR DESCRIPTION
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone SE, iOS 12.4

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->
Fixes #4236 by:
- not doing photo library fetch operations for determining if a collection is empty
- not doing fetch operations in advance for determining if an asset is selected, but rather check it when it is being displayed
