### PR TITLE
Display 4 square media in two rows instead of two columns

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/Cells/CVMediaAlbumView.swift
+++ b/Signal/src/ViewControllers/ConversationView/Cells/CVMediaAlbumView.swift
@@ -483,8 +483,8 @@ public class CVMediaAlbumView: ManualStackViewWithLayer {
             // XX
             // Square
             let imageSize = CGSize(square: floor((maxWidth - CVMediaAlbumView.kSpacingPts) / 2))
-            return .twoVerticalColumns(column1: ImageGroup(imageCount: 2, imageSize: imageSize),
-                                       column2: ImageGroup(imageCount: 2, imageSize: imageSize))
+            return .twoHorizontalRows(row1: ImageGroup(imageCount: 2, imageSize: imageSize),
+                                       row2: ImageGroup(imageCount: 2, imageSize: imageSize))
         default:
             // X X
             // xxx


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPad Pro 2018 11", iPadOS 15.2

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

Makes display consistent across platforms.
See #5227

Desktop, and as far as I know Android, display a grid of 4 images as two rows rather than two columns. This change makes that consistent across platforms. This allows users to refer to images by saying things like "the top right image" while knowing that what is displayed in the top right is consistent even if the other user is on desktop.