### PR TITLE
Accepts PDF data from Sarari to share to Signal

### DIFF
--- a/SignalShareExtension/ShareViewController.swift
+++ b/SignalShareExtension/ShareViewController.swift
@@ -647,6 +647,10 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
                     return UnloadedItem(itemProvider: itemProvider, itemType: .text)
                 }
 
+                if itemProvider.hasItemConformingToTypeIdentifier(kUTTypePDF as String) {
+                    return UnloadedItem(itemProvider: itemProvider, itemType: .pdf)
+                }
+
                 owsFailDebug("unexpected share item: \(itemProvider)")
                 return UnloadedItem(itemProvider: itemProvider, itemType: .other)
             }
@@ -681,6 +685,7 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
             case webUrl(_ webUrl: URL)
             case contact(_ contactData: Data)
             case text(_ text: String)
+            case pdf(_ data: Data)
         }
 
         let itemProvider: NSItemProvider
@@ -708,6 +713,7 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
             case fileUrl
             case contact
             case text
+            case pdf
             case other
         }
 
@@ -770,6 +776,11 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
             return itemProvider.loadText(forTypeIdentifier: kUTTypeText as String, options: nil).map { text in
                 LoadedItem(itemProvider: unloadedItem.itemProvider,
                            payload: .text(text))
+            }
+        case .pdf:
+            return itemProvider.loadData(forTypeIdentifier: kUTTypePDF as String, options: nil).map { data in
+                LoadedItem(itemProvider: unloadedItem.itemProvider,
+                           payload: .pdf(data))
             }
         case .other:
             return itemProvider.loadUrl(forTypeIdentifier: kUTTypeFileURL as String, options: nil).map { fileUrl in
@@ -855,6 +866,10 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
             }
             let dataSource = DataSourceValue.dataSource(with: pngData, fileExtension: "png")
             let attachment = SignalAttachment.attachment(dataSource: dataSource, dataUTI: kUTTypePNG as String, imageQuality: .medium)
+            return Promise.value(attachment)
+        case .pdf(let pdf):
+            let dataSource = DataSourceValue.dataSource(with: pdf, fileExtension: "pdf")
+            let attachment = SignalAttachment.attachment(dataSource: dataSource, dataUTI: kUTTypePDF as String)
             return Promise.value(attachment)
         }
     }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ ] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 11, iOS 13.4

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

Fixes #4377. Before, when you take a screenshot of a page in Safari, select "Full Page" and share it to Signal, you would see the error message indicating that the data is not compatible for Signal to accept. After the patch the in-memory PDF is accepted by Signal.

![pdf_error](https://user-images.githubusercontent.com/28482/92998140-2940f600-f4e6-11ea-962a-10b5abf9c9f8.png)

