### PR TITLE
Use Brewfile for xctool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,17 @@
 language: objective-c
 cache: cocoapods # pod install somtimes takes >20 minutes, so lets cache this
 
+addons:
+  homebrew:
+    update: true
+    brewfile: true
+
 osx_image: xcode8.3
 
 env:
   -EARLY_START_SIMULATOR=1 # early starting simulator reduces false negatives due to test timeouts
 
 before_install:
-    - brew update # we may not be running the latest version so always update
-    - brew outdated xctool || brew upgrade xctool # only upgrade if outdated (saves 2 minutes)
     - bundle
     - bundle exec pod repo update --silent # log output is too long without --silent
 

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,1 @@
+brew 'xctool'


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * travis-ci

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

Uses `brew`'s `bundle` feature to move `xctool` installation out of `.travis.yml` and into a `Brewfile`. Makes tool upgrades easier to manage