### PR TITLE
Disable idle timer when PhotoCaptureViewController is visible

### DIFF
--- a/Signal/src/ViewControllers/Photos/PhotoCaptureViewController.swift
+++ b/Signal/src/ViewControllers/Photos/PhotoCaptureViewController.swift
@@ -147,12 +147,14 @@ class PhotoCaptureViewController: OWSViewController, InteractiveDismissDelegate 
             BenchEventComplete(eventId: "Show-Camera")
             VolumeButtons.shared?.addObserver(observer: photoCapture)
         }
+        UIApplication.shared.isIdleTimerDisabled = true
     }
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillAppear(animated)
         isVisible = false
         VolumeButtons.shared?.removeObserver(photoCapture)
+        UIApplication.shared.isIdleTimerDisabled = false
     }
 
     override var prefersStatusBarHidden: Bool {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [ ] I have tested my contribution on these devices:

- - - - - - - - - -

### Description
Opening the capture view controller does not disable the system's idle timer, even while capturing a video (when locking the record button and not touching the screen any more). To make matters worse, video capture breaks once the screen locks automatically due to the idle timer. The resulting video file is unplayable! I propose to generally disable the idle timer on the video capture view controller – not only does this prevent the screen from locking during capture, but it also prevents the screen from dimming/locking while waiting to start capture, which might also be desirable while waiting for the right moment to take a pic.