### PR TITLE
Fixes a crash happens when deleting all media from a chat

### DIFF
--- a/Signal/src/ViewControllers/MediaGallery/MediaTileViewController.swift
+++ b/Signal/src/ViewControllers/MediaGallery/MediaTileViewController.swift
@@ -647,7 +647,7 @@ public class MediaTileViewController: UICollectionViewController, MediaGalleryDe
             return
         }
 
-        guard mediaGallery.galleryItemCount > 0  else {
+        guard galleryDates.count > 0 else {
             // Show Empty
             self.collectionView?.reloadData()
             return


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 7+ iOS 14.3

- - - - - - - - - -

### Description
Use the same method to count how many sections to show as the other delegate methods, to decide what to show after deleting items. Fixes #4932.
