### PR TITLE
GitHub Issue config: sync changes from Signal-Android

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,20 +1,20 @@
 blank_issues_enabled: false
 contact_links:
-  - name: 📃 User documentation
+  - name: 📃 Support Center
     url: https://support.signal.org/
-    about: Search for any questions you have about Signal
-  - name: 📖 Developer documentation
-    url: https://signal.org/docs/
-    about: Official Signal developer documentation
-  - name: 💬 Community support
-    url: https://community.signalusers.org/c/support/ios-support/
-    about: Feel free to ask anything
+    about: Find answers to many common questions.
   - name: ✨ Feature request
     url: https://community.signalusers.org/c/feature-requests/ios-feature-requests/
     about: Missing something in Signal? Let us know.
-  - name: 📚 Translation feedback
+  - name: 💬 Community support
+    url: https://community.signalusers.org/c/support/
+    about: Feel free to ask anything.
+  - name: 📖 Developer documentation
+    url: https://signal.org/docs/
+    about: Official Signal developer documentation.
+  - name: 📚 Translation feedback.
     url: https://community.signalusers.org/c/translation-feedback/
-    about: Share feedback on translations
+    about: Share feedback on translations.
   - name: ❓ Other issue?
     url: https://community.signalusers.org/
-    about: Search on the community forums
+    about: Search on the community forums.


### PR DESCRIPTION
This issue template got merged into Signal-Android with a few small changes (see https://github.com/signalapp/Signal-Android/commit/c0c8d2caa7777c8ad7664808619424078bdab310), so this commit brings those changes over to the Signal-iOS repo.

Only affects GitHub, no functional code changes. Succeeds #4743.

**Old lay-out:**
![Screenshot_595](https://user-images.githubusercontent.com/15776622/104820493-34f64d80-5835-11eb-804d-ee950d10dacb.png)

**New lay-out:**
![Screenshot_596](https://user-images.githubusercontent.com/15776622/104820495-36c01100-5835-11eb-843c-082d94292936.png)