### PR TITLE
Add PHPickerViewController to Avatar Selection on iOS 14+

### DIFF
--- a/Signal/src/ViewControllers/Avatars/AvatarSettingsViewController.swift
+++ b/Signal/src/ViewControllers/Avatars/AvatarSettingsViewController.swift
@@ -506,7 +506,7 @@ extension AvatarSettingsViewController: UIImagePickerControllerDelegate, UINavig
 }
 
 extension AvatarSettingsViewController: PHPickerViewControllerDelegate {
-    
+
     @available(iOS 14.0, *)
     func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
 
@@ -526,9 +526,9 @@ extension AvatarSettingsViewController: PHPickerViewControllerDelegate {
                                     if asset.type == .photo {
                                         let options = PHAssetResourceRequestOptions()
                                         options.isNetworkAccessAllowed = true
-                                        PHAssetResourceManager.default().requestData(for: asset, options: options, dataReceivedHandler: { (data:Data) in
+                                        PHAssetResourceManager.default().requestData(for: asset, options: options, dataReceivedHandler: { (data: Data) in
                                             photoBuffer.append(data)
-                                        }, completionHandler: { (error:Error?) in
+                                        }, completionHandler: { (error: Error?) in
                                             guard let image = UIImage(data: photoBuffer as Data) else { return }
                                             let vc = CropScaleImageViewController(srcImage: image) { croppedImage in
                                                 let imageModel = self.databaseStorage.write { transaction in


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPad Mini 6th Generation, iOS 16.2

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->
Signal currently doesn't utilize `PHPickerViewController` introduced with iOS 14. One of the benefits of this new picker is improved control over access to your devices photos. With this new picker, you can still provide photos to Signal without giving Signal access to your photo library. Right now the best option for control over Photo Library access is "Select Photos", but then every time you have a new photo you want to add, you have to go in and add it to the list of approved photos. I have tested this new picker with Signal Photo Library permissions set to None, and was still able to update the avatar image.

Since this is an iOS 14+ only feature and the app's minimum target is iOS 12, I have retained the current behavior, but added this new behavior behind a `#available` check. Updated users can get the improved privacy benefits without breaking anything for users on older versions of iOS.

The `PHPickerViewController` for the Avatar image is currently set to accept images as well as Live Photos. If a user selects a Live Photo however, the app will just take the image portion of it and assign that to the avatar image.

Ideally `PHPickerViewController` could be utilized to send images and videos in conversations as well from the keyboard, which would enable Signal to not have to request Photo Library Access whatsoever. However, that would be a much larger undertaking to convert that over, so I decided to start with this and see what the sentiment around it was.