### PR TITLE
Allow sharing `.pkpass` files from Wallet and adding received passes to Wallet

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/CV/CVComponents/CVComponentGenericAttachment.swift
+++ b/Signal/src/ViewControllers/ConversationView/CV/CVComponents/CVComponentGenericAttachment.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import QuickLook
+import PassKit
 
 @objc
 public class CVComponentGenericAttachment: CVComponentBase, CVComponent {
@@ -315,6 +316,17 @@ public class CVComponentGenericAttachment: CVComponentBase, CVComponent {
             return false
         }
         return QLPreviewController.canPreview(url as NSURL)
+    }
+
+    /// Returns the `PKPass` represented by this attachment, if any.
+    public func representedPKPass() -> PKPass? {
+        guard attachmentStream?.contentType == "application/vnd.apple.pkpass" else {
+            return nil
+        }
+        guard let data = try? attachmentStream?.readDataFromFile() else {
+            return nil
+        }
+        return try? PKPass(data: data)
     }
 
     @objc(showShareUIFromView:)

--- a/Signal/src/ViewControllers/ConversationView/ConversationViewController+CVComponentDelegate.swift
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewController+CVComponentDelegate.swift
@@ -5,6 +5,7 @@
 import Foundation
 import QuickLook
 import PromiseKit
+import PassKit
 
 extension ConversationViewController: CVComponentDelegate {
 
@@ -237,6 +238,11 @@ extension ConversationViewController: CVComponentDelegate {
             let previewController = QLPreviewController()
             previewController.dataSource = attachment
             self.present(previewController, animated: true, completion: nil)
+            return .handledByDelegate
+        } else if PKAddPassesViewController.canAddPasses(),
+                  let pkPass = attachment.representedPKPass(),
+                  let addPassesVC = PKAddPassesViewController(pass: pkPass) {
+            self.present(addPassesVC, animated: true, completion: nil)
             return .handledByDelegate
         } else {
             return .default

--- a/SignalShareExtension/Info.plist
+++ b/SignalShareExtension/Info.plist
@@ -66,6 +66,7 @@
                 $attachment,
                 ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.data"
                 || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.url"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.apple.pkpass"
                 ).@count &gt;= 1
                 ).@count == 1
             </string>

--- a/SignalShareExtension/ShareViewController.swift
+++ b/SignalShareExtension/ShareViewController.swift
@@ -648,6 +648,10 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
                     return UnloadedItem(itemProvider: itemProvider, itemType: .pdf)
                 }
 
+                if itemProvider.hasItemConformingToTypeIdentifier("com.apple.pkpass") {
+                    return UnloadedItem(itemProvider: itemProvider, itemType: .pkPass)
+                }
+
                 owsFailDebug("unexpected share item: \(itemProvider)")
                 return UnloadedItem(itemProvider: itemProvider, itemType: .other)
             }
@@ -683,6 +687,7 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
             case contact(_ contactData: Data)
             case text(_ text: String)
             case pdf(_ data: Data)
+            case pkPass(_ data: Data)
 
             var debugDescription: String {
                 switch self {
@@ -698,6 +703,8 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
                     return "text"
                 case .pdf:
                     return "pdf"
+                case .pkPass:
+                    return "pkPass"
                 @unknown default:
                     owsFailDebug("Unknown value.")
                     return "unknown"
@@ -735,6 +742,7 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
             case contact
             case text
             case pdf
+            case pkPass
             case other
         }
 
@@ -819,6 +827,11 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
             return itemProvider.loadData(forTypeIdentifier: kUTTypePDF as String, options: nil).map { data in
                 LoadedItem(itemProvider: unloadedItem.itemProvider,
                            payload: .pdf(data))
+            }
+        case .pkPass:
+            return itemProvider.loadData(forTypeIdentifier: "com.apple.pkpass", options: nil).map { data in
+                LoadedItem(itemProvider: unloadedItem.itemProvider,
+                           payload: .pkPass(data))
             }
         case .other:
             return itemProvider.loadUrl(forTypeIdentifier: kUTTypeFileURL as String, options: nil).map { fileUrl in
@@ -908,6 +921,10 @@ public class ShareViewController: UIViewController, ShareViewDelegate, SAEFailed
         case .pdf(let pdf):
             let dataSource = DataSourceValue.dataSource(with: pdf, fileExtension: "pdf")
             let attachment = SignalAttachment.attachment(dataSource: dataSource, dataUTI: kUTTypePDF as String)
+            return Promise.value(attachment)
+        case .pkPass(let pkPass):
+            let dataSource = DataSourceValue.dataSource(with: pkPass, fileExtension: "pkpass")
+            let attachment = SignalAttachment.attachment(dataSource: dataSource, dataUTI: "com.apple.pkpass")
             return Promise.value(attachment)
         }
     }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ ] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions) *(looks like that section was removed in https://github.com/signalapp/Signal-iOS/commit/5d312220ab7083a64a0f4c2d47e44566ab06bb7a)*
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * Simulator: iPhone 12, iOS 14.5

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

This PR aims to implement the [Support Sharing of iOS Wallet Passes (PKPASS files)](https://community.signalusers.org/t/34811) feature request by:

1. Allowing to share `.pkpass` files from the Wallet app;
2. Presenting a `PKAddPassesViewController` when an attachment containing a pass is tapped,

While this PR already works, I have a few questions, mostly regarding some specifics of the implementation.

#### Finding the UTI for `.pkpass` files

<details><summary>Seems to be `com.apple.pkpass`</summary>

> The universal type identifier for `.pkpass` doesn't seem to be very clearly documented (and there doesn't seem to be a constant for it), but because of the recent addition of multi-pass downloads in `.pkpasses` files (which notably are not supported by this PR, since iOS 15 is still in beta and I don't think it's possible to share multiple passes from Wallet at a time), [Distributing and Updating a Pass](https://developer.apple.com/documentation/walletpasses/distributing_and_updating_a_pass) says the MIME type for `.pkpasses` is `application/vnd.apple.pkpasses`.
> 
> So it seems the `.pkpass`'s MIME type is `application/vnd.apple.pkpass` then. To get the UTI type, I ran the following code:
> 
> ```swift
> if #available(iOS 14, *) {
>     let mimeType = "application/vnd.apple.pkpass"
>     let utTypes = UTType.types(tag: mimeType, tagClass: .mimeType, conformingTo: nil)
>     print("\(mimeType) -> \(utTypes)")
> }
> ```
> 
> Which outputs something like:
> 
> ```
> application/vnd.apple.pkpass -> [<_UTCoreType 0x123456789012> com.apple.pkpass]
> ```
> 
> So the UTI seems to be `com.apple.pkpass`.

</details>

On an iPhone XR with iOS 15.0 Public Beta 2, when I tap on a `.pkpass` file in the Files app, it literally says `com.apple.pkpass-data`... However, sharing that file from the Files app already works in Signal anyway (perhaps because Files gives a file URL? So the fact that this works might not be related to the UTI), and also if the implementation of *Part 1* is changed to `com.apple.pkpass-data`, it doesn't work when sharing a pass from Wallet. So I chose `com.apple.pkpass`.

**Edit:** see https://github.com/signalapp/Signal-iOS/pull/5053#issuecomment-880563253 below regarding this.

#### Part 1. Allowing to share `.pkpass` files from the Wallet app

The attachment is automatically named `signal-yyyy-mm-dd-hhmmss.pkpass`. Perhaps it makes sense to parse the file into a [`PKPass`](https://developer.apple.com/documentation/passkit/pkpass/) and grab some string from there, although I'm leaning more towards *not* doing that.

#### Part 2. Presenting a `PKAddPassesViewController` when an attachment containing a pass is tapped

Perhaps the method `representedPKPass` should actually be a `lazy` stored property instead in order to not read from disk multiple times (e.g. in case the user taps on it multiple times while being in the chat - maybe they don't want to add the pass but just preview it multiple times while composing some message)? The `handleTap` method seems like it wouldn't try to Quick Look / share the attachment if the `attachmentStream` is `nil`, so by the point this property would be initialized the attachment should be available?

Regarding the `contentType` check there, I'm not sure it's needed, but it seems like (as long as it itself doesn't read the file from disk?) it would allow to quickly tell if the attachment is not a pass, to save time in that case.

Also not sure if better error handling than just `try?` is needed here.

#### Testing

I've added a pass to Simulator's Wallet (by dropping a `.pkpass` file into the Simulator, which I got by sharing a pass via iMessage from a physical iPhone's Wallet) and tested:
- Sharing the pass from Wallet to Signal in the Simulator;
- Adding it from Signal to Wallet in the Simulator:
    - The one that I just shared to Signal;
    - When sent from Signal iOS (`5.16.0.43`);
    - When sent from Signal Desktop;
- Tested that (Quick Look)-able and non-(Quick Look)-able generic attachments still behave just as before when tapped.