### PR TITLE
Fix the image picker's dismissal animation of the collection view

### DIFF
--- a/Signal/src/ViewControllers/Photos/ImagePickerController.swift
+++ b/Signal/src/ViewControllers/Photos/ImagePickerController.swift
@@ -436,7 +436,7 @@ class ImagePickerGridController: UICollectionViewController, PhotoLibraryDelegat
         isShowingCollectionPickerController = false
 
         UIView.animate(.promise, duration: 0.25, delay: 0, options: .curveEaseInOut) {
-            self.collectionPickerController.view.frame = self.view.frame.offsetBy(dx: 0, dy: self.view.frame.height)
+            self.collectionPickerController.view.frame.origin.y += self.collectionPickerController.view.frame.height
             self.titleView.rotateIcon(.down)
         }.done { _ in
             self.collectionPickerController.view.removeFromSuperview()


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 11 Pro Max, iOS 13.5
 * iPad Pro, iPadOS 13.5

- - - - - - - - - -

### Description

The image picker was not quite dismissing a view but rather it was
restoring it to fill the screen's frame by updating the offset. This
change updates the frame.origin.y of the collection view's frame to
account for the height of the view's height. This gives us an animation
that pushes the view off-screen as we'd expect before the controller
removes the view altogether.

Here is a before and after with adjusted animation duration of 2.25 for clarity

Before | After
--|--
![before](https://user-images.githubusercontent.com/5240843/83824491-83325400-a68b-11ea-96de-b2bd29c4c820.gif) | ![after](https://user-images.githubusercontent.com/5240843/83824342-0d2ded00-a68b-11ea-8e33-a7e1f3108201.gif)

