### PR TITLE
Notify on reactions when preview is set to .nameNoContent

### DIFF
--- a/SignalMessaging/Notifications/AppNotifications.swift
+++ b/SignalMessaging/Notifications/AppNotifications.swift
@@ -652,10 +652,7 @@ public class NotificationPresenter: NSObject, NotificationsProtocol {
                            transaction: SDSAnyReadTransaction) {
         guard !isThreadMuted(thread, transaction: transaction) else { return }
 
-        // Reaction notifications only get displayed if we can
-        // include the reaction details, otherwise we don't
-        // disturb the user for a non-message
-        guard previewType == .namePreview else { return }
+        guard previewType != .noNameNoPreview else { return }
 
         let senderName = contactsManager.displayName(for: reaction.reactor, transaction: transaction)
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is

Unfortunately, testing this change isn't feasible without access to the signing key associated with the developer account and the APNS certificates. 

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

This fixes an issue where reaction notifications were not generated if you had set your notification content privacy to "Name Only". This resulted in missed responses since reactions did not generate notifications, nor were they indicated in message previews when viewed from the main screen.

Some of my contacts have started using emoji reactions for responses, meaning I've missed some responses to important messages due to my notification content setting (which was set to "Name Only").

Failure to notify recipients of responses is a bug as the UI is currently designed. The handling of reactions is ambiguous based on the options provided here:
![IMG_2974 (1)](https://user-images.githubusercontent.com/4872355/218521195-72b88dfb-d35c-477e-9975-47c44799c76d.jpg)

With these existing controls, reactions should cause notifications in at least the first two options. 

