### PR TITLE
Changed eng version of notification body

### DIFF
--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -146,7 +146,7 @@
 "ANSWER_CALL_BUTTON_TITLE" = "Answer";
 
 /* notification body */
-"APN_Message" = "You may have new messages";
+"APN_Message" = "New message!";
 
 /* Message for the 'app launch failed' alert. */
 "APP_LAUNCH_FAILURE_ALERT_MESSAGE" = "Signal can't launch. Please send a debug log to support@signal.org so that we can troubleshoot this issue.";


### PR DESCRIPTION
- - - - - - - - - -
- English Notification Body
Fixes #5099
### Description
<!--
Before when you get message: 'You may have new messages'
Now: 'New Message!'
-->

If this changes is not what you need you can close PR and issue 5099 respectively