### PR TITLE
Handle taps on outgoing messages being sent

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/CV/CVComponents/CVComponentMessage.swift
+++ b/Signal/src/ViewControllers/ConversationView/CV/CVComponents/CVComponentMessage.swift
@@ -1593,9 +1593,6 @@ public class CVComponentMessage: CVComponentBase, CVRootComponent {
                 return true
             case .pending:
                 componentDelegate.didTapPendingOutgoingMessage(outgoingMessage)
-            case .sending:
-                // Ignore taps on outgoing messages being sent.
-                return true
             default:
                 break
             }


### PR DESCRIPTION
In situations with unreliable/slow/no network connection taps on out going messages should be handled. This is so tapping on outgoing messages with replies still scroll back to the replied message

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 14 Pro simulator, iOS 16.1

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

The bug I'm wanting to fix is when tapping on an outgoing message (i.e. a message still being sent) that replies to an earlier message nothing happens. What I would expect to happen is when tapping on the message the conversation view scrolls back up to the message being replied to, the same behaviour present when tapping on a sent message that is replied to.

### Bug Video 
Not scrolling back when tapping on the outgoing message

https://user-images.githubusercontent.com/9101808/205613649-ab6edde4-4b89-491c-9a22-6dba2644501b.mp4


### Proposed Fix
Tapping on the outgoing message scrolls back to the message being replied to

https://user-images.githubusercontent.com/9101808/205613181-3213494b-51cb-42f9-b98a-d2ec4f0ae4de.mp4

