### PR TITLE
Add accessibilityLabel to items in PhotoLibrary

### DIFF
--- a/Signal/src/ViewControllers/Attachment Keyboard/RecentPhotoCollectionView.swift
+++ b/Signal/src/ViewControllers/Attachment Keyboard/RecentPhotoCollectionView.swift
@@ -338,8 +338,8 @@ class RecentPhotoCell: UICollectionViewCell {
         contentTypeBadgeView?.sizeToFit()
     }
 
-    private func setMedia(duration: TimeInterval) {
-        guard duration > 0 else {
+    private func setMedia(itemType: PhotoGridItemType) {
+        guard case .video(let duration) = itemType else {
             durationLabel?.isHidden = true
             durationLabelBackground?.isHidden = true
             return
@@ -396,7 +396,7 @@ class RecentPhotoCell: UICollectionViewCell {
             self.image = image
         }
 
-        setMedia(duration: item.duration)
+        setMedia(itemType: item.type)
 
         switch item.type {
         case .animated:

--- a/Signal/src/ViewControllers/MediaGallery/MediaTileViewController.swift
+++ b/Signal/src/ViewControllers/MediaGallery/MediaTileViewController.swift
@@ -898,17 +898,12 @@ class GalleryGridCellItem: PhotoGridItem {
 
     var type: PhotoGridItemType {
         if galleryItem.isVideo {
-            return .video
+            return .video(0) // TODO: return video duration
         } else if galleryItem.isAnimated {
             return .animated
         } else {
             return .photo
         }
-    }
-
-    var duration: TimeInterval {
-        // TODO: return video duration
-        0
     }
 
     func asyncThumbnail(completion: @escaping (UIImage?) -> Void) -> UIImage? {

--- a/Signal/src/ViewControllers/MediaGallery/MediaTileViewController.swift
+++ b/Signal/src/ViewControllers/MediaGallery/MediaTileViewController.swift
@@ -906,6 +906,8 @@ class GalleryGridCellItem: PhotoGridItem {
         }
     }
 
+    var creationDate: Date? { nil }
+
     func asyncThumbnail(completion: @escaping (UIImage?) -> Void) -> UIImage? {
         return galleryItem.thumbnailImage(async: completion)
     }

--- a/Signal/src/ViewControllers/Photos/PhotoLibrary.swift
+++ b/Signal/src/ViewControllers/Photos/PhotoLibrary.swift
@@ -46,6 +46,8 @@ class PhotoPickerAssetItem: PhotoGridItem {
         }
     }
 
+    var creationDate: Date? { asset.creationDate }
+
     func asyncThumbnail(completion: @escaping (UIImage?) -> Void) -> UIImage? {
         var syncImageResult: UIImage?
         var hasLoadedImage = false

--- a/Signal/src/ViewControllers/Photos/PhotoLibrary.swift
+++ b/Signal/src/ViewControllers/Photos/PhotoLibrary.swift
@@ -38,17 +38,12 @@ class PhotoPickerAssetItem: PhotoGridItem {
 
     var type: PhotoGridItemType {
         if asset.mediaType == .video {
-            return .video
+            return .video(asset.duration)
         } else if asset.playbackStyle == .imageAnimated {
             return .animated
         } else {
             return .photo
         }
-    }
-
-    var duration: TimeInterval {
-        guard asset.mediaType == .video else { return 0 }
-        return asset.duration
     }
 
     func asyncThumbnail(completion: @escaping (UIImage?) -> Void) -> UIImage? {

--- a/Signal/src/views/PhotoGridViewCell.swift
+++ b/Signal/src/views/PhotoGridViewCell.swift
@@ -5,15 +5,27 @@
 import SignalUI
 import UIKit
 
-public enum PhotoGridItemType {
+public enum PhotoGridItemType: Equatable {
     case photo
     case animated
     case video(TimeInterval)
+
+    var localizedString: String {
+        switch self {
+        case .photo:
+            return CommonStrings.attachmentTypePhoto
+        case .animated:
+            return CommonStrings.attachmentTypeAnimated
+        case .video(let duration):
+            return "\(CommonStrings.attachmentTypeVideo) \(OWSFormat.localizedDurationString(from: duration))"
+        }
+    }
 }
 
 public protocol PhotoGridItem: AnyObject {
     var type: PhotoGridItemType { get }
     func asyncThumbnail(completion: @escaping (UIImage?) -> Void) -> UIImage?
+    var creationDate: Date? { get }
 }
 
 public class PhotoGridViewCell: UICollectionViewCell {
@@ -36,6 +48,29 @@ public class PhotoGridViewCell: UICollectionViewCell {
     private static let animatedBadgeImage = #imageLiteral(resourceName: "ic_gallery_badge_gif")
     private static let selectedBadgeImage = UIImage(named: "media-composer-checkmark")
     public var loadingColor = Theme.washColor
+
+    private lazy var todayTimeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = .current
+        formatter.dateStyle = .none
+        formatter.timeStyle = .short
+        return formatter
+    }()
+
+    private lazy var thisYearDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = .current
+        formatter.setLocalizedDateFormatFromTemplate("MMMMd")
+        return formatter
+    }()
+
+    private lazy var longDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = .current
+        formatter.dateStyle = .long
+        formatter.timeStyle = .none
+        return formatter
+    }()
 
     override public var isSelected: Bool {
         didSet {
@@ -219,6 +254,17 @@ public class PhotoGridViewCell: UICollectionViewCell {
         durationLabel.sizeToFit()
     }
 
+    private func setUpAccessibility(item: PhotoGridItem) {
+        self.isAccessibilityElement = true
+
+        self.accessibilityLabel = [
+            item.type.localizedString,
+            formattedDateString(for: item.creationDate)
+        ]
+            .compactMap { $0 }
+            .joined(separator: ", ")
+    }
+
     public func configure(item: PhotoGridItem) {
         self.item = item
 
@@ -245,6 +291,7 @@ public class PhotoGridViewCell: UICollectionViewCell {
         }
 
         setMedia(itemType: item.type)
+        setUpAccessibility(item: item)
 
         switch item.type {
         case .animated:
@@ -266,5 +313,22 @@ public class PhotoGridViewCell: UICollectionViewCell {
         selectedMaskView.isHidden = true
         selectedBadgeView.isHidden = true
         outlineBadgeView.isHidden = true
+    }
+
+    private func formattedDateString(for date: Date?) -> String? {
+        guard let date = date else { return nil }
+
+        let dateIsThisYear = DateUtil.dateIsThisYear(date)
+        let dateIsToday = DateUtil.dateIsToday(date)
+
+        if dateIsToday {
+            return todayTimeFormatter.string(from: date)
+        }
+
+        if dateIsThisYear {
+            return thisYearDateFormatter.string(from: date)
+        }
+
+        return longDateFormatter.string(from: date)
     }
 }

--- a/Signal/src/views/PhotoGridViewCell.swift
+++ b/Signal/src/views/PhotoGridViewCell.swift
@@ -6,12 +6,13 @@ import SignalUI
 import UIKit
 
 public enum PhotoGridItemType {
-    case photo, animated, video
+    case photo
+    case animated
+    case video(TimeInterval)
 }
 
 public protocol PhotoGridItem: AnyObject {
     var type: PhotoGridItemType { get }
-    var duration: TimeInterval { get } // proxy to PHAsset.duration, always 0 for non-movie assets
     func asyncThumbnail(completion: @escaping (UIImage?) -> Void) -> UIImage?
 }
 
@@ -168,8 +169,8 @@ public class PhotoGridViewCell: UICollectionViewCell {
         contentTypeBadgeView?.sizeToFit()
     }
 
-    private func setMedia(duration: TimeInterval) {
-        guard duration > 0 else {
+    private func setMedia(itemType: PhotoGridItemType) {
+        guard case .video(let duration) = itemType else {
             durationLabel?.isHidden = true
             durationLabelBackground?.isHidden = true
             return
@@ -243,7 +244,7 @@ public class PhotoGridViewCell: UICollectionViewCell {
             self.image = image
         }
 
-        setMedia(duration: item.duration)
+        setMedia(itemType: item.type)
 
         switch item.type {
         case .animated:

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -313,6 +313,9 @@
 /* Short text label for a video attachment, used for thread preview and on the lock screen */
 "ATTACHMENT_TYPE_VIDEO" = "Video";
 
+/* Short text label for an animated attachment, used for thread preview and on the lock screen */
+"ATTACHMENT_TYPE_ANIMATED" = "Animated";
+
 /* Short text label for a voice message attachment, used for thread preview and on the lock screen */
 "ATTACHMENT_TYPE_VOICE_MESSAGE" = "Voice Message";
 

--- a/SignalMessaging/utils/CommonStrings.swift
+++ b/SignalMessaging/utils/CommonStrings.swift
@@ -266,6 +266,12 @@ public class CommonStrings: NSObject {
     }
 
     @objc
+    static public var attachmentTypeAnimated: String {
+        OWSLocalizedString("ATTACHMENT_TYPE_ANIMATED",
+                          comment: "Short text label for an animated attachment, used for thread preview and on the lock screen")
+    }
+
+    @objc
     static public var searchBarPlaceholder: String {
         OWSLocalizedString("INVITE_FRIENDS_PICKER_SEARCHBAR_PLACEHOLDER", comment: "Search")
     }


### PR DESCRIPTION
## Contributor checklist
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 13 Pro Simulator, iOS 15.5

- - - - - - - - - -

## Description

The media gallery was not accessible to a VoiceOver user previously. This PR surfaces basic information about a media item such as its type (Photo, Video, Animated) and creation date. The logic used for the creation date mimics the behaviour of the default Photos app.

### Before (notice how none of the items in the gallery have any accessibility information)
<img width="1446" alt="Before" src="https://user-images.githubusercontent.com/450030/183232956-e89be03b-58e8-4999-ba14-660ee16a0523.png">

### After
<img width="1446" alt="After" src="https://user-images.githubusercontent.com/450030/183233009-7e13c320-80d6-431e-9652-89a689145c01.png">



