### PR TITLE
Allow user to choose photo from synced/imported albums (#5258)

### DIFF
--- a/Signal/src/ViewControllers/Photos/PhotoLibrary.swift
+++ b/Signal/src/ViewControllers/Photos/PhotoLibrary.swift
@@ -380,6 +380,14 @@ class PhotoLibrary: NSObject, PHPhotoLibraryChangeObserver {
         processPHAssetCollections((fetchResult: PHAssetCollection.fetchAssetCollections(with: .smartAlbum, subtype: .albumRegular, options: fetchOptions),
                                    hideIfEmpty: true))
 
+        // Albums synced to the device from iPhoto.
+        processPHAssetCollections((fetchResult: PHAssetCollection.fetchAssetCollections(with: .album, subtype: .albumSyncedAlbum, options: fetchOptions),
+                                   hideIfEmpty: true))
+
+        // Albums imported from a camera or external storage.
+        processPHAssetCollections((fetchResult: PHAssetCollection.fetchAssetCollections(with: .album, subtype: .albumImported, options: fetchOptions),
+                                   hideIfEmpty: true))
+
         // User-created albums.
         processPHCollections((fetchResult: PHAssetCollection.fetchTopLevelUserCollections(with: fetchOptions),
                               hideIfEmpty: true))


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [ ] I have tested my contribution on these devices:
 * iDevice A, iOS X.Y.Z
 * iDevice B, iOS Z.Y

- - - - - - - - - -

### Description

I sync family photo album folders to my iPhone from my Mac using Finder. These photos are available for posting in apps like IG and Twitter, but are not shown in the Signal app. This gives me a sad. I made an issue about it (#5258), but @stalebot closed it before it could be addressed.

So, I added two lines of code -- one to add the user's *synced* albums to the list (which I *believe* will fix my issue), and, for good measure, a line to also provide access to any albums created by importing photos directly from a camera or external flash card (which I haven't tried in many years, but I know is possible on iPhone).

**Please note:** I'm not an iOS dev and have no setup here for compiling or testing Swift code. I'm a .NET and web guy. That said, the code seems straightforward enough based on the Apple docs, so hopefully it's an easy merge!