### PR TITLE
Stop activating camera behind the gallery view

### DIFF
--- a/Signal/src/ViewControllers/Photos/PhotoCapture.swift
+++ b/Signal/src/ViewControllers/Photos/PhotoCapture.swift
@@ -152,7 +152,7 @@ class PhotoCapture: NSObject {
         videoConnection.videoOrientation = orientation
     }
 
-    public func startVideoCapture() -> Promise<Void> {
+    public func prepareVideoCapture() -> Promise<Void> {
         AssertIsOnMainThread()
         guard !Platform.isSimulator else {
             // Trying to actually set up the capture session will fail on a simulator
@@ -219,8 +219,6 @@ class PhotoCapture: NSObject {
             } else {
                 owsFailDebug("couldn't add audioDataOutput")
             }
-        }.done(on: sessionQueue) {
-            self.session.startRunning()
         }
     }
 

--- a/Signal/src/ViewControllers/Photos/PhotoCaptureViewController.swift
+++ b/Signal/src/ViewControllers/Photos/PhotoCaptureViewController.swift
@@ -514,25 +514,23 @@ class PhotoCaptureViewController: OWSViewController, InteractiveDismissDelegate 
     }
 
     var hasCaptureStarted = false
+
+    private func captureReady() {
+      self.hasCaptureStarted = true
+      BenchEventComplete(eventId: "Show-Camera")
+    }
+
     private func setupPhotoCapture() {
         photoCapture.delegate = self
         captureButton.delegate = photoCapture
 
-        let captureReady = { [weak self] in
-            guard let self = self else { return }
-            self.hasCaptureStarted = true
-            BenchEventComplete(eventId: "Show-Camera")
-        }
-
         // If the session is already running, we're good to go.
         guard !photoCapture.session.isRunning else {
-            return captureReady()
+            return self.captureReady()
         }
 
         firstly {
-            photoCapture.startVideoCapture()
-        }.done {
-            captureReady()
+            photoCapture.prepareVideoCapture()
         }.catch { [weak self] error in
             guard let self = self else { return }
             self.showFailureUI(error: error)
@@ -555,7 +553,7 @@ class PhotoCaptureViewController: OWSViewController, InteractiveDismissDelegate 
         firstly {
             photoCapture.resumeCapture()
         }.done { [weak self] in
-            self?.hasCaptureStarted = true
+            self?.captureReady()
         }.catch { [weak self] error in
             self?.showFailureUI(error: error)
         }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 7+, iOS 14.8

- - - - - - - - - -

### Description
Start camera only when PhotoCaptureViewController is visible to the user.

Fixes #4751. Fixes #4817

### Steps to reproduce the issue
1. Launch Signal
2. Go to a chat
3. Click the [+] button
4. Tap on one of the recent image in the list
5. Wait for a few seconds

**Observed**
Green indicator appears on the right shoulder to indicate that the camera is active and capturing the scene.

**Expected**
Camera does not become active on the gallery view. Camera becomes active when the user switches to camera.

### Screen recordings

Behavior at [ce757447699891bd5880144a7c579f19e8fe84ec]

https://user-images.githubusercontent.com/28482/135758394-1f862f8e-920a-4df6-be39-56c4a704381f.mp4

---

After the fix by the PR

https://user-images.githubusercontent.com/28482/135758433-da261f6b-d0b3-41be-aeeb-5dda6a0c59eb.mp4



