### PR TITLE
Fix shared proxy URL format

### DIFF
--- a/Signal/src/ViewControllers/AppSettings/Privacy/ProxySettingsViewController.swift
+++ b/Signal/src/ViewControllers/AppSettings/Privacy/ProxySettingsViewController.swift
@@ -139,7 +139,7 @@ class ProxySettingsViewController: OWSTableViewController2, OWSNavigationView {
             actionBlock: { [weak self] in
                 guard let self = self else { return }
                 guard !self.notifyForInvalidHostIfNecessary() else { return }
-                AttachmentSharing.showShareUI(for: URL(string: "https://signal.tube#\(self.host ?? "")")!, sender: self.view)
+                AttachmentSharing.showShareUI(for: URL(string: "https://signal.tube/#\(self.host ?? "")")!, sender: self.view)
             }
         ))
         contents.addSection(shareSection)


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [ ] I have tested my contribution on these devices:
 * iDevice A, iOS X.Y.Z
 * iDevice B, iOS Z.Y

- - - - - - - - - -

### Description

Sharing proxy settings using the built-in share functionality leads to invalid URL format according to https://signal.org/blog/run-a-proxy/.

It generates URLs like

`https://signal.tube#some.proxyaddre.es`
instead of
`https://signal.tube/#some.proxyaddre.es`

Mind the missing `/` before `#` character.

The invalid format is working on iOS but not on Android. Android interpretes the `#` has a separator leading to two separated URLs `https://signal.tube` and `some.proxyaddre.es`.
