### PR TITLE
Send static WebP images in iOS 14 as JPEGs.

### DIFF
--- a/SignalMessaging/attachments/SignalAttachment.swift
+++ b/SignalMessaging/attachments/SignalAttachment.swift
@@ -817,29 +817,17 @@ public class SignalAttachment: NSObject {
             let dataFileExtension: String
             let imageData: Data
 
-            if attachment.mimeType == OWSMimeTypeImageWebp {
-                guard let pngImageData = dstImage.pngData() else {
-                    attachment.error = .couldNotConvertImage
-                    return attachment
-                }
-
-                dataUTI = kUTTypePNG as String
-                dataMIMEType = OWSMimeTypeImagePng
-                dataFileExtension = "png"
-                imageData = pngImageData
-            } else {
-                guard let jpgImageData = dstImage.jpegData(
-                    compressionQuality: jpegCompressionQuality(imageUploadQuality: imageUploadQuality)
-                ) else {
-                    attachment.error = .couldNotConvertImage
-                    return attachment
-                }
-
-                dataUTI = kUTTypeJPEG as String
-                dataMIMEType = OWSMimeTypeImageJpeg
-                dataFileExtension = "jpg"
-                imageData = jpgImageData
+            guard let jpgImageData = dstImage.jpegData(
+                compressionQuality: jpegCompressionQuality(imageUploadQuality: imageUploadQuality)
+            ) else {
+                attachment.error = .couldNotConvertImage
+                return attachment
             }
+
+            dataUTI = kUTTypeJPEG as String
+            dataMIMEType = OWSMimeTypeImageJpeg
+            dataFileExtension = "jpg"
+            imageData = jpgImageData
 
             guard let dataSource = DataSourceValue.dataSource(with: imageData, fileExtension: dataFileExtension) else {
                 attachment.error = .couldNotConvertImage

--- a/SignalMessaging/attachments/SignalAttachment.swift
+++ b/SignalMessaging/attachments/SignalAttachment.swift
@@ -759,7 +759,7 @@ public class SignalAttachment: NSObject {
                 dataSource.sourceFilename = baseFilename.appendingFileExtension("jpg")
             }
 
-            if isValidOutput {
+            if isValidOutput && dataUTI != "org.webmproject.webp" {
                 Logger.verbose("Rewriting attachment with metadata removed \(attachment.mimeType)")
                 return removeImageMetadata(attachment: attachment)
             } else {

--- a/SignalServiceKit/src/Util/NSData+Image.m
+++ b/SignalServiceKit/src/Util/NSData+Image.m
@@ -704,7 +704,7 @@ typedef struct {
 {
     if (imageFormat == ImageFormat_Webp) {
         CGSize imageSize = [self sizeForWebpData];
-        if (![NSData ows_isValidImageDimension:imageSize depthBytes:1 isAnimated:YES]) {
+        if (![NSData ows_isValidImageDimension:imageSize depthBytes:1 isAnimated:isAnimated]) {
             return ImageMetadata.invalid;
         }
         return [ImageMetadata validWithImageFormat:imageFormat pixelSize:imageSize hasAlpha:YES isAnimated:isAnimated];


### PR DESCRIPTION
Attempt to fix #4572 by just re-encoding static WebP images as JPEGs.  iOS 14 has native support for decoding WebP images now, so they have ended up in my camera roll, but it looks like it can't encode WebP images.  This becomes a problem when trying to strip the metadata from a WebP image, and  [CGImageDestinationCreateWithData](https://github.com/signalapp/Signal-iOS/blob/4c0ce6b9a7a3dab875d5edb2d12fc096a372b05a/SignalMessaging/attachments/SignalAttachment.swift#L992) fails. 

I see a few possible solutions to this: 
- Don't strip the metadata - It's not as terrible as it sounds, since WebP images are not likely to have been taken with the user's camera, and this is already what Signal does with animated images, including animated WebP images;
- Use a non-native encoder for WebP and new code to strip metadata for WebP images (maybe YYImage can be used to do this? It's already included); or
- Encode them as JPEGs, for which functionality already exists (this one-line change is what is included in this commit).

Please note that I've only been able to test this on the simulator, though.

So this includes two changes:

- Fix a bug where animated image size restrictions are applied to all WebP images.
- Send WebP Images re-encoded as JPEGs.

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [X] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [X] My commits are rebased on the latest master branch
- [X] My commits are in nice logical chunks
- [X] My contribution is fully baked and is ready to be merged as is
- [X] I have tested my contribution on these devices:
 * iPhone 11 Simulator, iOS 14.0