### PR TITLE
Fix 'guard' body fall through when contacts are unexpectedly not set after a fetch

### DIFF
--- a/SignalMessaging/contacts/SystemContactsFetcher.swift
+++ b/SignalMessaging/contacts/SystemContactsFetcher.swift
@@ -363,6 +363,7 @@ public class SystemContactsFetcher: NSObject {
             guard let contacts = fetchedContacts else {
                 owsFailDebug("contacts was unexpectedly not set.")
                 completion(nil)
+                return
             }
 
             Logger.info("fetched \(contacts.count) contacts.")


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [ ] I have tested my contribution on these devices:

- - - - - - - - - -

### Description
This pull request removes a compiler error in `SignalMessaging` that is caused by allowing a `guard` body to fall through, instead of returning or throwing an error.

The fix is simply to add a `return` to follow the same completion/return pattern found in the file.

I don't believe that this issue will be encountered in production. In the switch case of `fetchContacts` returning `.success`, the payload will at least be an empty array and in the case of `.error` we successfully `return` before the `guard`.
