### PR TITLE
Two lines for conversations preview (+ bigger avatar)

### DIFF
--- a/Signal/src/ViewControllers/HomeView/ConversationListCell.m
+++ b/Signal/src/ViewControllers/HomeView/ConversationListCell.m
@@ -123,7 +123,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     self.snippetLabel = [UILabel new];
     self.snippetLabel.font = [self snippetFont];
-    self.snippetLabel.numberOfLines = 1;
+    self.snippetLabel.numberOfLines = 2;
     self.snippetLabel.lineBreakMode = NSLineBreakByTruncatingTail;
     [self.snippetLabel setContentHuggingHorizontalLow];
     [self.snippetLabel setCompressionResistanceHorizontalLow];
@@ -137,7 +137,7 @@ NS_ASSUME_NONNULL_BEGIN
     ]];
 
     bottomRowView.axis = UILayoutConstraintAxisHorizontal;
-    bottomRowView.alignment = UIStackViewAlignmentLastBaseline;
+    bottomRowView.alignment = UIStackViewAlignmentTop;
     bottomRowView.spacing = 6.f;
 
     UIStackView *vStackView = [[UIStackView alloc] initWithArrangedSubviews:@[
@@ -145,13 +145,14 @@ NS_ASSUME_NONNULL_BEGIN
         bottomRowView,
     ]];
     vStackView.axis = UILayoutConstraintAxisVertical;
+    vStackView.spacing = 2.f;
 
     [self.contentView addSubview:vStackView];
     [vStackView autoPinLeadingToTrailingEdgeOfView:self.avatarView offset:self.avatarHSpacing];
-    [vStackView autoVCenterInSuperview];
+    [vStackView autoPinEdge:ALEdgeTop toEdge:ALEdgeTop ofView:self.avatarView withOffset:0 relation: NSLayoutRelationLessThanOrEqual];
     // Ensure that the cell's contents never overflow the cell bounds.
-    [vStackView autoPinEdgeToSuperviewEdge:ALEdgeTop withInset:8 relation:NSLayoutRelationGreaterThanOrEqual];
-    [vStackView autoPinEdgeToSuperviewEdge:ALEdgeBottom withInset:8 relation:NSLayoutRelationGreaterThanOrEqual];
+    [vStackView autoPinEdgeToSuperviewEdge:ALEdgeTop withInset:9 relation:NSLayoutRelationGreaterThanOrEqual];
+    [vStackView autoPinEdgeToSuperviewEdge:ALEdgeBottom withInset:9 relation:NSLayoutRelationGreaterThanOrEqual];
     [vStackView autoPinTrailingToSuperviewMargin];
 
     vStackView.userInteractionEnabled = NO;
@@ -446,7 +447,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSUInteger)avatarSize
 {
-    return kStandardAvatarSize;
+    return kMediumAvatarSize;
 }
 
 - (NSUInteger)avatarHSpacing

--- a/Signal/src/ViewControllers/HomeView/MessageStatusView.swift
+++ b/Signal/src/ViewControllers/HomeView/MessageStatusView.swift
@@ -10,8 +10,8 @@ public class MessageStatusView: UIView {
     private let imageView: UIImageView
     private let lastBaselineView: UIView
 
-    // MessageStatusView is aligned 1pt below it's baseline.
-    private let kBaselineOverhang: CGFloat = 1
+    // MessageStatusView is aligned 3pt below it's baseline.
+    private let kBaselineOverhang: CGFloat = 3
 
     @objc
     public var image: UIImage? {

--- a/SignalMessaging/utils/OWSAvatarBuilder.h
+++ b/SignalMessaging/utils/OWSAvatarBuilder.h
@@ -5,6 +5,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 extern const NSUInteger kStandardAvatarSize;
+extern const NSUInteger kMediumAvatarSize;
 extern const NSUInteger kLargeAvatarSize;
 
 @class TSThread;

--- a/SignalMessaging/utils/OWSAvatarBuilder.m
+++ b/SignalMessaging/utils/OWSAvatarBuilder.m
@@ -16,6 +16,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 const NSUInteger kStandardAvatarSize = 48;
+const NSUInteger kMediumAvatarSize = 56;
 const NSUInteger kLargeAvatarSize = 68;
 
 typedef void (^OWSAvatarDrawBlock)(CGContextRef context);


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 11 Pro 13.3

- - - - - - - - - -

### Description
Hi there! I have modified the conversation list, allowing two-lines preview for the messages. Basically, that's how WhatsApp, Telegram and iOS Messages show the message previews. Very little modifications. I also had to increase the avatar size. Tested with accessibility extra large font too. Check here:

![Simulator Screen Shot - iPhone 11 Pro - Normal text](https://user-images.githubusercontent.com/7063023/75354229-f0746300-58ac-11ea-8704-781c38082d52.png)
![Simulator Screen Shot - iPhone 11 Pro - Extra large text](https://user-images.githubusercontent.com/7063023/75354236-f23e2680-58ac-11ea-8a68-5f5e3773e302.png)

