### PR TITLE
Fix "hang up" behavior in message detail view controller

### DIFF
--- a/Signal/src/ViewControllers/MessageDetailViewController.swift
+++ b/Signal/src/ViewControllers/MessageDetailViewController.swift
@@ -510,6 +510,7 @@ class MessageDetailViewController: OWSTableViewController2 {
             } else {
                 popPercentDrivenTransition?.cancel()
             }
+            popPercentDrivenTransition = nil
         case .cancelled, .failed:
             popPercentDrivenTransition?.cancel()
             popPercentDrivenTransition = nil


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 5s, iOS 12.5.3
 * iPhone 7+, iOS 14.6

- - - - - - - - - -

### Description
Reset/clear the `popPercentDrivenTransition` after a gesture has ended so the cancelled instance won't be accidentally used by navigationController delegate. Fixes #4982

### Steps to reproduce the issue
It may be easier to see the screen recordings below.

1. Open a chat
2. Swipe a message to the left to open its details view
3. On the message details view, swipe to the right from the left edge to (pretend to) go back, but cancel the swipe before going over 50% of the width of the view
4. Back on the message details view, tap the Back arrow on the left shoulder.

Expected behavior:
Goes back to the previous view which is the chat.

Actual behavior:
Tapping the back arrow doesn't do anything. Moreover, after tapping the back arrow, nothing on the message details view reacts to any gesture; tap, swipe, long tap, none.

### Screen recording
Note that I enabled the assistive touch in the middle of the steps only to show where I was tapping in the video.

#### Bug

https://user-images.githubusercontent.com/28482/126049504-97997763-ca96-4abd-8e88-a2c0bf0c1941.mp4

#### Fixed

https://user-images.githubusercontent.com/28482/126049509-3f21fa8e-bc8f-4c03-b57a-17154ef1b7af.mp4







