### PR TITLE
Hiding Approve New Members if Group Link is not enabled

### DIFF
--- a/Signal/src/ViewControllers/ThreadSettings/GroupLinkViewController.swift
+++ b/Signal/src/ViewControllers/ThreadSettings/GroupLinkViewController.swift
@@ -114,14 +114,19 @@ public class GroupLinkViewController: OWSTableViewController2 {
             let section = OWSTableSection()
             section.footerTitle = NSLocalizedString("GROUP_LINK_VIEW_MEMBER_REQUESTS_SECTION_FOOTER",
                                                     comment: "Footer for the 'member requests' section of the 'group link' view.")
-            section.add(OWSTableItem.switch(withText: NSLocalizedString("GROUP_LINK_VIEW_APPROVE_NEW_MEMBERS_SWITCH",
-                                                                        comment: "Label for the 'approve new members' switch in the 'group link' view."),
-                                            isOn: { groupModelV2.access.addFromInviteLink == .administrator },
-                                            isEnabledBlock: {
-                                                true
-            },
-                                            target: self,
-                                            selector: #selector(didToggleApproveNewMembers(_:))))
+            
+            if groupModelV2.isGroupInviteLinkEnabled {
+                section.add(OWSTableItem.switch(withText: NSLocalizedString("GROUP_LINK_VIEW_APPROVE_NEW_MEMBERS_SWITCH",
+                                                                            comment: "Label for the 'approve new members' switch in the 'group link' view."),
+                                                isOn: { groupModelV2.access.addFromInviteLink == .administrator },
+                                                isEnabledBlock: {
+                                                    true
+                },
+                                                target: self,
+                                                selector: #selector(didToggleApproveNewMembers(_:))))
+                
+            }
+            
             contents.addSection(section)
         }
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-iOS/blob/master/README.md) and [CONTRIBUTING](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I'm following the [code, UI and style conventions](https://github.com/WhisperSystems/Signal-iOS/blob/master/CONTRIBUTING.md#code-conventions)
- [x] My commits are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 11, iOS 15.4.1
 * iPhone XS, iOS 15.4.1

- - - - - - - - - -

### Description
@Imperiopolis-Signal  => Regarding #5240 PR. 

In the Group Link section, if the "Group Link" is not enabled then the "Approve New Members" option is not shown. In this way, I think it is more clear for the user that he should "Approve New Members" only when the "Group Link" is enabled. If the user enables the "Group Link" then the "Approve New Members" is shown. If the user disables the "Group Link" then the "Approve New Members" is hidden. 
