### PR TITLE
Fix: empty string activates send button

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/ConversationInputToolbar.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationInputToolbar.m
@@ -623,8 +623,9 @@ const CGFloat kMaxIPadTextViewHeight = 142;
     // NOTE: We use untrimmedText, so that the sticker button disappears
     //       even if the user just enters whitespace.
     BOOL hasTextInput = self.inputTextView.untrimmedText.length > 0;
+    BOOL hasNoWhiteSpace = self.inputTextView.trimmedText.length > 0;
     ensureViewHiddenState(self.attachmentButton, NO);
-    if (hasTextInput) {
+    if (hasTextInput && hasNoWhiteSpace) {
         ensureViewHiddenState(self.cameraButton, YES);
         ensureViewHiddenState(self.voiceMemoButton, YES);
         ensureViewHiddenState(self.sendButton, NO);


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 11 Pro 13.4.1

- - - - - - - - - -

### Description
It was checked if the inputText for untrimmed strings is greater zero. But to prevent the activation of the send button with only empty spaces i've added a check if the length of the trimmedText is greater zero as well.

I've read the NOTE that the untrimmedText was used to hide the Sticker button even if the user types only whitespaces. I've considered that and separated it.
