### PR TITLE
Fix showing only most recent matched result

### DIFF
--- a/Signal/src/ViewControllers/HomeView/ConversationSearchViewController.swift
+++ b/Signal/src/ViewControllers/HomeView/ConversationSearchViewController.swift
@@ -258,13 +258,15 @@ public class ConversationSearchViewController: UITableViewController {
 
         // If we have an existing HVCellContentToken, use it.
         // Cell measurement/arrangement is expensive.
-        let cacheKey = configuration.thread.threadRecord.uniqueId
+        let cacheKey = configuration.overrideSnippet?.string ?? ""
         if let cellContentToken = cellContentCache.get(key: cacheKey) {
             return cellContentToken
         }
 
         let cellContentToken = HomeViewCell.buildCellContentToken(forConfiguration: configuration)
-        cellContentCache.set(key: cacheKey, value: cellContentToken)
+        if cacheKey.count > 0 {
+            cellContentCache.set(key: cacheKey, value: cellContentToken)
+        }
         return cellContentToken
     }
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 11, iOS 14.7.1

- - - - - - - - - -

### Description

Related Issue: https://github.com/signalapp/Signal-iOS/issues/5107, https://github.com/signalapp/Signal-iOS/issues/5137

Conversation contains 6 words that differ by one character:

<p align="center">
<img src="https://user-images.githubusercontent.com/47181362/131214743-ea51e02b-918f-440a-a559-860e623ae2f9.png" width="25%" height="25%" /> </a>

When a user wants to search for 6 separate messages he gets this result:

<p align="center">
<img src="https://user-images.githubusercontent.com/47181362/131214749-acde6670-3f6e-448b-991a-117584c6bab1.png" width="25%" height="25%" /> </a>

After fix the result looks like this:

<p align="center">
<img src="https://user-images.githubusercontent.com/47181362/131214751-39792b76-c7d0-434a-9030-00c870a153ad.png" width="25%" height="25%" /> </a>