### PR TITLE
Vertically align a line of text in placeholders and inputs

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/ConversationInputTextView.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationInputTextView.m
@@ -142,7 +142,15 @@ NS_ASSUME_NONNULL_BEGIN
         }
     }
 
-    self.textContainerInset = UIEdgeInsetsMake(7.f, leftInset, 7.f, rightInset);
+    // Check the system font size and increase text inset accordingly
+    // to keep the text vertically centered
+    CGFloat currentFontSize = self.font.pointSize;
+    // Default body font size is 17 according to the HIG (Typography)
+    CGFloat systemDefaultFontSize = 17.f;
+    CGFloat ourDefaultInset = 7.f;
+    CGFloat topInset = ourDefaultInset + (systemDefaultFontSize > currentFontSize ? systemDefaultFontSize - currentFontSize : 0);
+    CGFloat bottomInset = systemDefaultFontSize > currentFontSize ? topInset - 1 : topInset;
+    self.textContainerInset = UIEdgeInsetsMake(topInset, leftInset, bottomInset, rightInset);
 }
 
 - (void)setText:(NSString *_Nullable)text

--- a/SignalMessaging/ViewControllers/AttachmentApproval/AttachmentTextToolbar.swift
+++ b/SignalMessaging/ViewControllers/AttachmentApproval/AttachmentTextToolbar.swift
@@ -298,7 +298,16 @@ class AttachmentTextToolbar: UIView, UITextViewDelegate {
 
         textView.font = UIFont.ows_dynamicTypeBody
         textView.textColor = Theme.darkThemePrimaryColor
-        textView.textContainerInset = UIEdgeInsets(top: 7, left: 7, bottom: 7, right: 7)
+
+        // Check the system font size and increase text inset accordingly
+        // to keep the text vertically centered
+        let currentFontSize = textView.font!.pointSize
+        // Default body font size is 17 according to the HIG (Typography)
+        let systemDefaultFontSize: CGFloat = 17
+        let ourDefaultInset: CGFloat = 7
+        let topInset = ourDefaultInset + (systemDefaultFontSize > currentFontSize ? systemDefaultFontSize - currentFontSize : 0)
+        let bottomInset = systemDefaultFontSize > currentFontSize ? topInset - 1 : topInset
+        textView.textContainerInset = UIEdgeInsets(top: topInset, left: ourDefaultInset, bottom: bottomInset, right: ourDefaultInset)
 
         return textView
     }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 11 Pro, iOS 13.5
 * iPhone XR, iOS 12.4

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->
Increases the vertical insets of placeholders and text inputs to keep them vertically aligned when the system is set to use smaller font and it contains only a line of text. Fixes #4273

### Steps to verify the fix
1. Change the system font size to smaller ones by going to:
    - iOS 13: Settings > Accessibility > Display & Text Size > Larger Text and use the slider in the bottom of the view
    - iOS 12: Settings > General > Accessibility > Larger Text and use the slider in the bottom of the view
1. Launch Signal
1. Go to an existing conversation and look at the text input at the bottom of the view
1. See if the placeholder is vertically centered
1. Enter a few text and see if the single line text is vertically centered
1. Tap on the camera icon and open the gallery
1. Select a photo to share and tap the "proceed" button
1. Look at the text input at the bottom of the view
1. See if the placeholder is vertically centered
1. Enter a few text and see if the single line text is vertically centered

### Screenshots
#### Before the fix at master@[d57c3b96df30424cb16c764e2ec021001571f535]

![before1](https://user-images.githubusercontent.com/28482/87249965-1e0f1280-c430-11ea-9701-d59c89f03e61.png)|![before2](https://user-images.githubusercontent.com/28482/87249849-8dd0cd80-c42f-11ea-92ca-9d995202708f.png)

#### After the fix

![after1](https://user-images.githubusercontent.com/28482/87249971-2404f380-c430-11ea-885b-63b0b391c1f8.png)|![after2](https://user-images.githubusercontent.com/28482/87249976-26ffe400-c430-11ea-9478-9a9abee6e1b4.png)

