### PR TITLE
Fix truncated group descriptions if they contain multiple new lines

### DIFF
--- a/Signal/src/views/GroupDescriptionPreviewView.swift
+++ b/Signal/src/views/GroupDescriptionPreviewView.swift
@@ -102,7 +102,27 @@ class GroupDescriptionPreviewView: ManualLayoutView {
 
         setTextThatFits(textThatFits)
         var visibleCharacterRangeUpperBound = textView.visibleTextRange.upperBound
-
+        
+        
+        // Check if the line count exceeds the number if lines in the
+        // configuration.
+        let lineCount = textThatFits.filter { $0 == "\n" }.count + 1
+        
+        // If that is the case, we find the first offending new line,
+        // and truncate there.
+        if lineCount > numberOfLines {
+            var lines = textThatFits.components(separatedBy: "\n")
+            lines.removeSubrange(numberOfLines ... lines.count-1)
+            let joined = lines.joined(separator: "\n")
+            
+            if let firstIndex = joined.firstIndex(of: "\n") {
+                let intIndex = joined.distance(from: joined.startIndex, to: firstIndex)
+                visibleCharacterRangeUpperBound = intIndex
+            } else {
+                visibleCharacterRangeUpperBound = joined.count
+            }
+        }
+        
         // Check if we're displaying less than the full length of the description
         // text. If so, we will manually truncate and add a "more" button to view
         // the full description.
@@ -111,7 +131,7 @@ class GroupDescriptionPreviewView: ManualLayoutView {
         // We might fit without further truncation, for example if the description
         // contains new line characters, so set the possible new text immediately.
         textThatFits = textThatFits.substring(to: visibleCharacterRangeUpperBound)
-
+        
         setTextThatFits(textThatFits)
         visibleCharacterRangeUpperBound
             = textView.visibleTextRange.upperBound - Self.moreTextPlusPrefixLength
@@ -139,6 +159,7 @@ class GroupDescriptionPreviewView: ManualLayoutView {
     }
 
     func setTextThatFits(_ textThatFits: String) {
+        NSLog("Setting text:" + textThatFits)
         if textThatFits == descriptionText {
             textView.dataDetectorTypes = .all
             textView.linkTextAttributes = [


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] My commits are rebased on the latest main branch
- [X] My commits are in nice logical chunks
- [X] My contribution is fully baked and is ready to be merged as is
- [X] I have tested my contribution on these devices:
 * iPhone 12 mini, iOS 16.0
 * iPhone 14 Pro Max iOS 16.0

- - - - - - - - - -

### Description

This PR fixes an issue where multiple new lines in a group's description cause the description size to be calculated wrongly, and the "More..." link won't show. The single commit in this PR solves this issue by checking if there are more lines in the description than the description label allows, and truncates the description appropriately, so the "More..." link is shown correctly.