### PR TITLE
Accept HEIF as a valid image format

### DIFF
--- a/SignalServiceKit/src/Messages/Attachments/TSAttachmentStream.m
+++ b/SignalServiceKit/src/Messages/Attachments/TSAttachmentStream.m
@@ -498,11 +498,11 @@ typedef void (^OWSLoadedThumbnailSuccess)(OWSLoadedThumbnail *loadedThumbnail);
     BOOL result;
     BOOL didUpdateCache = NO;
     @synchronized(self) {
-        if (!self.isValidImageCached) {
+        if (!self.isValidImageCached.boolValue) {
             OWSLogVerbose(@"Updating isValidImageCached.");
             self.isValidImageCached = @([NSData ows_isValidImageAtPath:self.originalFilePath
                                                               mimeType:self.contentType]);
-            if (!self.isValidImageCached) {
+            if (!self.isValidImageCached.boolValue) {
                 OWSLogWarn(@"Invalid image.");
             }
             didUpdateCache = YES;

--- a/SignalServiceKit/src/Util/MIMETypeUtil.h
+++ b/SignalServiceKit/src/Util/MIMETypeUtil.h
@@ -14,6 +14,8 @@ extern NSString *const OWSMimeTypeImageTiff2;
 extern NSString *const OWSMimeTypeImageBmp1;
 extern NSString *const OWSMimeTypeImageBmp2;
 extern NSString *const OWSMimeTypeImageWebp;
+extern NSString *const OWSMimeTypeImageHeic;
+extern NSString *const OWSMimeTypeImageHeif;
 extern NSString *const OWSMimeTypePdf;
 extern NSString *const OWSMimeTypeOversizeTextMessage;
 extern NSString *const OWSMimeTypeProtobuf;

--- a/SignalServiceKit/src/Util/MIMETypeUtil.m
+++ b/SignalServiceKit/src/Util/MIMETypeUtil.m
@@ -24,6 +24,8 @@ NSString *const OWSMimeTypeImageTiff2 = @"image/x-tiff";
 NSString *const OWSMimeTypeImageBmp1 = @"image/bmp";
 NSString *const OWSMimeTypeImageBmp2 = @"image/x-windows-bmp";
 NSString *const OWSMimeTypeImageWebp = @"image/webp";
+NSString *const OWSMimeTypeImageHeic = @"image/heic";
+NSString *const OWSMimeTypeImageHeif = @"image/heif";
 NSString *const OWSMimeTypePdf = @"application/pdf";
 NSString *const OWSMimeTypeOversizeTextMessage = @"text/x-signal-plain";
 NSString *const OWSMimeTypeUnknownForTests = @"unknown/mimetype";
@@ -93,6 +95,8 @@ NSString *const kSyncMessageFileExtension = @"bin";
             @"image/bmp" : @"bmp",
             @"image/x-windows-bmp" : @"bmp",
             OWSMimeTypeImageWebp : @"webp",
+            OWSMimeTypeImageHeic : @"heic",
+            OWSMimeTypeImageHeif : @"heif",
         };
     });
     return result;
@@ -184,6 +188,8 @@ NSString *const kSyncMessageFileExtension = @"bin";
             @"tif" : @"image/tiff",
             @"tiff" : @"image/tiff",
             @"webp" : OWSMimeTypeImageWebp,
+            @"heic" : OWSMimeTypeImageHeic,
+            @"heif" : OWSMimeTypeImageHeif,
         };
     });
     return result;

--- a/SignalServiceKit/src/Util/NSData+Image.h
+++ b/SignalServiceKit/src/Util/NSData+Image.h
@@ -13,6 +13,8 @@ typedef NS_ENUM(NSInteger, ImageFormat) {
     ImageFormat_Jpeg,
     ImageFormat_Bmp,
     ImageFormat_Webp,
+    ImageFormat_Heic,
+    ImageFormat_Heif,
 };
 
 NSString *NSStringForImageFormat(ImageFormat value);

--- a/SignalServiceKit/src/Util/NSData+Image.m
+++ b/SignalServiceKit/src/Util/NSData+Image.m
@@ -137,6 +137,10 @@ NSString *NSStringForImageFormat(ImageFormat value)
             return OWSMimeTypeImageBmp1;
         case ImageFormat_Webp:
             return OWSMimeTypeImageWebp;
+        case ImageFormat_Heic:
+            return OWSMimeTypeImageHeic;
+        case ImageFormat_Heif:
+            return OWSMimeTypeImageHeif;
     }
 }
 
@@ -165,6 +169,8 @@ NSString *NSStringForImageFormat(ImageFormat value)
         case ImageFormat_Jpeg:
         case ImageFormat_Bmp:
         case ImageFormat_Webp:
+        case ImageFormat_Heic:
+        case ImageFormat_Heif:
             return YES;
     }
 }
@@ -190,6 +196,49 @@ NSString *NSStringForImageFormat(ImageFormat value)
                 [mimeType caseInsensitiveCompare:OWSMimeTypeImageBmp2] == NSOrderedSame);
         case ImageFormat_Webp:
             return (mimeType == nil || [mimeType caseInsensitiveCompare:OWSMimeTypeImageWebp] == NSOrderedSame);
+        case ImageFormat_Heic:
+            return (mimeType == nil || [mimeType caseInsensitiveCompare:OWSMimeTypeImageHeic] == NSOrderedSame);
+        case ImageFormat_Heif:
+            return (mimeType == nil || [mimeType caseInsensitiveCompare:OWSMimeTypeImageHeif] == NSOrderedSame);
+    }
+}
+
+- (ImageFormat)ows_guessHighEfficiencyImageFormat
+{
+    // A HEIF image file has the first 16 bytes like
+    // 0000 0018 6674 7970 6865 6963 0000 0000
+    // so in this case the 5th to 12th bytes shall make a string of "ftypheic"
+    const NSUInteger kHeifHeaderStartsAt = 4;
+    const NSUInteger kHeifBrandStartsAt = 8;
+    // We support "heic", "mif1" or "msf1". Other brands are invalid for us for now.
+    // The length is 4 + 1 because the brand must be terminated with a nul.
+    // Include the nul in the comparison to prevent a bogus brand like "heicfake"
+    // from being considered valid.
+    const NSUInteger kHeifSupportedBrandLength = 5;
+    const NSUInteger kTotalHeaderLength = kHeifBrandStartsAt - kHeifHeaderStartsAt + kHeifSupportedBrandLength;
+    if (self.length < kHeifBrandStartsAt + kHeifSupportedBrandLength) {
+        return ImageFormat_Unknown;
+    }
+
+    // These are the brands of HEIF formatted files that are renderable by CoreGraphics
+    const NSString *kHeifBrandHeaderHeic = @"ftypheic\0";
+    const NSString *kHeifBrandHeaderHeif = @"ftypmif1\0";
+    const NSString *kHeifBrandHeaderHeifStream = @"ftypmsf1\0";
+
+    // Pull the string from the header and compare it with the supported formats
+    unsigned char bytes[kTotalHeaderLength];
+    [self getBytes:&bytes range:NSMakeRange(kHeifHeaderStartsAt, kTotalHeaderLength)];
+    NSData *data = [[NSData alloc] initWithBytes:bytes length:kTotalHeaderLength];
+    NSString *marker = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+
+    if ([kHeifBrandHeaderHeic isEqualToString:marker]) {
+        return ImageFormat_Heic;
+    } else if ([kHeifBrandHeaderHeif isEqualToString:marker]) {
+        return ImageFormat_Heif;
+    } else if ([kHeifBrandHeaderHeifStream isEqualToString:marker]) {
+        return ImageFormat_Heif;
+    } else {
+        return ImageFormat_Unknown;
     }
 }
 
@@ -225,7 +274,7 @@ NSString *NSStringForImageFormat(ImageFormat value)
         return ImageFormat_Webp;
     }
 
-    return ImageFormat_Unknown;
+    return [self ows_guessHighEfficiencyImageFormat];
 }
 
 + (BOOL)ows_areByteArraysEqual:(NSUInteger)length left:(unsigned char *)left right:(unsigned char *)right


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone SE 2nd Gen iOS 13.5
- - - - - - - - - -

### Description
Accepts still images in HEIF format as valid media in a conversation. Fixes #4449.

### Steps to verify the PR
The easiest way to test the feature is to prepare a Signal Desktop installation in a PC/mac and have some HEIF files downloaded to the laptop.

1. Prepare a few HEIF format images. There are a few examples in the [NOKIA's GitHub page](https://nokiatech.github.io/heif/examples.html). Note that these NOKIA files are either in `mif1` or in `msf1` format. If you can you may also want to take a photo in an iPhone and AirDrop it to a mac to prepare a `heic` file.
2. Send those images to a Signal conversation that can be opened in an iPhone.
3. Open the conversation in iPhone.

#### Behavior at the current master at [6fe6c808a3b85b018bd476ca2a6c81f1a300fd0c]:

Those images appear as a generic attachments.

#### Behavior after the PR:

Those images appear as media in the conversation. Tapping it opens the media view.

### Screenshots

Before:

![Before](https://user-images.githubusercontent.com/28482/85933038-58a97480-b8a0-11ea-87ee-82f1d438689a.png)

----

After:

![After](https://user-images.githubusercontent.com/28482/85933046-71b22580-b8a0-11ea-9c87-f049a17dd6f1.png)
