### PR TITLE
Add "Mute" notification action

### DIFF
--- a/Signal/src/UserNotificationActionHandler.swift
+++ b/Signal/src/UserNotificationActionHandler.swift
@@ -60,6 +60,8 @@ public class UserNotificationActionHandler: NSObject {
             return try actionHandler.declineCall(userInfo: userInfo)
         case .markAsRead:
             return try actionHandler.markAsRead(userInfo: userInfo)
+        case .mute:
+            return try actionHandler.mute(userInfo: userInfo)
         case .reply:
             guard let textInputResponse = response as? UNTextInputNotificationResponse else {
                 throw OWSAssertionError("response had unexpected type: \(response)")

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -4031,6 +4031,9 @@
 "PUSH_MANAGER_REACT_WITH_THUMBS_UP" = "👍";
 
 /* Notification action button title */
+"PUSH_MANAGER_MUTE" = "Mute";
+
+/* Notification action button title */
 "PUSH_MANAGER_REPLY" = "Reply";
 
 /* Title of alert shown when push tokens sync job succeeds. */

--- a/SignalMessaging/Notifications/AppNotifications.swift
+++ b/SignalMessaging/Notifications/AppNotifications.swift
@@ -41,6 +41,7 @@ public enum AppNotificationAction: String, CaseIterable {
     case callBack
     case declineCall
     case markAsRead
+    case mute
     case reply
     case showThread
     case reactWithThumbsUp
@@ -93,16 +94,16 @@ extension AppNotificationCategory {
         switch self {
         case .incomingMessageWithActions_CanReply:
             if DebugFlags.reactWithThumbsUpFromLockscreen {
-                return [.markAsRead, .reply, .reactWithThumbsUp]
+                return [.markAsRead, .mute, .reply, .reactWithThumbsUp]
             } else {
-                return [.markAsRead, .reply]
+                return [.markAsRead, .mute, .reply]
             }
         case .incomingMessageWithActions_CannotReply:
-            return [.markAsRead]
+            return [.markAsRead, .mute]
         case .incomingReactionWithActions_CanReply:
-            return [.markAsRead, .reply]
+            return [.markAsRead, .mute, .reply]
         case .incomingReactionWithActions_CannotReply:
-            return [.markAsRead]
+            return [.markAsRead, .mute]
         case .incomingMessageWithoutActions,
              .incomingMessageFromNoLongerVerifiedIdentity:
             return []
@@ -135,6 +136,8 @@ extension AppNotificationAction {
             return "Signal.AppNotifications.Action.declineCall"
         case .markAsRead:
             return "Signal.AppNotifications.Action.markAsRead"
+        case .mute:
+            return "Signal.AppNotifications.AppNotifications.mute"
         case .reply:
             return "Signal.AppNotifications.Action.reply"
         case .showThread:

--- a/SignalMessaging/Notifications/UserNotificationsAdaptee.swift
+++ b/SignalMessaging/Notifications/UserNotificationsAdaptee.swift
@@ -42,6 +42,10 @@ public class UserNotificationConfig {
             return UNNotificationAction(identifier: action.identifier,
                                         title: MessageStrings.markAsReadNotificationAction,
                                         options: [])
+        case .mute:
+            return UNNotificationAction(identifier: action.identifier,
+                                        title: MessageStrings.muteNotificationAction,
+                                        options: [])
         case .reply:
             return UNTextInputNotificationAction(identifier: action.identifier,
                                                  title: MessageStrings.replyNotificationAction,

--- a/SignalMessaging/Views/CommonStrings.swift
+++ b/SignalMessaging/Views/CommonStrings.swift
@@ -168,6 +168,9 @@ public class MessageStrings: NSObject {
     static public let markAsReadNotificationAction = NSLocalizedString("PUSH_MANAGER_MARKREAD", comment: "Notification action button title")
 
     @objc
+    static public let muteNotificationAction = NSLocalizedString("PUSH_MANAGER_MUTE", comment: "Notification action button title")
+
+    @objc
     static public let reactWithThumbsUpNotificationAction = NSLocalizedString("PUSH_MANAGER_REACT_WITH_THUMBS_UP", comment: "Notification action button title for 'react with thumbs up.'")
 
     @objc


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [ ] My contribution is fully baked and is ready to be merged as is
- [ ] I have tested my contribution on these devices:

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

This PR intends to allow users to mute a conversation for one hour from the
notification.

This is a feature that has been requested both by personal contacts of mine, as
a prerequisite for switching to Signal, and [by others in the Signal
community](https://community.signalusers.org/t/mute-a-chat-via-the-notification-centre/27385).

While attempted to follow the template set by cc7875de4, which adds the ability
to react to incoming notifications with a thumbs up, in addition to the existing
code used to mute conversations, I have no experience with Objective-C/Swift/iOS
development (there are a few things I am not sure about in this PR), and I do
not have the hardware and software needed to build and test Signal-iOS.

While the contribution guidelines request that only fully tested pull requests
should be submitted, since I do not have the capacity to do so, I've opted to
submit a PR so that the development team can minimally use this as a jumping off
point to implement the simple requested feature (or hopefully, if my attempt was
sufficient, accept the PR after it has been built and tested).

If this is inappropriate, I apologize and will withdraw the pull request.

Note that this does not include any non-English localization strings for the
"Mute" notification action button title.

