### PR TITLE
Translation error fixed

### DIFF
--- a/Signal/translations/fi.lproj/Localizable.strings
+++ b/Signal/translations/fi.lproj/Localizable.strings
@@ -5510,7 +5510,7 @@
 "SETTINGS_PAYMENTS_PAYMENT_ADD_MONEY" = "Lisää varoja";
 
 /* Label for the 'MobileCoin block index' in the payment details view in the app settings. */
-"SETTINGS_PAYMENTS_PAYMENT_DETAILS_BLOCK_INDEX" = "Estä numero";
+"SETTINGS_PAYMENTS_PAYMENT_DETAILS_BLOCK_INDEX" = "Lohkon numero";
 
 /* Label for the 'MobileCoin network fee' in the payment details view in the app settings. */
 "SETTINGS_PAYMENTS_PAYMENT_DETAILS_FEE" = "Verkkomaksu";


### PR DESCRIPTION
"Block number" was translated to Finnish as it would mean blocking a certain phone number ("estä numero"). Here it refers to block ID in the payment system ("lohkon numero", literally "number of the block".

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iDevice A, iOS X.Y.Z
 * iDevice B, iOS Z.Y

- - - - - - - - - -

### Description
<!--
"Block number" was mistranslated to Finnish as it would mean blocking a certain phone number ("estä numero"). Here it refers to block ID in the payment system ("lohkon numero", literally "number of the block").

I understand that the translation is managed in Transifex, but till today no one has approved the join request I did do in December. I am a professional tech writer and experienced with Zotero citation management software localization in Transifex and would be glad to contribute to Signal also.
-->
