### PR TITLE
[warnings] Remove unused function definition

### DIFF
--- a/SignalServiceKit/src/Messages/MessageSender.m
+++ b/SignalServiceKit/src/Messages/MessageSender.m
@@ -52,16 +52,6 @@ NSString *NoSessionForTransientMessageException = @"NoSessionForTransientMessage
 
 const NSUInteger kOversizeTextMessageSizeThreshold = 2 * 1024;
 
-NSError *SSKEnsureError(NSError *_Nullable error, OWSErrorCode fallbackCode, NSString *fallbackErrorDescription)
-{
-    if (error) {
-        return error;
-    }
-    OWSCFailDebug(@"Using fallback error.");
-    // TODO: Audit all of the places this is called and replace with more specific errors.
-    return [OWSError withError:fallbackCode description:fallbackErrorDescription isRetryable:true];
-}
-
 #pragma mark -
 
 @implementation OWSOutgoingAttachmentInfo


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * Compiled on Xcode 14.2, removes warning
- - - - - - - - - -

### Description

It looks like the last invocation of SSKEnsureError was removed in [this commit](https://github.com/signalapp/Signal-iOS/commit/590c89eba5dc7727f0599e8a5d778907ab0d993d#diff-a3642627644f6b2c0c719f8855d1f125aa7cd78efe74421d2ed4b268700918a6L910-L911). Remove the unused function definition.
 
<img width="409" alt="Screenshot 2023-01-18 at 10 05 53 PM" src="https://user-images.githubusercontent.com/692900/213539368-bfb058e5-9598-453e-a6a9-0df0cb5036b9.png">
