### PR TITLE
shouldAllowLinkification now uses caseInsensitive regex when looking …

### DIFF
--- a/Signal/test/util/DisplayableTextFilterTest.swift
+++ b/Signal/test/util/DisplayableTextFilterTest.swift
@@ -124,6 +124,10 @@ class DisplayableTextTest: SignalBaseTest {
         assertNotLinkifies("foo http://asĸ.com")
         assertNotLinkifies("http://asĸ.com")
         assertNotLinkifies("asĸ.com")
+        assertLinkifies("Https://ask.com")
+        assertLinkifies("HTTP://ask.com")
+        assertLinkifies("HttPs://ask.com")
+
 
         // Mixed latin and cyrillic text, but it's not a link
         // (nothing to linkify, but there's nothing illegal here)
@@ -151,6 +155,7 @@ class DisplayableTextTest: SignalBaseTest {
         assertNotLinkifies("asĸ.com")
         assertNotLinkifies("https://кц.cфm")
         assertNotLinkifies("https://google.cфm")
+        assertNotLinkifies("Https://google.cфm")
 
         assertLinkifies("кц.рф")
         assertLinkifies("кц.рф/some/path")

--- a/SignalMessaging/utils/DisplayableText.swift
+++ b/SignalMessaging/utils/DisplayableText.swift
@@ -180,7 +180,7 @@ public class DisplayableText: NSObject {
 
     private static let hostRegex: NSRegularExpression? = {
         let pattern = "^(?:https?:\\/\\/)?([^:\\/\\s]+)(.*)?$"
-        return try? NSRegularExpression(pattern: pattern)
+        return try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive])
     }()
 
     @objc


### PR DESCRIPTION
…for host

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [X] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 12- Simulator, iOS 14.3


- - - - - - - - - -

### Description
The `shouldAllowLinkification` checker was returning a false positive for a URL containing a mix of ascii and non-ascii characters. The issue was caused by the regex failing to detect uppercase charaters in the URL. 

I resolved the issue by making the regex match letters in the pattern independent of case.

I tested the resolution by adding positive and negative test cases.
