### PR TITLE
Lower AAC bitrate for voice message from 128 to 48 kbps

### DIFF
--- a/SignalUI/ViewModels/VoiceMessageModel.swift
+++ b/SignalUI/ViewModels/VoiceMessageModel.swift
@@ -131,7 +131,7 @@ public class VoiceMessageModel: NSObject {
                     AVFormatIDKey: kAudioFormatMPEG4AAC,
                     AVSampleRateKey: 44100,
                     AVNumberOfChannelsKey: 2,
-                    AVEncoderBitRateKey: 128 * 1024
+                    AVEncoderBitRateKey: 48 * 1024
                 ]
             )
             self.audioRecorder = audioRecorder


### PR DESCRIPTION
Good enough quality and less space/network used.

Initial intent is be consistent with Android (~36kbps), but as this seems to be stereo, give it a little more, so 48kbps. This quick change would lower storage usage by a factor > 2.6. Setting it to mono with even lower bitrate can also be an option.

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] My commits are rebased on the latest main branch
- [X] My commits are in nice logical chunks
- [X] My contribution is fully baked and is ready to be merged as is
- [ ] I have tested my contribution on these devices: => tiny change, to illustrate the issue.
 * iDevice A, iOS X.Y.Z
 * iDevice B, iOS Z.Y

- - - - - - - - - -

### Description

This contributes to #5440 which aims at lowering the bitrate used by voice messages Signal (and provide more consistency between platforms). That would end up in using less storage and network resources.