### PR TITLE
Fix bug when build is failing if project path contains whitespaces

### DIFF
--- a/Scripts/update_plist_info.sh
+++ b/Scripts/update_plist_info.sh
@@ -9,9 +9,9 @@ if [ "${PROJECT_DIR}" = "" ]; then
 fi
 
 # Capture hash & comment from last WebRTC git commit.
-cd $PROJECT_DIR/ThirdParty/WebRTC/
+cd "${PROJECT_DIR}"/ThirdParty/WebRTC/
 _git_commit=`git log --pretty=oneline | head -1`
-cd $PROJECT_DIR
+cd "${PROJECT_DIR}"
 
 # Remove existing .plist entry, if any.
 /usr/libexec/PlistBuddy -c "Delete BuildDetails" Signal/Signal-Info.plist || true


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iOS Simulator, iPhone 12 mini, iOS 14.3

- - - - - - - - - -

### Description
This small PR fixes issue #4822 when Xcode build fails if project path contains whitespaces.
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->
