### PR TITLE
Check if it can be removed before moving a file upon sharing it

### DIFF
--- a/SignalServiceKit/src/Util/DataSource.m
+++ b/SignalServiceKit/src/Util/DataSource.m
@@ -487,12 +487,16 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wblock-capture-autoreleasing"
                                self.isConsumed = YES;
-                               if ([[NSFileManager defaultManager] isWritableFileAtPath:self.fileUrl.path]) {
+                               // We generally prefer moving the file when the file is writable (thus removable) because
+                               // it is faster. But we should not move a file when the file is not in our container.
+                               // So we check if the file's path is under our temporary directory instead of checking
+                               // if the file is writable to decide whether we are going to move the file or copy the file.
+                               if ([self.fileUrl.path hasPrefix:OWSTemporaryDirectory()]) {
                                    success = [NSFileManager.defaultManager moveItemAtURL:self.fileUrl
                                                                                    toURL:dstUrl
                                                                                    error:error];
                                } else {
-                                   OWSLogError(@"File was not writeable. Copying instead of moving.");
+                                   OWSLogInfo(@"File was not in our temporary directory or not writeable. Copying instead of moving.");
                                    success = [NSFileManager.defaultManager copyItemAtURL:self.fileUrl
                                                                                    toURL:dstUrl
                                                                                    error:error];


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 11, iOS 13.5
 * iPhone 12, iOS 14.2

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

When sharing files that are *not* images or movies, the app *moves* the file to a destination when it sends the file to the contact of the chat. It effectively removes the file from where it was before. It was originally reported in #4427 .

Note that after the PR was submitted, the commit [c799f663c807101111ebed0faf6ef06aa0dc1427] was made which effectively got rid of the problem described in the Github issue that was about a movie file. But the problem is still there for the files that are not encoded by Signal (thus to be copied in the temporary directory) even after the commit.

### Steps to verify the fix
1. Prepare a file that is not an image (bin or txt or something else)
1. Open Files app
1. Select the file prepared at the step 1
1. Share it to Signal
1. Choose a contact (or Note to Self) and send it
1. Go back to the Files app
1. You may still see the file there. Go back up one directory in the Files app
1. Come back to the original directory again

**Behavior before the fix**

The file is now gone.

**Behavior after the fix**

The file remains there.
