### PR TITLE
Added a toggle to hide avatars in group chats

### DIFF
--- a/Signal/src/ViewControllers/AppSettings/AppearanceSettingsTableViewController.swift
+++ b/Signal/src/ViewControllers/AppSettings/AppearanceSettingsTableViewController.swift
@@ -53,6 +53,27 @@ class AppearanceSettingsTableViewController: OWSTableViewController {
         )
 
         contents.addSection(contactSection)
+        
+        let avaterSection = OWSTableSection()
+        avaterSection.customHeaderHeight = 14
+        avaterSection.footerTitle = NSLocalizedString(
+            "SETTINGS_APPEARANCE_GROUP_AVATARS_FOOTER",
+            comment: "Footer for group chat avatar section in appearance settings")
+
+        avaterSection.add(
+            OWSTableItem.switch(
+                withText: NSLocalizedString(
+                    "SETTINGS_APPEARANCE_GROUP_AVATARS_PREFERENCE_LABEL",
+                    comment: "Title for switch to toggle preference of whether to show profile pictures in group chat"),
+                isOn: {
+                    SDSDatabaseStorage.shared.read { SSKPreferences.hideGroupChatAvatars(transaction: $0) }
+                },
+                target: self,
+                selector: #selector(didToggleGroupAvatarsPreference(_:))
+            )
+        )
+
+        contents.addSection(avaterSection)
 
         // TODO iOS 13 – maybe expose the preferred language settings here to match android
         // It not longer seems to exist in iOS 13.1 so not sure if Apple got rid of it
@@ -96,5 +117,15 @@ class AppearanceSettingsTableViewController: OWSTableViewController {
         SDSDatabaseStorage.shared.asyncWrite { writeTx in
             SSKPreferences.setPreferContactAvatars(sender.isOn, transaction: writeTx)
         }
+
     }
+    
+    @objc func didToggleGroupAvatarsPreference(_ sender: UISwitch) {
+        Logger.info("Group Avatar preference toggled: \(sender.isOn)")
+        SDSDatabaseStorage.shared.asyncWrite { writeTx in
+            SSKPreferences.setHideGroupChatAvatars(sender.isOn, transaction: writeTx)
+        }
+    }
+    
+    
 }

--- a/Signal/src/ViewControllers/ConversationView/CV/CVComponents/CVComponentMessage.swift
+++ b/Signal/src/ViewControllers/ConversationView/CV/CVComponents/CVComponentMessage.swift
@@ -40,9 +40,10 @@ public class CVComponentMessage: CVComponentBase, CVRootComponent {
 
     private var senderAvatar: CVComponentState.SenderAvatar?
     private var hasSenderAvatarLayout: Bool {
+
         // Return true if space for a sender avatar appears in the layout.
         // Avatar itself might not appear due to de-duplication.
-        isIncoming && isGroupThread && senderAvatar != nil
+        isIncoming && isGroupThread && senderAvatar != nil && !shouldHideSenderAvaters
     }
     private var hasSenderAvatar: Bool {
         // Return true if a sender avatar appears.
@@ -75,6 +76,8 @@ public class CVComponentMessage: CVComponentBase, CVRootComponent {
     private var swipeToReplyReference: CVSwipeToReplyState.Reference?
 
     private var hasSendFailureBadge = false
+    
+    private var shouldHideSenderAvaters = false;
 
     override init(itemModel: CVItemModel) {
         super.init(itemModel: itemModel)
@@ -194,7 +197,12 @@ public class CVComponentMessage: CVComponentBase, CVRootComponent {
     }
 
     private func buildComponentStates() {
-
+        if isGroupThread {
+            SDSDatabaseStorage.shared.asyncRead { readTx in
+                self.shouldHideSenderAvaters = SSKPreferences.hideGroupChatAvatars(transaction: readTx)
+            }
+        }
+        
         hasSendFailureBadge = componentState.sendFailureBadge != nil
 
         if let senderName = itemViewState.senderName {

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -4309,6 +4309,12 @@
 /* Title for switch to toggle preference between contact and profile avatars */
 "SETTINGS_APPEARANCE_AVATAR_PREFERENCE_LABEL" = "Use system contact photos";
 
+/* Footer for group chat avatar section in appearance settings */
+"SETTINGS_APPEARANCE_GROUP_AVATARS_FOOTER" = "Should senders avatars be hidden in group chats";
+
+/* Title for switch to toggle preference of whether to show profile pictures in group chat */
+"SETTINGS_APPEARANCE_GROUP_AVATARS_PREFERENCE_LABEL" = "Hide Avaters in Group Chat";
+
 /* The title for the theme section in the appearance settings. */
 "SETTINGS_APPEARANCE_THEME_TITLE" = "Theme";
 

--- a/SignalMessaging/Storage Service/StorageServiceProto+Sync.swift
+++ b/SignalMessaging/Storage Service/StorageServiceProto+Sync.swift
@@ -650,7 +650,10 @@ extension StorageServiceProtoAccountRecord {
 
         let preferContactAvatars = SSKPreferences.preferContactAvatars(transaction: transaction)
         builder.setPreferContactAvatars(preferContactAvatars)
-
+        
+        let hideGroupChatAvatars = SSKPreferences.hideGroupChatAvatars(transaction: transaction)
+        builder.setHideGroupChatAvatars(preferContactAvatars)
+        
         if let unknownFields = unknownFields {
             builder.setUnknownFields(unknownFields)
         }
@@ -784,7 +787,17 @@ extension StorageServiceProtoAccountRecord {
                 updateStorageService: false,
                 transaction: transaction)
         }
+        
+        let localHideGroupChatAvatars = SSKPreferences.hideGroupChatAvatars(transaction: transaction)
+        if hideGroupChatAvatars != localHideGroupChatAvatars {
+            SSKPreferences.setHideGroupChatAvatars(
+                hideGroupChatAvatars,
+                updateStorageService: false,
+                transaction: transaction)
+        }
 
+        
+        
         return mergeState
     }
 }

--- a/SignalServiceKit/src/Protos/Generated/StorageService.pb.swift
+++ b/SignalServiceKit/src/Protos/Generated/StorageService.pb.swift
@@ -404,6 +404,8 @@ struct StorageServiceProtos_AccountRecord {
   var pinnedConversations: [StorageServiceProtos_AccountRecord.PinnedConversation] = []
 
   var preferContactAvatars: Bool = false
+  
+  var hideGroupChatAvatars: Bool = false
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -1077,7 +1079,8 @@ extension StorageServiceProtos_AccountRecord: SwiftProtobuf.Message, SwiftProtob
     12: .same(proto: "phoneNumberSharingMode"),
     13: .same(proto: "notDiscoverableByPhoneNumber"),
     14: .same(proto: "pinnedConversations"),
-    15: .same(proto: "preferContactAvatars")
+    15: .same(proto: "preferContactAvatars"),
+    16: .same(proto: "hideGroupChatAvatars")
   ]
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -1098,6 +1101,7 @@ extension StorageServiceProtos_AccountRecord: SwiftProtobuf.Message, SwiftProtob
       case 13: try decoder.decodeSingularBoolField(value: &self.notDiscoverableByPhoneNumber)
       case 14: try decoder.decodeRepeatedMessageField(value: &self.pinnedConversations)
       case 15: try decoder.decodeSingularBoolField(value: &self.preferContactAvatars)
+      case 16: try decoder.decodeSingularBoolField(value: &self.hideGroupChatAvatars)
       default: break
       }
     }
@@ -1149,6 +1153,9 @@ extension StorageServiceProtos_AccountRecord: SwiftProtobuf.Message, SwiftProtob
     if self.preferContactAvatars != false {
       try visitor.visitSingularBoolField(value: self.preferContactAvatars, fieldNumber: 15)
     }
+    if self.hideGroupChatAvatars != false {
+      try visitor.visitSingularBoolField(value: self.hideGroupChatAvatars, fieldNumber: 16)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -1168,6 +1175,7 @@ extension StorageServiceProtos_AccountRecord: SwiftProtobuf.Message, SwiftProtob
     if lhs.notDiscoverableByPhoneNumber != rhs.notDiscoverableByPhoneNumber {return false}
     if lhs.pinnedConversations != rhs.pinnedConversations {return false}
     if lhs.preferContactAvatars != rhs.preferContactAvatars {return false}
+    if lhs.hideGroupChatAvatars != rhs.hideGroupChatAvatars {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/SignalServiceKit/src/Protos/Generated/StorageServiceProto.swift
+++ b/SignalServiceKit/src/Protos/Generated/StorageServiceProto.swift
@@ -2367,6 +2367,11 @@ public struct StorageServiceProtoAccountRecord: Codable, CustomDebugStringConver
         if hasPreferContactAvatars {
             builder.setPreferContactAvatars(preferContactAvatars)
         }
+
+        if hasHideGroupChatAvatars {
+            builder.setHideGroupChatAvatars(hideGroupChatAvatars)
+        }
+
         if let _value = unknownFields {
             builder.setUnknownFields(_value)
         }
@@ -2467,6 +2472,10 @@ public struct StorageServiceProtoAccountRecord: Codable, CustomDebugStringConver
             proto.preferContactAvatars = valueParam
         }
 
+        public mutating func setHideGroupChatAvatars(_ valueParam: Bool) {
+            proto.hideGroupChatAvatars = valueParam
+        }
+        
         public mutating func setUnknownFields(_ unknownFields: SwiftProtobuf.UnknownStorage) {
             proto.unknownFields = unknownFields
         }
@@ -2602,6 +2611,13 @@ public struct StorageServiceProtoAccountRecord: Codable, CustomDebugStringConver
         return proto.preferContactAvatars
     }
     public var hasPreferContactAvatars: Bool {
+        return true
+    }
+
+    public var hideGroupChatAvatars: Bool {
+        return proto.hideGroupChatAvatars
+    }
+    public var hasHideGroupChatAvatars: Bool {
         return true
     }
 

--- a/SignalServiceKit/src/Util/SSKPreferences.swift
+++ b/SignalServiceKit/src/Util/SSKPreferences.swift
@@ -194,6 +194,39 @@ public class SSKPreferences: NSObject {
             NotificationCenter.default.postNotificationNameAsync(Self.preferContactAvatarsPreferenceDidChange, object: nil)
         }
     }
+    
+    // MARK: - Group chat avatars preference
+
+    @objc
+    public static let hideGroupChatAvatarsPreferenceDidChange = Notification.Name("HideGroupChatAvatarsPreferenceDidChange")
+    private static let hideGroupChatAvatarsKey = "hideGroupChatAvatarsKey"
+    private static var hideGroupChatAvatarsCached: Bool?
+
+    @objc
+    public static func hideGroupChatAvatars(transaction: SDSAnyReadTransaction) -> Bool {
+        if let value = hideGroupChatAvatarsCached { return value }
+        let value = store.getBool(hideGroupChatAvatarsKey, defaultValue: false, transaction: transaction)
+        hideGroupChatAvatarsCached = value
+        return value
+    }
+
+    @objc
+    public static func setHideGroupChatAvatars(
+        _ value: Bool,
+        updateStorageService: Bool = true,
+        transaction: SDSAnyWriteTransaction) {
+
+        let oldValue = store.getBool(hideGroupChatAvatarsKey, transaction: transaction)
+        store.setBool(value, key: hideGroupChatAvatarsKey, transaction: transaction)
+        hideGroupChatAvatarsCached = value
+
+        if oldValue != value {
+            if updateStorageService {
+                SSKEnvironment.shared.storageServiceManager.recordPendingLocalAccountUpdates()
+            }
+            NotificationCenter.default.postNotificationNameAsync(Self.hideGroupChatAvatarsPreferenceDidChange, object: nil)
+        }
+    }
 
     // MARK: -
 


### PR DESCRIPTION
The prefences code is based on how I saw that the "preferContactAvatars" feature was implemented.

The functionallity changes are made in CVComponentMessage.swift

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x ] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x ] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ ] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions) - **This link is broken...**
- [ ] My commits are rebased on the latest master branch
- [ x] My commits are in nice logical chunks
- [x ] My contribution is fully baked and is ready to be merged as is
- [x ] I have tested my contribution on these devices:
 * iPhone 11, iOS 14.3

- - - - - - - - - -

### Description
**TL;DR - Added a toggle in Appearance settings that prevents profile pictures from being displayed in group chat.**

Background:
I've recently joined Signal as most of my friends decided that it is time to move on from WhatsApp. While the app has been great for me, I found that I had many UI annoyances that prevented me from completely making the switch. I've asked around and many of my friends agreed. After a few talks, I've decided to make use of the fact that Signal is an open source application and set out to add the features that would make me enjoy the UI and would allow me to make the switch.

This is the first of those. I don't like the UI experience of having a lot of small images cluttering my group chats, and so in this PR I've added the ability to hide the sender's avatar in group chat messages.

Technical:
Most of the changes were made in order to add the storage support for this setting. I don't know if there's an easier way to do so, but I just went ahead and replicated the code for the other toggle in the appearance pane (preferContactAvatars). The actual code for hiding the avatars is rather small and is based in CVComponentMessage.swift.

I'm here for any comments, and waiting to hear from you :)
