### PR TITLE
Fix to a crash bug when tapping on a cell in iOS 14

### DIFF
--- a/Signal/src/ViewControllers/Attachment Keyboard/RecentPhotoCollectionView.swift
+++ b/Signal/src/ViewControllers/Attachment Keyboard/RecentPhotoCollectionView.swift
@@ -118,6 +118,7 @@ extension RecentPhotosCollectionView: UICollectionViewDelegate {
         guard fetchingAttachmentIndex == nil else { return }
         fetchingAttachmentIndex = indexPath
 
+        guard collectionContents.assetCount > indexPath.item else { return }
         let asset = collectionContents.asset(at: indexPath.item)
         collectionContents.outgoingAttachment(
             for: asset,


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 12 Pro Max, iOS 14.2

- - - - - - - - - -

### Description
App crashes at in v5.2.0.4 (and before) when you tap on the last cell that says "Not seeing your photos?" in iOS 14. The crash is basically due to out of range access to an array.

The PR adds a line that checks if the content is there in the array before accessing it.

Fixes #4642; Fixes #4755
