### PR TITLE
Fix `SocketManager.isAnySocketOpen` (fixes #5221)

### DIFF
--- a/SignalServiceKit/src/Network/WebSockets/SocketManager.swift
+++ b/SignalServiceKit/src/Network/WebSockets/SocketManager.swift
@@ -151,7 +151,7 @@ public class SocketManager: NSObject {
 
     @objc
     public var isAnySocketOpen: Bool {
-        !OWSWebSocketType.allCases.compactMap { socketState(forType: $0) == .open }.isEmpty
+        OWSWebSocketType.allCases.contains { socketState(forType: $0) == .open }
     }
 
     public func socketState(forType webSocketType: OWSWebSocketType) -> OWSWebSocketState {


### PR DESCRIPTION
### Contributor checklist
- [ ] ~~I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)~~ (no conventions accessible at that link)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * Simulator: iPod touch (7th generation), iOS 15.2

- - - - - - - - - -

### Description

It seems that this was broken during a refactor in https://github.com/signalapp/Signal-iOS/commit/417655de94be854891ba54d8de8154524b9b4779#diff-c0cde744bba9dae9bf29668dec2662dfc2f210b73fa34d358d28a0f51d549463L138-R142.

I've tested this by toggling Wi-Fi on the Mac running the simulator and observing the text as described in #5221. A downside of this testing approach appears to be that it takes a while (and sometimes even going Home and back) for Signal in the simulator to realize it doesn't have a network/server connection, which I assume should work much better on a real device. Other than that, it does seem to work as per the expected behavior in the issue.

Fixes #5221.