### PR TITLE
Fix Issue #5257 - Broken new feature: Reaction picker configuration (where you can set your default emojis): Changing an emoji replaces not selected emoji 

### DIFF
--- a/Signal.xcodeproj/project.pbxproj
+++ b/Signal.xcodeproj/project.pbxproj
@@ -4845,7 +4845,6 @@
 						ProvisioningStyle = Automatic;
 					};
 					D221A088169C9E5E00537ABF = {
-						DevelopmentTeam = U68MSDN6DR;
 						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
@@ -8391,7 +8390,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = U68MSDN6DR;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Signal/src/ViewControllers/Context Menus/ContextMenuReactionBarAccessory.swift
+++ b/Signal/src/ViewControllers/Context Menus/ContextMenuReactionBarAccessory.swift
@@ -90,7 +90,9 @@ public class ContextMenuRectionBarAccessory: ContextMenuTargetedPreviewAccessory
                 didSelectAnyEmoji()
             } else {
                 let isRemoving = focusedEmoji == self.itemViewModel?.reactionState?.localUserEmoji
-                didSelectReaction(reaction: focusedEmoji, isRemoving: isRemoving )
+                if let index = reactionPicker.currentEmojiSet().firstIndex(of: focusedEmoji) {
+                    didSelectReaction(reaction: focusedEmoji, isRemoving: isRemoving, inPosition: index )
+                }
             }
             return true
         }
@@ -101,7 +103,8 @@ public class ContextMenuRectionBarAccessory: ContextMenuTargetedPreviewAccessory
     // MARK: MessageReactionPickerDelegate
     func didSelectReaction(
         reaction: String,
-        isRemoving: Bool
+        isRemoving: Bool,
+        inPosition position: Int
     ) {
         guard let message = itemViewModel?.interaction as? TSMessage else {
             owsFailDebug("Not sending reaction for unexpected interaction type")

--- a/Signal/src/ViewControllers/ConversationView/Emoji Picker/EmojiReactionPickerConfigViewController.swift
+++ b/Signal/src/ViewControllers/ConversationView/Emoji Picker/EmojiReactionPickerConfigViewController.swift
@@ -87,7 +87,7 @@ extension EmojiReactionPickerConfigViewController: MessageReactionPickerDelegate
         }
         picker.backdropColor = .clear
 
-        reactionPicker.startReplaceAnimation(focusedEmoji: reaction)
+        reactionPicker.startReplaceAnimation(focusedEmoji: reaction, inPosition: position)
         present(picker, animated: true)
     }
 

--- a/Signal/src/ViewControllers/ConversationView/Emoji Picker/EmojiReactionPickerConfigViewController.swift
+++ b/Signal/src/ViewControllers/ConversationView/Emoji Picker/EmojiReactionPickerConfigViewController.swift
@@ -48,7 +48,7 @@ public class EmojiReactionPickerConfigViewController: UIViewController {
 
         for (index, emoji) in reactionPicker.currentEmojiSet().enumerated() {
             if let newEmoji = emojiSet[safe: index]?.rawValue {
-                reactionPicker.replaceEmojiReaction(emoji, newEmoji: newEmoji)
+                reactionPicker.replaceEmojiReaction(emoji, newEmoji: newEmoji, inPosition: index)
             }
         }
     }
@@ -66,7 +66,7 @@ public class EmojiReactionPickerConfigViewController: UIViewController {
 }
 
 extension EmojiReactionPickerConfigViewController: MessageReactionPickerDelegate {
-    func didSelectReaction(reaction: String, isRemoving: Bool) {
+    func didSelectReaction(reaction: String, isRemoving: Bool, inPosition position: Int) {
 
         if presentedViewController != nil {
             self.reactionPicker.endReplaceAnimation()
@@ -82,7 +82,7 @@ extension EmojiReactionPickerConfigViewController: MessageReactionPickerDelegate
                 return
             }
 
-            self.reactionPicker.replaceEmojiReaction(reaction, newEmoji: emojiString)
+            self.reactionPicker.replaceEmojiReaction(reaction, newEmoji: emojiString, inPosition: position)
             self.reactionPicker.endReplaceAnimation()
         }
         picker.backdropColor = .clear

--- a/Signal/src/ViewControllers/MessageReactionPicker.swift
+++ b/Signal/src/ViewControllers/MessageReactionPicker.swift
@@ -6,7 +6,7 @@ import Foundation
 import SignalUI
 
 protocol MessageReactionPickerDelegate: AnyObject {
-    func didSelectReaction(reaction: String, isRemoving: Bool)
+    func didSelectReaction(reaction: String, isRemoving: Bool, inPosition position: Int)
     func didSelectAnyEmoji()
 }
 
@@ -93,14 +93,14 @@ class MessageReactionPicker: UIStackView {
             }
         }
 
-        for emoji in emojiSet {
+        for (index, emoji) in emojiSet.enumerated() {
             let button = OWSFlatButton()
             button.autoSetDimensions(to: CGSize(square: reactionHeight))
             button.setTitle(title: emoji.rawValue, font: .systemFont(ofSize: reactionFontSize), titleColor: Theme.primaryTextColor)
             button.setPressedBlock { [weak self] in
                 // current title of button may have changed in the meantime
                 if let currentEmoji = button.button.title(for: .normal) {
-                    self?.delegate?.didSelectReaction(reaction: currentEmoji, isRemoving: currentEmoji == self?.selectedEmoji?.rawValue)
+                    self?.delegate?.didSelectReaction(reaction: currentEmoji, isRemoving: currentEmoji == self?.selectedEmoji?.rawValue, inPosition: index)
                 }
             }
             buttonForEmoji[emoji.rawValue] = button
@@ -131,9 +131,7 @@ class MessageReactionPicker: UIStackView {
         }
     }
 
-    public func replaceEmojiReaction(_ oldEmoji: String, newEmoji: String) {
-        let button = buttonForEmoji[oldEmoji]
-        if let button = button {
+    public func replaceEmojiReaction(_ oldEmoji: String, newEmoji: String, inPosition position: Int) {
             button.setTitle(title: newEmoji, font: .systemFont(ofSize: reactionFontSize), titleColor: Theme.primaryTextColor)
             buttonForEmoji[newEmoji] = button
         }

--- a/Signal/src/ViewControllers/MessageReactionPicker.swift
+++ b/Signal/src/ViewControllers/MessageReactionPicker.swift
@@ -21,8 +21,6 @@ class MessageReactionPicker: UIStackView {
     var selectedBackgroundHeight: CGFloat { return pickerDiameter - 4 }
     let configureMode: Bool
 
-    // MARK: Change 1
-//    private var buttonForEmoji = [String: OWSFlatButton]()
     private var buttonForEmoji = [(emoji: String, button: OWSFlatButton)]()
     private var selectedEmoji: EmojiWithSkinTones?
     private var backgroundView: UIView?
@@ -105,8 +103,6 @@ class MessageReactionPicker: UIStackView {
                     self?.delegate?.didSelectReaction(reaction: currentEmoji, isRemoving: currentEmoji == self?.selectedEmoji?.rawValue, inPosition: index)
                 }
             }
-            //MARK: Change 2
-//            buttonForEmoji[emoji.rawValue] = button
             buttonForEmoji.append((emoji.rawValue, button))
             addArrangedSubview(button)
 
@@ -130,22 +126,15 @@ class MessageReactionPicker: UIStackView {
             button.setPressedBlock { [weak self] in
                 self?.delegate?.didSelectAnyEmoji()
             }
-            // MARK: Change 3
-//            buttonForEmoji[MessageReactionPicker.anyEmojiName] = button
             buttonForEmoji.append((MessageReactionPicker.anyEmojiName, button))
             addArrangedSubview(button)
         }
     }
 
     public func replaceEmojiReaction(_ oldEmoji: String, newEmoji: String, inPosition position: Int) {
-        // MARK: Change 4
-//        let button = buttonForEmoji[oldEmoji]
         let buttonTuple = buttonForEmoji[position]
-//        if let buttonTuple = buttonTuple {
-            let button = buttonTuple.button
-            button.setTitle(title: newEmoji, font: .systemFont(ofSize: reactionFontSize), titleColor: Theme.primaryTextColor)
-//            buttonForEmoji[newEmoji] = button
-//        }
+        let button = buttonTuple.button
+        button.setTitle(title: newEmoji, font: .systemFont(ofSize: reactionFontSize), titleColor: Theme.primaryTextColor)
     }
 
     public func currentEmojiSet() -> [String] {
@@ -226,8 +215,6 @@ class MessageReactionPicker: UIStackView {
         var previouslyFocusedButton: OWSFlatButton?
         var focusedButton: OWSFlatButton?
 
-        // MARK: Change 5
-//        if let focusedEmoji = focusedEmoji, let focusedButton = buttonForEmoji[focusedEmoji] {
         if let focusedEmoji = focusedEmoji, let focusedButton = buttonForEmoji.first(where: { $0.emoji == focusedEmoji})?.button {
             previouslyFocusedButton = focusedButton
         }
@@ -237,8 +224,6 @@ class MessageReactionPicker: UIStackView {
         for (emoji, button) in buttonForEmoji {
             guard focusArea(for: button).contains(position) else { continue }
             focusedEmoji = emoji
-            // MARK: Change 6
-//            focusedButton = buttonForEmoji[emoji]
             focusedButton = buttonForEmoji.first(where: { $0.emoji == emoji })?.button
             break
         }

--- a/Signal/src/ViewControllers/MessageReactionPicker.swift
+++ b/Signal/src/ViewControllers/MessageReactionPicker.swift
@@ -21,7 +21,9 @@ class MessageReactionPicker: UIStackView {
     var selectedBackgroundHeight: CGFloat { return pickerDiameter - 4 }
     let configureMode: Bool
 
-    private var buttonForEmoji = [String: OWSFlatButton]()
+    // MARK: Change 1
+//    private var buttonForEmoji = [String: OWSFlatButton]()
+    private var buttonForEmoji = [(emoji: String, button: OWSFlatButton)]()
     private var selectedEmoji: EmojiWithSkinTones?
     private var backgroundView: UIView?
     init(selectedEmoji: String?, delegate: MessageReactionPickerDelegate?, configureMode: Bool = false) {
@@ -103,7 +105,9 @@ class MessageReactionPicker: UIStackView {
                     self?.delegate?.didSelectReaction(reaction: currentEmoji, isRemoving: currentEmoji == self?.selectedEmoji?.rawValue, inPosition: index)
                 }
             }
-            buttonForEmoji[emoji.rawValue] = button
+            //MARK: Change 2
+//            buttonForEmoji[emoji.rawValue] = button
+            buttonForEmoji.append((emoji.rawValue, button))
             addArrangedSubview(button)
 
             // Add a circle behind the currently selected emoji
@@ -126,15 +130,22 @@ class MessageReactionPicker: UIStackView {
             button.setPressedBlock { [weak self] in
                 self?.delegate?.didSelectAnyEmoji()
             }
-            buttonForEmoji[MessageReactionPicker.anyEmojiName] = button
+            // MARK: Change 3
+//            buttonForEmoji[MessageReactionPicker.anyEmojiName] = button
+            buttonForEmoji.append((MessageReactionPicker.anyEmojiName, button))
             addArrangedSubview(button)
         }
     }
 
     public func replaceEmojiReaction(_ oldEmoji: String, newEmoji: String, inPosition position: Int) {
+        // MARK: Change 4
+//        let button = buttonForEmoji[oldEmoji]
+        let buttonTuple = buttonForEmoji[position]
+//        if let buttonTuple = buttonTuple {
+            let button = buttonTuple.button
             button.setTitle(title: newEmoji, font: .systemFont(ofSize: reactionFontSize), titleColor: Theme.primaryTextColor)
-            buttonForEmoji[newEmoji] = button
-        }
+//            buttonForEmoji[newEmoji] = button
+//        }
     }
 
     public func currentEmojiSet() -> [String] {
@@ -215,7 +226,9 @@ class MessageReactionPicker: UIStackView {
         var previouslyFocusedButton: OWSFlatButton?
         var focusedButton: OWSFlatButton?
 
-        if let focusedEmoji = focusedEmoji, let focusedButton = buttonForEmoji[focusedEmoji] {
+        // MARK: Change 5
+//        if let focusedEmoji = focusedEmoji, let focusedButton = buttonForEmoji[focusedEmoji] {
+        if let focusedEmoji = focusedEmoji, let focusedButton = buttonForEmoji.first(where: { $0.emoji == focusedEmoji})?.button {
             previouslyFocusedButton = focusedButton
         }
 
@@ -224,7 +237,9 @@ class MessageReactionPicker: UIStackView {
         for (emoji, button) in buttonForEmoji {
             guard focusArea(for: button).contains(position) else { continue }
             focusedEmoji = emoji
-            focusedButton = buttonForEmoji[emoji]
+            // MARK: Change 6
+//            focusedButton = buttonForEmoji[emoji]
+            focusedButton = buttonForEmoji.first(where: { $0.emoji == emoji })?.button
             break
         }
 

--- a/Signal/src/ViewControllers/MessageReactionPicker.swift
+++ b/Signal/src/ViewControllers/MessageReactionPicker.swift
@@ -135,6 +135,8 @@ class MessageReactionPicker: UIStackView {
         let buttonTuple = buttonForEmoji[position]
         let button = buttonTuple.button
         button.setTitle(title: newEmoji, font: .systemFont(ofSize: reactionFontSize), titleColor: Theme.primaryTextColor)
+//        buttonForEmoji.remove(at: position)
+        buttonForEmoji.replaceSubrange(position...position, with: [(newEmoji, button)])
     }
 
     public func currentEmojiSet() -> [String] {
@@ -147,13 +149,14 @@ class MessageReactionPicker: UIStackView {
         return emojiSet
     }
 
-    public func startReplaceAnimation(focusedEmoji: String) {
+    public func startReplaceAnimation(focusedEmoji: String, inPosition position: Int) {
         var buttonToWiggle: OWSFlatButton?
         UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseInOut) {
-            for view in self.arrangedSubviews {
+            for (index, view) in self.arrangedSubviews.enumerated() {
                 if let button = view as? OWSFlatButton, let emoji = button.button.title(for: .normal) {
                     // Shrink and fade
-                    if emoji != focusedEmoji {
+//                    if emoji != focusedEmoji {
+                    if index != position {
                         button.alpha = 0.3
                         button.transform = CGAffineTransform(scaleX: 0.8, y: 0.8)
                     } else { // Expand and wiggle


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 8, iOS 15.2.1 (Physical device)
 * iPhone 13, iOS 15.2 (Simulator)

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->
This fix addresses Issue [#5257](https://github.com/signalapp/Signal-iOS/issues/5257) where it was reported that when multiple emojis in the favorites bar were set to the same emoji, it would lock you into just changing the last of those and you would be unable to change from the multiple emoji's. 

As I ran through the method in the MessageReactionPicker to see how the values change, I found that the issue was the dictionary buttonForEmoji. As a duplicate emoji (i.e. Thumbs Up) was added, it would add the button from the old emoji (i.e. Thumbs Down) to the emoji that matches the new emoji in the dictionary. This meant that Thumbs Up in the dictionary now has the button for the Thumbs Down, and Thumbs Down also does, and the button for the original Thumbs Up is lost. 

I had two ideas for fixing this, one was simply to have it return out of the method without changing the emoji if it was a duplicate, and the other was to change it from a dictionary to a structure that would maintain duplicates, namely an array of tuples (closely mirroring the key value pairing of the dictionary). I felt that the latter would be less noticeable a change and opted to do it this way. However, this did require quite a bit more changed lines of code. If this is not the preferred change, I'm happy to submit a PR with a simple few lines returning out of the method without changing the emoji in the case of a duplicate to simply prevent duplicates in the first place. 

As a note, I did in a separate branch, add a little bit more code that changed the functionality slightly more to swap emoji's in the case of a duplicate in case that would be a more desirable functionality that having duplicates. This would allow users to swap the positions on the emoji picker and rearrange their emojis simply that way. At this point I am not submitting that PR as it is enough of a change that I wasn't sure that it would be a welcome change. 

If the emoji swap change would be desired, I am happy to submit that and if you would prefer staying with a dictionary and simply not doing anything if a duplicate is chosen, I am happy to submit that instead also. 
