### PR TITLE
Improved README and BUILDING documentation

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -25,6 +25,20 @@ You can then add the Signal repo to sync with upstream changes:
 git remote add upstream https://github.com/signalapp/Signal-iOS
 ```
 
+Another way to clone the repo is by using Xcode:
+
+When first opening Xcode choose the 'Clone an existing project' option
+
+![Signal Message](https://drive.google.com/uc?export=view&id=1nH6Yp-9h_aEd1N82Jv2vZhvGmCXJbnKf =400x350)
+
+Then, paste the repo's GitHub link (https://github.com/signalapp/Signal-iOS.git) into the navigation bar on the popup window and click the 'Clone' button on the bottom right corner
+
+![Signal Message](https://drive.google.com/uc?export=view&id=1kvi4hUiCVKAWzoIYJ8hI4T1X3UgUfsAk =500x320)
+
+Finally, choose which branch to check out and hit the 'Clone' button
+
+![Signal Message](https://drive.google.com/uc?export=view&id=1VXq34OFxEGE5Fm4K7ZjLDvhlVgateuD9 =500x310)
+
 ## 2. Dependencies
 
 To build and configure the libraries Signal uses, just run:
@@ -33,10 +47,12 @@ To build and configure the libraries Signal uses, just run:
 make dependencies
 ```
 
+Make sure to run this command within the working directory where you cloned the repo.
+
 ### Building RingRTC
 
 A prebuilt version of WebRTC.framework and the libringrtc static library reside
-in a sub-module and should be installed by the above steps.  However, if you'd 
+in a sub-module and should be installed by the above steps. However, if you'd
 like to build it from source, see: https://github.com/signalapp/ringrtc
 
 ## 3. Xcode
@@ -48,14 +64,14 @@ open Signal.xcworkspace
 ```
 
 In the TARGETS area of the General tab, change the Team drop down to
-your own. You will need to do that for all the listed targets, for ex. 
+your own. You will need to do that for all the listed targets, for ex.
 Signal, SignalShareExtension, and SignalMessaging. You will need an Apple
-Developer account for this. 
+Developer account for this.
 
 On the Capabilities tab, turn off Push Notifications and Data Protection,
 while keeping Background Modes on. The App Groups capability will need to
 remain on in order to access the shared data storage. The App ID needs to
-match the `applicationGroup` string set (both Production and Staging) in TSConstants.swift. 
+match the `applicationGroup` string set (both Production and Staging) in TSConstants.swift.
 
 If you wish to test the Documents API, the iCloud capability will need to
 be on with the iCloud Documents option selected.
@@ -72,4 +88,3 @@ certificate.
 Turn on Push Notifications on the Capabilities tab if you want to register a new Signal account using the application installed via XCode.
 
 If you have any other issues, please ask on the [community forum](https://whispersystems.discoursehosting.net/).
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,22 @@
 # Signal iOS
 
-Signal is a free, open source, messaging app for simple private communication with friends. 
+![Signal Logo](https://upload.wikimedia.org/wikipedia/commons/8/8d/Signal-Logo.svg =200x200)
+
+# Description
+
+Signal is a free, open source, messaging and video/voice calling app for simple private communication with friends and family.
+
+With Signal users are able to send and receive messages and calls that are protected by end-to-end encryption.
+
+Here are some sample screenshots of the Signal app interface during messaging and calling.
+
+![Signal Message](https://drive.google.com/uc?export=view&id=1kYzXU1qjEr3MDOXJ4C7g__6d1cO6lbA7 =200x450)
+Users are able to send instant messages including images, GIFs, files, payments, contact, location, and voicenotes quickly and reliably, even over slow networks.
+
+![Signal Voice Call](https://drive.google.com/uc?export=view&id=1VtWBURfLyCVzE_ipvzvw0Yee2sPkOgxT =200x450) ![Signal Video Call](https://drive.google.com/uc?export=view&id=1O_otJOZqtbho-mE1RQcK_ecs2AzygiC5 =200x450)
+Users are able to make phone/video calls using their existing phone number and address book to communicate with others.
+
+## Download Signal
 
 [![Available on the App Store](http://cl.ly/WouG/Download_on_the_App_Store_Badge_US-UK_135x40.svg)](https://apps.apple.com/app/id874139669)
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iDevice A, iOS X.Y.Z
 * iDevice B, iOS Z.Y

- - - - - - - - - -

### Description
<!--
In this contribution, a better description of the Signal app was added to the existing README file. This new description includes other functionalities that the Signal app provides, such as video and voice calls which were not mentioned prior to the pull request. Another contribution to the README file were screenshots of the Signal app showing the messaging, voice, and video calling functionalities mentioned in the description. Under these images there are more details explaining the images as well as extra functionalities and features of the Signal app. In the existing BUILDING file that explains how to build/clone the repo I also made some contributions giving an alternative way to clone the repo using Xcode’s ‘Clone existing project’ option. In this contribution I included detailed instructions along with screenshots for the reader to follow and successfully clone the repo. Finally, in the BUILDING file I added one more clarification under the Dependencies section to make sure there is no confusion when building and configuring the dependencies. 
Tested using StackEdit to make sure it looked right
-->
