### PR TITLE
Add 'Speak Message' accessibility feature

### DIFF
--- a/Signal.xcodeproj/project.pbxproj
+++ b/Signal.xcodeproj/project.pbxproj
@@ -794,6 +794,7 @@
 		76C87F19181EFCE600C4ACAB /* MediaPlayer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 76C87F18181EFCE600C4ACAB /* MediaPlayer.framework */; };
 		76EB054018170B33006006FC /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 76EB03C318170B33006006FC /* AppDelegate.m */; };
 		76FCCDBC27AB8FBE00BAA7F0 /* MediaControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76FCCDBB27AB8FBE00BAA7F0 /* MediaControls.swift */; };
+		83120ACD289A2E0D008FE217 /* SpeechManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83120ACC289A2E0D008FE217 /* SpeechManager.swift */; };
 		83B9573927C9A1FA00A678FD /* CaptchaView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B9573827C9A1FA00A678FD /* CaptchaView.swift */; };
 		8806EF19248DBD7200E764C7 /* NotificationPermissionReminderMegaphone.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8806EF18248DBD7200E764C7 /* NotificationPermissionReminderMegaphone.swift */; };
 		8806EF1B248DBFC100E764C7 /* ContactPermissionReminderMegaphone.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8806EF1A248DBFC100E764C7 /* ContactPermissionReminderMegaphone.swift */; };
@@ -2161,6 +2162,7 @@
 		7BB1CB6F2D7841356BE367EA /* Pods-Signal.testable release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Signal.testable release.xcconfig"; path = "Pods/Target Support Files/Pods-Signal/Pods-Signal.testable release.xcconfig"; sourceTree = "<group>"; };
 		7C5EABE2C09180BC71C4E097 /* Pods-SignalShareExtension.app store release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SignalShareExtension.app store release.xcconfig"; path = "Pods/Target Support Files/Pods-SignalShareExtension/Pods-SignalShareExtension.app store release.xcconfig"; sourceTree = "<group>"; };
 		7F3D23C799645E52E3BE5040 /* Pods-SignalUI.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SignalUI.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SignalUI/Pods-SignalUI.debug.xcconfig"; sourceTree = "<group>"; };
+		83120ACC289A2E0D008FE217 /* SpeechManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechManager.swift; sourceTree = "<group>"; };
 		83B9573827C9A1FA00A678FD /* CaptchaView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptchaView.swift; sourceTree = "<group>"; };
 		8806EF18248DBD7200E764C7 /* NotificationPermissionReminderMegaphone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPermissionReminderMegaphone.swift; sourceTree = "<group>"; };
 		8806EF1A248DBFC100E764C7 /* ContactPermissionReminderMegaphone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactPermissionReminderMegaphone.swift; sourceTree = "<group>"; };
@@ -4097,6 +4099,7 @@
 		76EB03C118170B33006006FC /* src */ = {
 			isa = PBXGroup;
 			children = (
+				83120ACB289A2DF1008FE217 /* Accessibility */,
 				76EB03C218170B33006006FC /* AppDelegate.h */,
 				76EB03C318170B33006006FC /* AppDelegate.m */,
 				F92074752888648A00B7F087 /* AppDelegate.swift */,
@@ -4187,6 +4190,14 @@
 			);
 			name = Views;
 			path = views;
+			sourceTree = "<group>";
+		};
+		83120ACB289A2DF1008FE217 /* Accessibility */ = {
+			isa = PBXGroup;
+			children = (
+				83120ACC289A2E0D008FE217 /* SpeechManager.swift */,
+			);
+			path = Accessibility;
 			sourceTree = "<group>";
 		};
 		8809CE8822F93C0D00D38867 /* Attachment Keyboard */ = {
@@ -6678,6 +6689,7 @@
 				347C3832252CE69400F3D941 /* CVCell.swift in Sources */,
 				32B2A434256CDC42001D66C7 /* GroupCallErrorView.swift in Sources */,
 				328EF3DC25782A6A00D5C31D /* GroupCallSwipeToastView.swift in Sources */,
+				83120ACD289A2E0D008FE217 /* SpeechManager.swift in Sources */,
 				346C19DF25ACDF0B00061D3A /* DataSettingsTableViewController.swift in Sources */,
 				88238EAF24EB798900F28079 /* ConversationViewController+GestureRecognizers.swift in Sources */,
 				3444E6BB264EDFF300B32E3B /* CVColorOrGradientView.swift in Sources */,

--- a/Signal/src/Accessibility/SpeechManager.swift
+++ b/Signal/src/Accessibility/SpeechManager.swift
@@ -1,0 +1,35 @@
+//
+//  Copyright (c) 2022 Open Whisper Systems. All rights reserved.
+//
+
+import Foundation
+import AVFAudio
+
+@objc
+public class SpeechManager: NSObject {
+    private let speechSynthesizer: AVSpeechSynthesizer
+
+    @objc
+    override init() {
+        speechSynthesizer = AVSpeechSynthesizer()
+
+        super.init()
+
+        SwiftSingletons.register(self)
+    }
+
+    @objc
+    public var isSpeaking: Bool {
+        speechSynthesizer.isSpeaking
+    }
+
+    @objc
+    public func speak(_ utterance: AVSpeechUtterance) {
+        speechSynthesizer.speak(utterance)
+    }
+
+    @objc
+    public func stop() {
+        speechSynthesizer.stopSpeaking(at: .immediate)
+    }
+}

--- a/Signal/src/Models/MessageActions.swift
+++ b/Signal/src/Models/MessageActions.swift
@@ -1,5 +1,5 @@
 //
-//  Copyright (c) 2021 Open Whisper Systems. All rights reserved.
+//  Copyright (c) 2022 Open Whisper Systems. All rights reserved.
 //
 
 import Foundation
@@ -11,6 +11,8 @@ protocol MessageActionsDelegate: AnyObject {
     func messageActionsForwardItem(_ itemViewModel: CVItemViewModelImpl)
     func messageActionsStartedSelect(initialItem itemViewModel: CVItemViewModelImpl)
     func messageActionsDeleteItem(_ itemViewModel: CVItemViewModelImpl)
+    func messageActionsSpeakItem(_ itemViewModel: CVItemViewModelImpl)
+    func messageActionsStopSpeakingItem(_ itemViewModel: CVItemViewModelImpl)
 }
 
 // MARK: -
@@ -93,6 +95,28 @@ struct MessageActionBuilder {
                                 delegate?.messageActionsStartedSelect(initialItem: itemViewModel)
         })
     }
+
+    static func speakMessage(itemViewModel: CVItemViewModelImpl, delegate: MessageActionsDelegate) -> MessageAction {
+        return MessageAction(.speak,
+                             accessibilityLabel: NSLocalizedString("MESSAGE_ACTION_SPEAK_MESSAGE", comment: "Action sheet accessibility label"),
+                             accessibilityIdentifier: UIView.accessibilityIdentifier(containerName: "message_action", name: "speak_message"),
+                             contextMenuTitle: NSLocalizedString("CONTEXT_MENU_SPEAK_MESSAGE", comment: "Context menu button title"),
+                             contextMenuAttributes: [],
+                             block: { [weak delegate] (_) in
+                                delegate?.messageActionsSpeakItem(itemViewModel)
+        })
+    }
+
+    static func stopSpeakingMessage(itemViewModel: CVItemViewModelImpl, delegate: MessageActionsDelegate) -> MessageAction {
+        return MessageAction(.stopSpeaking,
+                             accessibilityLabel: NSLocalizedString("MESSAGE_ACTION_STOP_SPEAKING_MESSAGE", comment: "Action sheet accessibility label"),
+                             accessibilityIdentifier: UIView.accessibilityIdentifier(containerName: "message_action", name: "stop_speaking_message"),
+                             contextMenuTitle: NSLocalizedString("CONTEXT_MENU_STOP_SPEAKING_MESSAGE", comment: "Context menu button title"),
+                             contextMenuAttributes: [],
+                             block: { [weak delegate] (_) in
+                                delegate?.messageActionsStopSpeakingItem(itemViewModel)
+        })
+    }
 }
 
 @objc
@@ -124,6 +148,18 @@ class MessageActions: NSObject {
 
         let selectAction = MessageActionBuilder.selectMessage(itemViewModel: itemViewModel, delegate: delegate)
         actions.append(selectAction)
+
+        if UIAccessibility.isSpeakSelectionEnabled {
+            let action: MessageAction = {
+                if self.speechManager.isSpeaking {
+                    return MessageActionBuilder.stopSpeakingMessage(itemViewModel: itemViewModel, delegate: delegate)
+                }
+
+                return MessageActionBuilder.speakMessage(itemViewModel: itemViewModel, delegate: delegate)
+            }()
+
+            actions.append(action)
+        }
 
         return actions
     }

--- a/Signal/src/ViewControllers/ConversationView/ConversationViewController+MessageActions.swift
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewController+MessageActions.swift
@@ -109,7 +109,17 @@ extension ConversationViewController: ContextMenuInteractionDelegate {
             var contextMenuActions: [ContextMenuAction] = []
             if let actions = self.collectionViewActiveContextMenuInteraction?.messageActions {
 
-                let actionOrder: [MessageAction.MessageActionType] = [.reply, .forward, .copy, .share, .select, .info, .delete]
+                let actionOrder: [MessageAction.MessageActionType] = [
+                    .reply,
+                    .forward,
+                    .copy,
+                    .share,
+                    .select,
+                    .speak,
+                    .stopSpeaking,
+                    .info,
+                    .delete
+                ]
 
                 for type in actionOrder {
                     let actionWithType = actions.first { $0.actionType == type }

--- a/Signal/src/ViewControllers/ConversationView/ConversationViewController+MessageActionsDelegate.swift
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewController+MessageActionsDelegate.swift
@@ -2,6 +2,8 @@
 //  Copyright (c) 2022 Open Whisper Systems. All rights reserved.
 //
 
+import AVFAudio
+
 extension ConversationViewController: MessageActionsDelegate {
     func messageActionsShowDetailsForItem(_ itemViewModel: CVItemViewModelImpl) {
         showDetailView(itemViewModel)
@@ -97,5 +99,26 @@ extension ConversationViewController: MessageActionsDelegate {
     func messageActionsDeleteItem(_ itemViewModel: CVItemViewModelImpl) {
         guard let message = itemViewModel.interaction as? TSMessage else { return }
         message.presentDeletionActionSheet(from: self)
+    }
+
+    func messageActionsSpeakItem(_ itemViewModel: CVItemViewModelImpl) {
+        guard let textValue = itemViewModel.displayableBodyText?.fullTextValue else {
+            return
+        }
+
+        let utterance: AVSpeechUtterance = {
+            switch textValue {
+            case .text(let text):
+                return AVSpeechUtterance(string: text)
+            case .attributedText(let attributedText):
+                return AVSpeechUtterance(attributedString: attributedText)
+            }
+        }()
+
+        self.speechManager.speak(utterance)
+    }
+
+    func messageActionsStopSpeakingItem(_ itemViewModel: CVItemViewModelImpl) {
+        self.speechManager.stop()
     }
 }

--- a/Signal/src/ViewControllers/MessageActionsToolbar.swift
+++ b/Signal/src/ViewControllers/MessageActionsToolbar.swift
@@ -20,6 +20,8 @@ public class MessageAction: NSObject {
         case share
         case forward
         case select
+        case speak
+        case stopSpeaking
     }
 
     let actionType: MessageActionType
@@ -55,6 +57,10 @@ public class MessageAction: NSObject {
             return Theme.iconImage(.messageActionForward)
         case .select:
             return Theme.iconImage(.contextMenuSelect)
+        case .speak:
+            return Theme.iconImage(.speakerButton)
+        case .stopSpeaking:
+            return Theme.iconImage(.stopButton)
         }
     }
 }

--- a/Signal/src/environment/AppEnvironment.swift
+++ b/Signal/src/environment/AppEnvironment.swift
@@ -57,6 +57,9 @@ public class AppEnvironment: NSObject {
     let cvAudioPlayerRef = CVAudioPlayer()
 
     @objc
+    let speechManagerRef = SpeechManager()
+
+    @objc
     public var windowManagerRef: OWSWindowManager = OWSWindowManager()
 
     private override init() {

--- a/Signal/src/util/Dependencies+MainApp.swift
+++ b/Signal/src/util/Dependencies+MainApp.swift
@@ -74,6 +74,14 @@ public extension NSObject {
         AppEnvironment.shared.cvAudioPlayerRef
     }
 
+    final var speechManager: SpeechManager {
+        AppEnvironment.shared.speechManagerRef
+    }
+
+    static var speechManager: SpeechManager {
+        AppEnvironment.shared.speechManagerRef
+    }
+
     final var deviceSleepManager: DeviceSleepManager {
         .shared
     }

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -1163,6 +1163,12 @@
 "CONTEXT_MENU_SELECT_MESSAGE" = "Select";
 
 /* Context menu button title */
+"CONTEXT_MENU_SPEAK_MESSAGE" = "Speak";
+
+/* Context menu button title */
+"CONTEXT_MENU_STOP_SPEAKING_MESSAGE" = "Stop";
+
+/* Context menu button title */
 "CONTEXT_MENU_SHARE_MEDIA" = "Share";
 
 /* Message for the 'conversation delete confirmation' alert. */
@@ -3390,6 +3396,12 @@
 
 /* Action sheet accessibility label */
 "MESSAGE_ACTION_SELECT_MESSAGE" = "Select Multiple";
+
+/* Action sheet accessibility label */
+"MESSAGE_ACTION_SPEAK_MESSAGE" = "Speak Message";
+
+/* Action sheet accessibility label */
+"MESSAGE_ACTION_STOP_SPEAKING_MESSAGE" = "Stop Speaking Message";
 
 /* Action sheet button title */
 "MESSAGE_ACTION_SHARE_MEDIA" = "Share Media";

--- a/SignalUI/Appearance/Theme+OWS.swift
+++ b/SignalUI/Appearance/Theme+OWS.swift
@@ -55,6 +55,8 @@ public enum ThemeIcon: UInt {
     case stickerButton
     case cameraButton
     case micButton
+    case speakerButton
+    case stopButton
 
     case attachmentCamera
     case attachmentContact
@@ -293,6 +295,11 @@ public extension Theme {
             return isDarkThemeEnabled ? "camera-solid-24" : "camera-outline-24"
         case .micButton:
             return isDarkThemeEnabled ? "mic-solid-24" : "mic-outline-24"
+        case .speakerButton:
+            return "speaker-solid-28" // TODO: Add outline for dark theme or select another asset.
+        case .stopButton:
+            return "pause-filled-24" // TODO: Use correct asset
+
         case .attachmentCamera:
             return "camera-outline-32"
         case .attachmentContact:


### PR DESCRIPTION
### Contributor checklist
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [ ] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 11 Pro, iOS 15.6
 * iPhone 13 Pro Simulator, iOS 15.5

- - - - - - - - - -

### Description

This feature was requested on the Signal Community forum [here](https://community.signalusers.org/t/option-to-speak-messages/27113/).

This PR adds support for the Spoken Content accessibility feature (Settings > Accessibility > Spoken Content, toggle on Speak Selection). Once this feature is enabled, message bubbles on iMessage (WhatsApp too) support speaking out the text inside a selected bubble. This is useful for many people including those with visual impairments but don't use VoiceOver and those with dyslexia.

I attempted to replicate the user experience on iMessage with the "Stop" feature (on iMessage, it's called "Pause" but it behaves more like a stop button, hence the change in name).

| iMessage (existing)  | Signal (new) |
| ------------- | ------------- |
| <video src="https://user-images.githubusercontent.com/450030/182534529-fa66db86-d241-452f-81ed-3014e0c5d672.mp4">  | <video src="https://user-images.githubusercontent.com/450030/182534566-de3a8b0f-ac5b-4b57-a2c2-edbcef1951c4.mp4">  |
