### PR TITLE
Turn off camera when the view is not in the foreground

### DIFF
--- a/Signal/src/ViewControllers/Photos/PhotoCapture.swift
+++ b/Signal/src/ViewControllers/Photos/PhotoCapture.swift
@@ -233,6 +233,13 @@ class PhotoCapture: NSObject {
         }
     }
 
+    @discardableResult
+    public func resumeCapture() -> Guarantee<Void> {
+        sessionQueue.async(.promise) { [session] in
+            session.startRunning()
+        }
+    }
+
     public func assertIsOnSessionQueue() {
         assertOnQueue(sessionQueue)
     }

--- a/Signal/src/ViewControllers/Photos/PhotoCaptureViewController.swift
+++ b/Signal/src/ViewControllers/Photos/PhotoCaptureViewController.swift
@@ -150,7 +150,7 @@ class PhotoCaptureViewController: OWSViewController, InteractiveDismissDelegate 
     }
 
     override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillAppear(animated)
+        super.viewWillDisappear(animated)
         isVisible = false
         VolumeButtons.shared?.removeObserver(photoCapture)
     }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 7+ iOS 14.6

- - - - - - - - - -

### Description
Turn off the camera capture session when the view is not in the foreground and resume the session again when the view becomes foreground. This way the green indicator on the status bar turns off too when the camera is not actually in use.