### PR TITLE
Fix 'New message' shortcut on cold start.

### DIFF
--- a/Signal/src/AppDelegate.m
+++ b/Signal/src/AppDelegate.m
@@ -77,6 +77,7 @@ NSString *NSStringForLaunchFailure(LaunchFailure launchFailure)
 
 @property (nonatomic) BOOL areVersionMigrationsComplete;
 @property (nonatomic) BOOL didAppLaunchFail;
+@property (nonatomic) UIApplicationShortcutItem *shortcutItem;
 
 @end
 
@@ -354,6 +355,11 @@ NSString *NSStringForLaunchFailure(LaunchFailure launchFailure)
     OWSLogInfo(@"launchOptions: %@.", launchOptions);
 
     [OWSAnalytics appLaunchDidBegin];
+
+    self.shortcutItem = launchOptions[UIApplicationLaunchOptionsShortcutItemKey];
+    if (self.shortcutItem) {
+        return NO;
+    }
 
     return YES;
 }
@@ -1214,6 +1220,10 @@ NSString *NSStringForLaunchFailure(LaunchFailure launchFailure)
     [self.profileManager fetchAndUpdateLocalUsersProfile];
 
     [SignalApp.sharedApp ensureRootViewController:launchStartedAt];
+
+    if (self.shortcutItem) {
+        [SignalApp.sharedApp showNewConversationView];
+    }
 
     [self.messageManager startObserving];
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 11 Pro iOS 13.3

- - - - - - - - - -

### Description
Fixes signalapp/Signal-iOS#4393. According to [UIKit docs (see "Discussion" section)](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1622935-application?language=objc), shortcut items must be intercepted in `application:didFinishLaunchingWithOptions:` or `application:willFinishLaunchingWithOptions:` if the app hasn't started yet.
