### PR TITLE
fix weird alpha issue with highlighted background color (UIColor.clear)

### DIFF
--- a/SignalMessaging/Views/OWSFlatButton.swift
+++ b/SignalMessaging/Views/OWSFlatButton.swift
@@ -173,7 +173,7 @@ public class OWSFlatButton: UIView {
     }
 
     @objc
-    public func setBackgroundColors(upColor: UIColor ) {
+    public func setBackgroundColors(upColor: UIColor) {
         let downColor = upColor == .clear ? upColor : upColor.withAlphaComponent(0.7)
         setBackgroundColors(upColor: upColor, downColor: downColor)
     }

--- a/SignalMessaging/Views/OWSFlatButton.swift
+++ b/SignalMessaging/Views/OWSFlatButton.swift
@@ -174,8 +174,8 @@ public class OWSFlatButton: UIView {
 
     @objc
     public func setBackgroundColors(upColor: UIColor ) {
-        setBackgroundColors(upColor: upColor,
-                            downColor: upColor.withAlphaComponent(0.7) )
+        let downColor = upColor == .clear ? upColor : upColor.withAlphaComponent(0.7)
+        setBackgroundColors(upColor: upColor, downColor: downColor)
     }
 
     @objc


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 6, iOS 12.4.8

- - - - - - - - - -

### Description
As stated in [documentation](https://developer.apple.com/documentation/uikit/uicolor/1621945-clear)

> UIColor.clear : A color object with grayscale and alpha values that are both 0.0.

`setBackgroundColors(upColor: UIColor )` also sets the `downColor` which is used for button's `highlighted` color with `upColor.withAlphaComponent(0.7)`.

The problem is if we set `upColor` as `UIColor.clear`,  `downColor` will be darker and cause an unexpected view.

Here is example flow of touching button.

Before            |  TouchUp
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/16730661/104180938-03d5e180-541f-11eb-8140-516d94f12a9c.png) |  ![](https://user-images.githubusercontent.com/16730661/104180983-13edc100-541f-11eb-97e3-6c56ecac39a4.png)


