### PR TITLE
Adding approve new members message if group link is disabled

### DIFF
--- a/Signal/src/ViewControllers/ThreadSettings/GroupLinkViewController.swift
+++ b/Signal/src/ViewControllers/ThreadSettings/GroupLinkViewController.swift
@@ -166,6 +166,10 @@ public class GroupLinkViewController: OWSTableViewController2 {
     @objc
     func didToggleApproveNewMembers(_ sender: UISwitch) {
         guard groupModelV2.isGroupInviteLinkEnabled else {
+            let message = NSLocalizedString("GROUP_APPROVE_NEW_MEMBERS_WITHOUT_GROUP_LINK_WARNING",
+                                            comment: "Message indicating that you cannot approve new members if the group link is not enabled.")
+            presentToast(text: message)
+            updateTableContents()
             return
         }
         let canEditGroupLinkSettings = groupModelV2.groupMembership.isLocalUserFullMemberAndAdministrator

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -1951,6 +1951,9 @@
 /* Message indicating that a feature can only be used by group admins. */
 "GROUP_ADMIN_ONLY_WARNING" = "Only admins can change this option.";
 
+/* Message indicating that you cannot approve new members if the group link is not enabled. */
+"GROUP_APPROVE_NEW_MEMBERS_WITHOUT_GROUP_LINK_WARNING" = "You cannot approve new members if the group link is disabled.";
+
 /* Message body for alert explaining that a group call participant is blocked */
 "GROUP_CALL_BLOCKED_ALERT_MESSAGE" = "You won’t receive their audio or video and they won’t receive yours.";
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 iPhone 11, iOS 15.0.2,
 iPhone XS, iOS 15.2

- - - - - - - - - -

### Description

In the "Group Link" section if you enable "Approve New Members" without enabling the group link nothing happens because the function didToggleApproveNewMembers returns immediately if groupModelV2.isGroupInviteLinkEnabled is false. _This is not a bug_ but **the user is not informed in any way**. 
I've modified the function so that the user cannot "Approve New Members" if the group link is disabled. Also, I've added a new message GROUP_APPROVE_NEW_MEMBERS_WITHOUT_GROUP_LINK_WARNING ("You cannot approve new members if the group link is disabled.") so that the user is informed that he cannot "Approve New Members" if the group link is disabled.
I build Signal on a real device and tested my code.  

