### PR TITLE
Add selection accessibility trait for selected message

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/CV/CVComponents/CVComponentMessage.swift
+++ b/Signal/src/ViewControllers/ConversationView/CV/CVComponents/CVComponentMessage.swift
@@ -312,6 +312,7 @@ public class CVComponentMessage: CVComponentBase, CVRootComponent {
             let selectionView = componentView.selectionView
             selectionView.isSelected = componentDelegate.cvc_isMessageSelected(interaction)
             cellView.addSubview(selectionView)
+            rootView.accessibilityTraits = buildAccessibilityTraits(componentView: componentView)
             selectionView.autoPinEdges(toSuperviewMarginsExcludingEdge: .trailing)
             leadingView = selectionView
         }
@@ -641,6 +642,17 @@ public class CVComponentMessage: CVComponentBase, CVRootComponent {
 
         componentView.rootView.accessibilityLabel = buildAccessibilityLabel(componentView: componentView)
         componentView.rootView.isAccessibilityElement = true
+        componentView.rootView.accessibilityTraits = buildAccessibilityTraits(componentView: componentView)
+    }
+    
+    private func buildAccessibilityTraits(componentView: CVComponentViewMessage) -> UIAccessibilityTraits {
+        var accessibilityTraits = componentView.accessibilityTraits
+        if componentView.selectionView.isSelected {
+            accessibilityTraits.insert(.selected)
+        } else {
+            accessibilityTraits.remove(.selected)
+        }
+        return accessibilityTraits
     }
 
     // Builds an accessibility label for the entire message.
@@ -927,6 +939,7 @@ public class CVComponentMessage: CVComponentBase, CVRootComponent {
                 componentDelegate.cvc_didSelectViewItem(itemViewModel)
             }
             // Suppress other tap handling during selection mode.
+            componentView.rootView.accessibilityTraits = buildAccessibilityTraits(componentView: componentView)
             return true
         }
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 iOS Simulator with using accessibility inspector

- - - - - - - - - -

### Description
Addresses issue #4809. 

- Builds accessibility traits based message selection status
- This enables VoiceOver users to know which messages are selected
