### PR TITLE
Add missing accessibility labels Share extension

### DIFF
--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -3898,6 +3898,9 @@
 /* No comment provided by engineer. */
 "RELAY_REGISTERED_ERROR_RECOVERY" = "The phone number you are trying to register has already been registered on another server, please unregister from there and try again.";
 
+/* Accessibility label for the 'x' button that removes a preview from a drafted message. */
+"REMOVE_PREVIEW" = "Remove preview";
+
 /* The title for the 'replace group admin' view. */
 "REPLACE_ADMIN_VIEW_TITLE" = "Choose New Admin";
 

--- a/SignalMessaging/ViewControllers/ApprovalFooterView.swift
+++ b/SignalMessaging/ViewControllers/ApprovalFooterView.swift
@@ -127,9 +127,9 @@ public class ApprovalFooterView: UIView {
     }()
 
     lazy var proceedButton: OWSButton = {
-		let button = OWSButton.sendButton(
-			imageName: self.approvalMode.proceedButtonImageName
-		) { [weak self] in
+        let button = OWSButton.sendButton(
+            imageName: self.approvalMode.proceedButtonImageName
+        ) { [weak self] in
             guard let self = self else { return }
             self.delegate?.approvalFooterDelegateDidRequestProceed(self)
         }
@@ -138,25 +138,25 @@ public class ApprovalFooterView: UIView {
     }()
 
     private func updateContents() {
-		proceedButton.setImage(imageName: approvalMode.proceedButtonImageName)
-		proceedButton.accessibilityLabel = approvalMode.proceedButtonAccessibilityLabel
+        proceedButton.setImage(imageName: approvalMode.proceedButtonImageName)
+        proceedButton.accessibilityLabel = approvalMode.proceedButtonAccessibilityLabel
     }
 }
 
 fileprivate extension ApprovalMode {
-	var proceedButtonAccessibilityLabel: String {
-		switch self {
-		case .next: return CommonStrings.nextButton
-		case .send: return MessageStrings.sendButton
-		}
-	}
+    var proceedButtonAccessibilityLabel: String {
+        switch self {
+        case .next: return CommonStrings.nextButton
+        case .send: return MessageStrings.sendButton
+        }
+    }
 
-	var proceedButtonImageName: String {
-		switch self {
-		case .next:
-			return "arrow-right-24"
-		case .send:
-			return "send-solid-24"
-		}
-	}
+    var proceedButtonImageName: String {
+        switch self {
+        case .next:
+            return "arrow-right-24"
+        case .send:
+            return "send-solid-24"
+        }
+    }
 }

--- a/SignalMessaging/ViewControllers/ApprovalFooterView.swift
+++ b/SignalMessaging/ViewControllers/ApprovalFooterView.swift
@@ -127,7 +127,9 @@ public class ApprovalFooterView: UIView {
     }()
 
     lazy var proceedButton: OWSButton = {
-        let button = OWSButton.sendButton(imageName: proceedImageName) { [weak self] in
+		let button = OWSButton.sendButton(
+			imageName: self.approvalMode.proceedButtonImageName
+		) { [weak self] in
             guard let self = self else { return }
             self.delegate?.approvalFooterDelegateDidRequestProceed(self)
         }
@@ -135,11 +137,26 @@ public class ApprovalFooterView: UIView {
         return button
     }()
 
-    private var proceedImageName: String {
-        return approvalMode == .send ? "send-solid-24" : "arrow-right-24"
-    }
-
     private func updateContents() {
-        proceedButton.setImage(imageName: proceedImageName)
+		proceedButton.setImage(imageName: approvalMode.proceedButtonImageName)
+		proceedButton.accessibilityLabel = approvalMode.proceedButtonAccessibilityLabel
     }
+}
+
+fileprivate extension ApprovalMode {
+	var proceedButtonAccessibilityLabel: String {
+		switch self {
+		case .next: return CommonStrings.nextButton
+		case .send: return MessageStrings.sendButton
+		}
+	}
+
+	var proceedButtonImageName: String {
+		switch self {
+		case .next:
+			return "arrow-right-24"
+		case .send:
+			return "send-solid-24"
+		}
+	}
 }

--- a/SignalMessaging/Views/CommonStrings.swift
+++ b/SignalMessaging/Views/CommonStrings.swift
@@ -157,6 +157,9 @@ public class MessageStrings: NSObject {
 
     @objc
     static public let viewOnceViewVideo = NSLocalizedString("PER_MESSAGE_EXPIRATION_VIEW_VIDEO", comment: "Label for view-once messages indicating that user can tap to view the message's contents.")
+
+	@objc
+	static public let removePreviewButtonLabel = NSLocalizedString("REMOVE_PREVIEW", comment: "Accessibility label for a button that removes the preview from a drafted message.")
 }
 
 @objc

--- a/SignalMessaging/Views/CommonStrings.swift
+++ b/SignalMessaging/Views/CommonStrings.swift
@@ -158,8 +158,8 @@ public class MessageStrings: NSObject {
     @objc
     static public let viewOnceViewVideo = NSLocalizedString("PER_MESSAGE_EXPIRATION_VIEW_VIDEO", comment: "Label for view-once messages indicating that user can tap to view the message's contents.")
 
-	@objc
-	static public let removePreviewButtonLabel = NSLocalizedString("REMOVE_PREVIEW", comment: "Accessibility label for a button that removes the preview from a drafted message.")
+    @objc
+    static public let removePreviewButtonLabel = NSLocalizedString("REMOVE_PREVIEW", comment: "Accessibility label for a button that removes the preview from a drafted message.")
 }
 
 @objc

--- a/SignalMessaging/Views/Link Preview/LinkPreviewView.swift
+++ b/SignalMessaging/Views/Link Preview/LinkPreviewView.swift
@@ -984,7 +984,7 @@ public class LinkPreviewView: UIStackView {
         let cancelImage = UIImage(named: "compose-cancel")?.withRenderingMode(.alwaysTemplate)
         let cancelButton = UIButton(type: .custom)
         cancelButton.setImage(cancelImage, for: .normal)
-		cancelButton.accessibilityLabel = MessageStrings.removePreviewButtonLabel
+        cancelButton.accessibilityLabel = MessageStrings.removePreviewButtonLabel
         cancelButton.addTarget(self, action: #selector(didTapCancel(sender:)), for: .touchUpInside)
         self.cancelButton = cancelButton
         cancelButton.tintColor = Theme.secondaryTextAndIconColor

--- a/SignalMessaging/Views/Link Preview/LinkPreviewView.swift
+++ b/SignalMessaging/Views/Link Preview/LinkPreviewView.swift
@@ -984,6 +984,7 @@ public class LinkPreviewView: UIStackView {
         let cancelImage = UIImage(named: "compose-cancel")?.withRenderingMode(.alwaysTemplate)
         let cancelButton = UIButton(type: .custom)
         cancelButton.setImage(cancelImage, for: .normal)
+		cancelButton.accessibilityLabel = MessageStrings.removePreviewButtonLabel
         cancelButton.addTarget(self, action: #selector(didTapCancel(sender:)), for: .touchUpInside)
         self.cancelButton = cancelButton
         cancelButton.tintColor = Theme.secondaryTextAndIconColor


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 8 Simulator, iOS 14.2

- - - - - - - - - -

### Description

The icon-based buttons in the Share extension were missing accessibility labels in three places. I used the existing "Send" and "Next" ones where appropriate, and added a third "Remove Preview" string to the button that removes a preview from a shared URL.

Closes https://github.com/signalapp/Signal-iOS/issues/4801

Test Plan:
1. Open the Share extension, and check out the VoiceOver labels on the buttons (see screenshot here).

<img width="957" alt="screenshot of changes" src="https://user-images.githubusercontent.com/868389/105291923-98ea8000-5b6d-11eb-9997-6cb57d950850.png">
