### PR TITLE
Fix guard fall through and linting errors

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,3 +1,6 @@
+function_body_length:
+  - 60
+  - 100
 line_length: 200
 disabled_rules:
   - file_length

--- a/SignalMessaging/contacts/OWSContactsManager.m
+++ b/SignalMessaging/contacts/OWSContactsManager.m
@@ -172,7 +172,7 @@ NSString *const OWSContactsManagerKeyNextFullIntersectionDate = @"OWSContactsMan
 
 - (BOOL)systemContactsHaveBeenRequestedAtLeastOnce
 {
-    return self.systemContactsFetcher.systemContactsHaveBeenRequestedAtLeastOnce;
+    return self.systemContactsFetcher.systemContactsPreviouslyRequested;
 }
 
 - (BOOL)supportsContactEditing

--- a/SignalMessaging/contacts/SystemContactsFetcher.swift
+++ b/SignalMessaging/contacts/SystemContactsFetcher.swift
@@ -400,9 +400,7 @@ public class SystemContactsFetcher: NSObject {
 
                 guard shouldNotifyDelegate else {
                     Logger.info("no reason to notify delegate.")
-
                     completion(nil)
-
                     return
                 }
 

--- a/SignalMessaging/contacts/SystemContactsFetcher.swift
+++ b/SignalMessaging/contacts/SystemContactsFetcher.swift
@@ -1,5 +1,5 @@
 //
-//  Copyright (c) 2019 Open Whisper Systems. All rights reserved.
+//  Copyright (c) 2020 Open Whisper Systems. All rights reserved.
 //
 
 import Foundation
@@ -190,7 +190,7 @@ public class SystemContactsFetcher: NSObject {
     }
 
     @objc
-    public private(set) var systemContactsHaveBeenRequestedAtLeastOnce = false
+    public private(set) var systemContactsPreviouslyRequested = false
     private var hasSetupObservation = false
 
     override init() {
@@ -237,7 +237,7 @@ public class SystemContactsFetcher: NSObject {
             })
         }
 
-        guard !systemContactsHaveBeenRequestedAtLeastOnce else {
+        guard !systemContactsPreviouslyRequested else {
             completion(nil)
             return
         }
@@ -284,7 +284,7 @@ public class SystemContactsFetcher: NSObject {
             self.delegate?.systemContactsFetcher(self, hasAuthorizationStatus: authorizationStatus)
             return
         }
-        guard !systemContactsHaveBeenRequestedAtLeastOnce else {
+        guard !systemContactsPreviouslyRequested else {
             return
         }
 
@@ -328,7 +328,7 @@ public class SystemContactsFetcher: NSObject {
                 return
             }
 
-            guard let _ = self else {
+            guard self != nil else {
                 return
             }
             Logger.error("background task time ran out before contacts fetch completed.")
@@ -344,7 +344,7 @@ public class SystemContactsFetcher: NSObject {
             })
         }
 
-        systemContactsHaveBeenRequestedAtLeastOnce = true
+        systemContactsPreviouslyRequested = true
         setupObservationIfNecessary()
 
         serialQueue.async {
@@ -363,6 +363,7 @@ public class SystemContactsFetcher: NSObject {
             guard let contacts = fetchedContacts else {
                 owsFailDebug("contacts was unexpectedly not set.")
                 completion(nil)
+                return
             }
 
             Logger.info("fetched \(contacts.count) contacts.")


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 11 Pro, iOS 13.4
 * iPad Pro 12.9 (3rd Gen), iPadOS 13.4

- - - - - - - - - -

### Description
Added missing return to contacts guard.

Promoted ./Signal/.swiftlint.yml to project root to ensure custom rules are applied correctly. I think 40 line function length warning is a little aggressive considering the default error length is 100 so I am overwriting the warning length to 60. Resolved remaining listing rule warning by renaming variable to a shorter name that is semantically correct but within the bounds of the linter rules.