### PR TITLE
Photo taken in landscape mode didn't rotate when sent (signalapp#4334)

### DIFF
--- a/Signal/src/ViewControllers/Photos/PhotoCaptureViewController.swift
+++ b/Signal/src/ViewControllers/Photos/PhotoCaptureViewController.swift
@@ -55,7 +55,7 @@ class PhotoCaptureViewController: OWSViewController, InteractiveDismissDelegate 
     public lazy var photoCapture = PhotoCapture()
 
     deinit {
-        UIDevice.current.endGeneratingDeviceOrientationNotifications()
+        photoCapture.stopOrientationUpdates()
         photoCapture.stopCapture().done {
             Logger.debug("stopCapture completed")
         }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 6s iOS 15.5

- - - - - - - - - -

### Description
This is fix for issue where, when the rotation lock is enabled, a photo will not be properly rotated upon capture. I also noticed, under this scenario, that the UI buttons also did not rotate in the same manner as the built-in iOS camera with the lock enabled.

#### Background
This occurs because UIDevice.current.orientation becomes locked to portrait when the rotation lock is enabled.

#### Implementation
The only way to get device orientation data regardless of the orientation lock is to pull the data directly from the accelerometer. I have added three functions to act as drop-in replacements to the current functions handling notifications from beginGeneratingDeviceOrientationNotifications().

**startOrientationUpdates()** -> This sets up CoreMotion to generate updates from the accelerometer. If CoreMotion or the accelerometer is not available or restricted from use, then the original method of using beginGeneratingDeviceOrientationNotifications() is used.

**stopOrientationUpdates()** -> Stops updates from CoreMotion or GeneratingDeviceOrientationNotifications if they are active.

**orientationDidChange(orientation: UIDeviceOrientation)** -> Overload of the existing orientationDidChange and basically does the same thing aside from the translation of data types.

The accelerometer update code was based on references from this post:
https://stackoverflow.com/questions/49164302/get-current-ios-device-orientation-even-if-devices-orientation-locked

#### Result
With the rotation lock enabled, photos now capture the correct rotation and the camera UI buttons rotate with the device as expected.