### PR TITLE
A handful of fixes for ConversationView gesture recognizers

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/CV/CVComponents/CVComponentMessage.swift
+++ b/Signal/src/ViewControllers/ConversationView/CV/CVComponents/CVComponentMessage.swift
@@ -2079,11 +2079,13 @@ public class CVComponentMessage: CVComponentBase, CVRootComponent {
                                                            renderItem: renderItem,
                                                            messageSwipeActionState: messageSwipeActionState) {
             return panHandler
+        } else if componentView.contentViewSwipeToReplyWrapper.containsGestureLocation(sender) {
+            return CVPanHandler(delegate: componentDelegate,
+                                panType: .messageSwipeAction,
+                                renderItem: renderItem)
+        } else {
+            return nil
         }
-
-        return CVPanHandler(delegate: componentDelegate,
-                            panType: .messageSwipeAction,
-                            renderItem: renderItem)
     }
 
     public override func startPanGesture(sender: UIPanGestureRecognizer,

--- a/Signal/src/ViewControllers/ConversationView/Cells/AudioMessageView.swift
+++ b/Signal/src/ViewControllers/ConversationView/Cells/AudioMessageView.swift
@@ -426,7 +426,7 @@ class AudioMessageView: ManualStackView {
         }
 
         let locationInSlider = convert(point, to: waveformProgress)
-        return locationInSlider.x >= 0 && locationInSlider.x <= waveformProgress.width
+        return waveformProgress.bounds.contains(locationInSlider)
     }
 
     func progressForLocation(_ point: CGPoint) -> CGFloat {

--- a/Signal/src/ViewControllers/HomeView/ConversationSplitViewController.swift
+++ b/Signal/src/ViewControllers/HomeView/ConversationSplitViewController.swift
@@ -66,6 +66,7 @@ class ConversationSplitViewController: UISplitViewController, ConversationSplit 
         viewControllers = [homeVC, detailPlaceholderVC]
 
         chatListNavController.delegate = self
+        detailNavController.delegate = self
         delegate = self
         preferredDisplayMode = .allVisible
 
@@ -572,6 +573,7 @@ extension ConversationSplitViewController: UISplitViewControllerDelegate {
         // some strange behavior around the title view + input accessory view.
         // TODO iPad: Maybe investigate this further.
         detailNavController = OWSNavigationController()
+        detailNavController.delegate = self
         detailNavController.viewControllers = Array(allViewControllers[conversationVCIndex..<allViewControllers.count])
 
         return detailNavController


### PR DESCRIPTION
- Fixes an issue where swipe-to-reply was broken for trackpads. This is from a conflict between the UINavigationController's interactive pop gesture and the collection view's pan gesture recognizer.

  Traditionally, the interactive pop gesture requires an edge swipe from the left edge. With indirect input like a trackpad, UIKit will also activate this gesture recognizer with a two-finger swipe anywhere in the view controller.

  The result here is that any initial rightward swipe would be recgonized as a pop gesture instead of a swipe-to-reply gesture. Reversing the gesture recognizer failure ordering fixed this.

- Constrain the recognition area for the swipe-to-reply pan gesture to only the cell content that gets translated during the reply gesture. Now, when the user pans over a bubble, it activates the swipe-to-reply gesture. But when the user pans over blank space, it's a interpreted as a navigation stack pop.

- Fixes an issue where swiping to reply on an audio message was difficult. The vertical recognition area of the audio waveform was occupying the entirety of audio message view. Now, it only recognizes pans on the waveform itself.

- Fixes a UI glitch with the interactive MessageDetail transition that occurs on iPad. The DetailNavController in the split view wasn't setting the SplitViewController as its delegate like the ChatListNavController. This interrupted a delegation chain from the ConversationVC to the MessageDetailVC in the DetailNavController. This only occurred on iPad since the compact size class collapses everything down to only use the ChatListNavController which was always properly configured.
