### PR TITLE
Security Enhancement: Enable Certificate Transparency in Signal iOS app (RFC6962)

### DIFF
--- a/NotificationServiceExtension/Info.plist
+++ b/NotificationServiceExtension/Info.plist
@@ -37,16 +37,12 @@
 				<true/>
 				<key>NSIncludesSubdomains</key>
 				<true/>
-				<key>NSRequiresCertificateTransparency</key>
-				<true/>
 			</dict>
 			<key>whispersystems.org</key>
 			<dict>
 				<key>NSExceptionAllowsInsecureHTTPLoads</key>
 				<true/>
 				<key>NSIncludesSubdomains</key>
-				<true/>
-				<key>NSRequiresCertificateTransparency</key>
 				<true/>
 			</dict>
 			<key>signalcaptchas.org</key>

--- a/NotificationServiceExtension/Info.plist
+++ b/NotificationServiceExtension/Info.plist
@@ -37,12 +37,23 @@
 				<true/>
 				<key>NSIncludesSubdomains</key>
 				<true/>
+				<key>NSRequiresCertificateTransparency</key>
+				<true/>
 			</dict>
 			<key>whispersystems.org</key>
 			<dict>
 				<key>NSExceptionAllowsInsecureHTTPLoads</key>
 				<true/>
 				<key>NSIncludesSubdomains</key>
+				<true/>
+				<key>NSRequiresCertificateTransparency</key>
+				<true/>
+			</dict>
+			<key>signalcaptchas.org</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+				<key>NSRequiresCertificateTransparency</key>
 				<true/>
 			</dict>
 		</dict>

--- a/Signal/Signal-Info.plist
+++ b/Signal/Signal-Info.plist
@@ -105,12 +105,23 @@
 				<true/>
 				<key>NSIncludesSubdomains</key>
 				<true/>
+				<key>NSRequiresCertificateTransparency</key>
+				<true/>
 			</dict>
 			<key>whispersystems.org</key>
 			<dict>
 				<key>NSExceptionAllowsInsecureHTTPLoads</key>
 				<true/>
 				<key>NSIncludesSubdomains</key>
+				<true/>
+				<key>NSRequiresCertificateTransparency</key>
+				<true/>
+			</dict>
+			<key>signalcaptchas.org</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+				<key>NSRequiresCertificateTransparency</key>
 				<true/>
 			</dict>
 		</dict>

--- a/Signal/Signal-Info.plist
+++ b/Signal/Signal-Info.plist
@@ -105,16 +105,12 @@
 				<true/>
 				<key>NSIncludesSubdomains</key>
 				<true/>
-				<key>NSRequiresCertificateTransparency</key>
-				<true/>
 			</dict>
 			<key>whispersystems.org</key>
 			<dict>
 				<key>NSExceptionAllowsInsecureHTTPLoads</key>
 				<true/>
 				<key>NSIncludesSubdomains</key>
-				<true/>
-				<key>NSRequiresCertificateTransparency</key>
 				<true/>
 			</dict>
 			<key>signalcaptchas.org</key>

--- a/SignalShareExtension/Info.plist
+++ b/SignalShareExtension/Info.plist
@@ -39,16 +39,12 @@
 				<true/>
 				<key>NSIncludesSubdomains</key>
 				<true/>
-				<key>NSRequiresCertificateTransparency</key>
-				<true/>
 			</dict>
 			<key>whispersystems.org</key>
 			<dict>
 				<key>NSExceptionAllowsInsecureHTTPLoads</key>
 				<true/>
 				<key>NSIncludesSubdomains</key>
-				<true/>
-				<key>NSRequiresCertificateTransparency</key>
 				<true/>
 			</dict>
 			<key>signalcaptchas.org</key>

--- a/SignalShareExtension/Info.plist
+++ b/SignalShareExtension/Info.plist
@@ -39,12 +39,23 @@
 				<true/>
 				<key>NSIncludesSubdomains</key>
 				<true/>
+				<key>NSRequiresCertificateTransparency</key>
+				<true/>
 			</dict>
 			<key>whispersystems.org</key>
 			<dict>
 				<key>NSExceptionAllowsInsecureHTTPLoads</key>
 				<true/>
 				<key>NSIncludesSubdomains</key>
+				<true/>
+				<key>NSRequiresCertificateTransparency</key>
+				<true/>
+			</dict>
+			<key>signalcaptchas.org</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+				<key>NSRequiresCertificateTransparency</key>
 				<true/>
 			</dict>
 		</dict>


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * Simulator iOS 14.4

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

Certificate Transparency (CT) is a protocol that iOS App Transport Security can use to identify mistakenly or maliciously issued X.509 certificates. Set the value for the NSRequiresCertificateTransparency key to YES to require that for a given domain, server certificates are supported by valid, signed CT timestamps from at least two CT logs trusted by Apple. **Unlike most other ATS exceptions, using a non-default value in this case tightens security requirements.**

Reference: https://developer.apple.com/documentation/bundleresources/information_property_list/nsrequirescertificatetransparency

In addition to this, it will be great if signal maintainers can setup CT log alerts for signal domains like 
`signal.org` , `signalcaptchas.org` and `whispersystems.org`.