### PR TITLE
Adds InfoPlist.strings.

### DIFF
--- a/Signal.xcodeproj/project.pbxproj
+++ b/Signal.xcodeproj/project.pbxproj
@@ -733,6 +733,7 @@
 		A1C32D5017A06538000A904E /* AddressBookUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A1C32D4F17A06537000A904E /* AddressBookUI.framework */; };
 		A1C32D5117A06544000A904E /* AddressBook.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A1C32D4D17A0652C000A904E /* AddressBook.framework */; };
 		A5509ECA1A69AB8B00ABA4BC /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A5509EC91A69AB8B00ABA4BC /* Main.storyboard */; };
+		A5E7C675248C5443007C949A /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = A5E7C673248C5442007C949A /* InfoPlist.strings */; };
 		B60EDE041A05A01700D73516 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B60EDE031A05A01700D73516 /* AudioToolbox.framework */; };
 		B660F6D41C29868000687D6E /* whisperFake.cer in Resources */ = {isa = PBXBuildFile; fileRef = B660F69F1C29868000687D6E /* whisperFake.cer */; };
 		B660F6DB1C29868000687D6E /* FunctionalUtilTest.m in Sources */ = {isa = PBXBuildFile; fileRef = B660F6AD1C29868000687D6E /* FunctionalUtilTest.m */; };
@@ -1714,6 +1715,8 @@
 		A1C32D4F17A06537000A904E /* AddressBookUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AddressBookUI.framework; path = System/Library/Frameworks/AddressBookUI.framework; sourceTree = SDKROOT; };
 		A1FDCBEE16DAA6C300868894 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
 		A5509EC91A69AB8B00ABA4BC /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = Main.storyboard; path = Storyboard/Main.storyboard; sourceTree = "<group>"; };
+		A5E7C674248C5442007C949A /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = translations/en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		A5E7C676248C544E007C949A /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = translations/ja.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		B60EDE031A05A01700D73516 /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
 		B634CBB31AB10D2300C49B99 /* hr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hr; path = translations/hr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		B634CBB51AB10D5400C49B99 /* ro */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ro; path = translations/ro.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -3387,6 +3390,7 @@
 		B6B6C3C419193F5B00C0B76B /* Translations */ = {
 			isa = PBXGroup;
 			children = (
+				A5E7C673248C5442007C949A /* InfoPlist.strings */,
 				B6F509951AA53F760068F56A /* Localizable.strings */,
 			);
 			name = Translations;
@@ -3943,6 +3947,7 @@
 				34CF078A203E6B78005C4D61 /* end_call_tone_cept.caf in Resources */,
 				8889006C23DBB39B00F40186 /* reactionsMegaphone.json in Resources */,
 				34330A5A1E7875FB00DF2FB9 /* fontawesome-webfont.ttf in Resources */,
+				A5E7C675248C5443007C949A /* InfoPlist.strings in Resources */,
 				A5509ECA1A69AB8B00ABA4BC /* Main.storyboard in Resources */,
 				34330A5C1E787A9800DF2FB9 /* dripicons-v2.ttf in Resources */,
 				880C0FF7233D3F7C00386FB8 /* playPauseButton.json in Resources */,
@@ -5055,6 +5060,15 @@
 				4535186D1FC635DD00210559 /* Base */,
 			);
 			name = MainInterface.storyboard;
+			sourceTree = "<group>";
+		};
+		A5E7C673248C5442007C949A /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				A5E7C674248C5442007C949A /* en */,
+				A5E7C676248C544E007C949A /* ja */,
+			);
+			name = InfoPlist.strings;
 			sourceTree = "<group>";
 		};
 		B6F509951AA53F760068F56A /* Localizable.strings */ = {

--- a/Signal/translations/en.lproj/InfoPlist.strings
+++ b/Signal/translations/en.lproj/InfoPlist.strings
@@ -1,0 +1,8 @@
+NSAppleMusicUsageDescription = "Signal needs to use Apple Music to play media attachments.";
+NSCameraUsageDescription = "Signal uses your camera to take photos and for video calls.";
+NSContactsUsageDescription = "Signal uses your contacts to find users you know. We do not store your contacts on the server.";
+NSFaceIDUsageDescription = "Signal's Screen Lock uses Face ID.";
+NSLocationWhenInUseUsageDescription = "Signal needs access to your location in order to share your current location.";
+NSMicrophoneUsageDescription = "Signal needs access to your microphone to make and receive phone calls and record voice messages.";
+NSPhotoLibraryAddUsageDescription = "Signal will save photos to your library.";
+NSPhotoLibraryUsageDescription = "Signal will let you choose which photos from your library to send.";

--- a/Signal/translations/ja.lproj/InfoPlist.strings
+++ b/Signal/translations/ja.lproj/InfoPlist.strings
@@ -1,0 +1,8 @@
+NSAppleMusicUsageDescription = "Signalはメディアファイルを再生するためにApple Musicを利用します。";
+NSCameraUsageDescription = "Signalはビデオ通話と写真撮影のためにカメラを利用します。";
+NSContactsUsageDescription = "Signalは他のユーザーを探すために連絡先にアクセスします。連絡先の情報はサーバーには保存されません。";
+NSFaceIDUsageDescription = "Signalの画面ロックはFace IDを利用します。";
+NSLocationWhenInUseUsageDescription = "Signalは現在地を共有するために位置情報を利用します。";
+NSMicrophoneUsageDescription = "Signalは通話とメッセージを録音するためにマイクを利用します。";
+NSPhotoLibraryAddUsageDescription = "Signalは写真をフォトライブラリに保存します。";
+NSPhotoLibraryUsageDescription = "Signalは送信する写真をフォトライブラリから選択できるようにします。";


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iOS Simulator iPhone SE 2nd Gen, iOS 13.4

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->
I noticed that the contents in the permission dialogs were not translated. I added a base (en) file and a translation (Japanese which I am native of). I don't know how it could be picked up by Transifex, so let me know if I need to do something more, for example to add the file to all translation folders.

Screenshots before and after in a device in Japanese:

Before
![before](https://user-images.githubusercontent.com/28482/84085941-b4c15d00-a9b4-11ea-84cc-3823272106ea.png)

After
![after](https://user-images.githubusercontent.com/28482/84085960-bf7bf200-a9b4-11ea-9f35-d7ada9ab0579.png)



