### PR TITLE
Enabled torch for video recording.

### DIFF
--- a/Signal/src/ViewControllers/Photos/PhotoCapture.swift
+++ b/Signal/src/ViewControllers/Photos/PhotoCapture.swift
@@ -487,6 +487,7 @@ class PhotoCapture: NSObject {
         }.done(on: captureOutput.movieRecordingQueue) { movieRecording in
             self.captureOutput.movieRecording = movieRecording
         }.done {
+            self.setTorchMode(self.flashMode.toTorchMode)
             self.delegate?.photoCaptureDidBeginMovie(self)
         }.catch { error in
             self.delegate?.photoCapture(self, processingDidError: error)
@@ -498,6 +499,7 @@ class PhotoCapture: NSObject {
         BenchEventStart(title: "Movie Processing", eventId: "Movie Processing")
         captureOutput.movieRecordingQueue.async(.promise) {
             self.captureOutput.completeMovie(delegate: self)
+            self.setTorchMode(.off)
         }.done(on: sessionQueue) {
             self.stopAudioCapture()
         }
@@ -514,6 +516,17 @@ class PhotoCapture: NSObject {
             self.stopAudioCapture()
         }
         delegate?.photoCaptureDidCancelMovie(self)
+    }
+    
+    private func setTorchMode(_ mode: AVCaptureDevice.TorchMode) {
+        guard let captureDevice = captureDevice, captureDevice.hasTorch, captureDevice.isTorchModeSupported(mode) else { return }
+        do {
+            try captureDevice.lockForConfiguration()
+            captureDevice.torchMode = mode
+            captureDevice.unlockForConfiguration()
+        } catch {
+            owsFailDebug("Error setting torchMode: \(error)")
+        }
     }
 }
 
@@ -1171,6 +1184,22 @@ extension CGSize {
             return CGSize(width: width, height: width * aspectRatio)
         } else {
             return CGSize(width: height * aspectRatio, height: height)
+        }
+    }
+}
+
+extension AVCaptureDevice.FlashMode {
+    var toTorchMode: AVCaptureDevice.TorchMode {
+        switch self {
+        case .auto:
+            return .auto
+        case .on:
+            return .on
+        case .off:
+            return .off
+        @unknown default:
+            owsFailDebug("Unhandled AVCaptureDevice.FlashMode type: \(self)")
+            return .off
         }
     }
 }


### PR DESCRIPTION
Making use of existing flash mode property to set the `flashMode` when recording a video.

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iDevice 6, iOS 12.4.6
 * iDevice XR, iOS 13.6.1

- - - - - - - - - -

### Description

This PR fixes #4518 by enabling the torch on the device when the user starts recording a video, by making use of the existing `flashMode` property.

#### Testing Steps

1. Launch app and tap camera icon top right.
2. Tap flash icon top right and set flash to either `on` or `automatic`.
3. Hold capture button to record video.
4. Confirm torch turns on.

Repeated these steps from a user chat page also.
