### PR TITLE
CI: Use ruby/setup-ruby step with .ruby-version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,9 +41,7 @@ jobs:
         run: make dependencies
 
       - name: Setup Ruby
-        uses: actions/setup-ruby@v1
-        with:
-          ruby-version: 2.6
+        uses: ruby/setup-ruby@v1 # Reads .ruby-version file by default
 
       - name: Cache Bundle Install
         uses: actions/cache@v1


### PR DESCRIPTION
### Contributor checklist
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is

- - - - - - - - - -

### Description
Updates the Ruby setup step in the CI configuration:
 - Replaces the [actions/setup-ruby](https://github.com/actions/setup-ruby) step, which is deprecated, with the [ruby/setup-ruby](https://github.com/ruby/setup-ruby) step
 - Uses the Ruby version from the `.ruby-version` file

