### PR TITLE
Bug fix: Stale thread selection in ChatListViewController

### DIFF
--- a/Signal/src/ViewControllers/HomeView/Chat List/ChatListViewController+Actions.swift
+++ b/Signal/src/ViewControllers/HomeView/Chat List/ChatListViewController+Actions.swift
@@ -21,7 +21,6 @@ extension ChatListViewController {
         if let previousIndexPath = renderState.indexPath(beforeThread: currentThread),
            let thread = self.thread(forIndexPath: previousIndexPath) {
             self.present(thread, action: .compose, animated: true)
-            tableView.selectRow(at: previousIndexPath, animated: true, scrollPosition: .none)
         }
     }
 
@@ -40,7 +39,6 @@ extension ChatListViewController {
         if let nextIndexPath = renderState.indexPath(afterThread: currentThread),
            let thread = self.thread(forIndexPath: nextIndexPath) {
             self.present(thread, action: .compose, animated: true)
-            tableView.selectRow(at: nextIndexPath, animated: true, scrollPosition: .none)
         }
     }
 }

--- a/Signal/src/ViewControllers/HomeView/Chat List/ChatListViewController+Helpers.swift
+++ b/Signal/src/ViewControllers/HomeView/Chat List/ChatListViewController+Helpers.swift
@@ -145,8 +145,6 @@ public extension ChatListViewController {
             owsFailDebug("Missing threadViewModel.")
             return nil
         }
-        self.lastViewedThread = threadViewModel.threadRecord
-
         let vc = ConversationViewController(threadViewModel: threadViewModel,
                                             action: .none,
                                             focusMessageId: nil)

--- a/Signal/src/ViewControllers/HomeView/Chat List/ChatListViewController.h
+++ b/Signal/src/ViewControllers/HomeView/Chat List/ChatListViewController.h
@@ -28,7 +28,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)unarchiveSelectedConversation;
 
 @property (nonatomic, readonly) CLVViewState *viewState;
-@property (nonatomic) TSThread *lastViewedThread;
+
+/// Used to update the selected cell for split view and maintain scroll positions for reappearing collapsed views.
+- (void)updateLastViewedThread:(TSThread *)thread animated:(BOOL)animated;
 
 // For use by Swift extension.
 - (void)updateBarButtonItems;

--- a/Signal/src/ViewControllers/HomeView/Chat List/ChatListViewController.m
+++ b/Signal/src/ViewControllers/HomeView/Chat List/ChatListViewController.m
@@ -52,6 +52,8 @@ NSString *const kArchiveButtonPseudoGroup = @"kArchiveButtonPseudoGroup";
 
 @property (nonatomic) BOOL hasEverPresentedExperienceUpgrade;
 
+@property (nonatomic, nullable) TSThread *lastViewedThread;
+
 @end
 
 #pragma mark -
@@ -693,6 +695,12 @@ NSString *const kArchiveButtonPseudoGroup = @"kArchiveButtonPseudoGroup";
     self.isViewVisible = NO;
 
     [self.searchResultsController viewWillDisappear:animated];
+}
+
+- (void)updateLastViewedThread:(TSThread *)thread animated:(BOOL)animated
+{
+    self.lastViewedThread = thread;
+    [self ensureSelectedThread:thread animated:animated];
 }
 
 #pragma mark -

--- a/Signal/src/ViewControllers/HomeView/Chat List/ChatListViewController.swift
+++ b/Signal/src/ViewControllers/HomeView/Chat List/ChatListViewController.swift
@@ -497,7 +497,7 @@ public extension ChatListViewController {
         presentFormSheet(navigationController, animated: true, completion: completion)
     }
 
-    /// Verifies that the currently selected cell matches the provided thread's uniqueId.
+    /// Verifies that the currently selected cell matches the provided thread.
     /// If it does or if the user's in multi-select: Do nothing.
     /// If it doesn't: Select the first cell matching the provided thread, if one exists. Otherwise, deselect the current row.
     @objc

--- a/Signal/src/ViewControllers/HomeView/Chat List/ChatListViewController.swift
+++ b/Signal/src/ViewControllers/HomeView/Chat List/ChatListViewController.swift
@@ -510,7 +510,7 @@ public extension ChatListViewController {
         }
 
         let currentlySelectedThread = currentSelection.first.flatMap {
-            self.tableDataSource.thread(forIndexPath: $0)
+            self.tableDataSource.thread(forIndexPath: $0, expectsSuccess: false)
         }
 
         if currentlySelectedThread?.uniqueId != targetThread.uniqueId {

--- a/Signal/src/ViewControllers/HomeView/Chat List/ChatListViewController.swift
+++ b/Signal/src/ViewControllers/HomeView/Chat List/ChatListViewController.swift
@@ -496,6 +496,21 @@ public extension ChatListViewController {
         navigationController.setViewControllers(viewControllers, animated: false)
         presentFormSheet(navigationController, animated: true, completion: completion)
     }
+
+    /// Verifies that the currently selected cell matches the provided thread's uniqueId.
+    /// If it does: Do nothing.
+    /// If it doesn't: Select the first cell matching the provided thread, if one exists.
+    func ensureSelectedThread(_ targetThread: TSThread, animated: Bool) {
+        let currentSelection = tableView.indexPathsForSelectedRows ?? []
+        let isThreadCurrentlySelected = currentSelection.lazy
+            .map { self.tableDataSource.thread(forIndexPath: $0) }
+            .contains { $0?.uniqueId == targetThread.uniqueId }
+
+        if !isThreadCurrentlySelected,
+           let targetPath = tableDataSource.renderState.indexPath(forUniqueId: targetThread.uniqueId) {
+            tableView.selectRow(at: targetPath, animated: animated, scrollPosition: .none)
+        }
+    }
 }
 
 extension ChatListViewController: BadgeExpirationSheetDelegate {

--- a/Signal/src/ViewControllers/HomeView/ConversationSplitViewController.swift
+++ b/Signal/src/ViewControllers/HomeView/ConversationSplitViewController.swift
@@ -175,6 +175,7 @@ class ConversationSplitViewController: UISplitViewController, ConversationSplit 
         // Update the last viewed thread on the conversation list so it
         // can maintain its scroll position when navigating back.
         homeVC.chatListViewController.lastViewedThread = thread
+        homeVC.chatListViewController.ensureSelectedThread(thread, animated: animated)
 
         let threadViewModel = databaseStorage.read {
             return ThreadViewModel(thread: thread,

--- a/Signal/src/ViewControllers/HomeView/ConversationSplitViewController.swift
+++ b/Signal/src/ViewControllers/HomeView/ConversationSplitViewController.swift
@@ -174,8 +174,7 @@ class ConversationSplitViewController: UISplitViewController, ConversationSplit 
 
         // Update the last viewed thread on the conversation list so it
         // can maintain its scroll position when navigating back.
-        homeVC.chatListViewController.lastViewedThread = thread
-        homeVC.chatListViewController.ensureSelectedThread(thread, animated: animated)
+        homeVC.chatListViewController.updateLastViewedThread(thread, animated: animated)
 
         let threadViewModel = databaseStorage.read {
             return ThreadViewModel(thread: thread,


### PR DESCRIPTION
~Branched off of existing PR #5423. Relevant changes start with 25d8f76d39bd97f141757faef292947e57fce18e~
Rebased off main as of 10/5/22

This change corrects an issue where presented threads may not update the selected thread in a split view. See the following video for a couple of examples:

https://user-images.githubusercontent.com/3432567/189549645-8eaf07ef-144a-4078-83c9-5c130d6963fc.mov

After this change:

https://user-images.githubusercontent.com/3432567/189549659-48715760-a43a-4cab-8312-e30d96824787.mov

### Implementation Details

When updating the DetailVC, the split view will notify the ChatListVC to update its selection for the newly presented thread. More details in the commit messages.

It's worth noting that `CLVTableDataSource.buildConversationCell(tableView:indexPath:)` will also update the table's selection when building a cell if it observes that the SplitView's selected thread matches the cell currently being built. One alternative approach could be for the SplitView to dirty the selected cell to force the ChatList to rebuild this cell and force a selection update.

I think a great future direction (not included in this change) would be for the ChatList to automatically reconfigure its mode based on the selected thread. If the user opens an archived thread, should the ChatList automatically switch to archived view? When searching threads, should selections persist themselves? (They don't currently, see the first line of `ConversationSearchViewController.tableView(_:didSelectRowAt:)`)

### Testing Details
I've only tested on iOS 15 since that's all of the devices I have available to me. I've tested my changes both when the split view is collapsed and expanded. I've tested conversation presentation from the ChatList inbox, archive, and search modes. I've also tested conversation presentation originating from outside the ChatList, such as notification handlers and contact sheets.