### PR TITLE
Fix quoted reply preview delegation

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSQuotedMessageView.h
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSQuotedMessageView.h
@@ -18,14 +18,15 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)didTapQuotedReply:(OWSQuotedReplyModel *)quotedReply
     failedThumbnailDownloadAttachmentPointer:(TSAttachmentPointer *)attachmentPointer;
 
-- (void)didCancelQuotedReply;
-
 @end
+
+@protocol QuotedReplyPreviewCancelDelegate;
 
 // TODO: Remove this view.
 @interface OWSQuotedMessageView : UIView
 
 @property (nonatomic, nullable, weak) id<OWSQuotedMessageViewDelegate> delegate;
+@property (nonatomic, nullable, weak) id<QuotedReplyPreviewCancelDelegate> cancelDelegate;
 
 + (instancetype)new NS_UNAVAILABLE;
 - (instancetype)init NS_UNAVAILABLE;

--- a/Signal/src/ViewControllers/ConversationView/Cells/OWSQuotedMessageView.m
+++ b/Signal/src/ViewControllers/ConversationView/Cells/OWSQuotedMessageView.m
@@ -673,7 +673,7 @@ const CGFloat kRemotelySourcedContentRowSpacing = 3;
 
 - (void)didTapCancel
 {
-    [self.delegate didCancelQuotedReply];
+    [self.cancelDelegate quotedReplyPreviewDidPressCancel];
 }
 
 @end

--- a/Signal/src/ViewControllers/ConversationView/ConversationInputToolbar.swift
+++ b/Signal/src/ViewControllers/ConversationView/ConversationInputToolbar.swift
@@ -57,7 +57,7 @@ protocol ConversationInputToolbarDelegate: AnyObject {
     func showUnblockConversationUI(completion: ((Bool) -> Void)?)
 }
 
-public class ConversationInputToolbar: UIView, LinkPreviewViewDraftDelegate, QuotedReplyPreviewDelegate {
+public class ConversationInputToolbar: UIView, LinkPreviewViewDraftDelegate, QuotedReplyPreviewCancelDelegate {
 
     private var conversationStyle: ConversationStyle
 
@@ -918,8 +918,7 @@ public class ConversationInputToolbar: UIView, LinkPreviewViewDraftDelegate, Quo
             return
         }
 
-        let quotedMessagePreview = QuotedReplyPreview(quotedReply: quotedReply, conversationStyle: conversationStyle)
-        quotedMessagePreview.delegate = self
+        let quotedMessagePreview = QuotedReplyPreview(quotedReply: quotedReply, conversationStyle: conversationStyle, cancelDelegate: self)
         quotedMessagePreview.setContentHuggingHorizontalLow()
         quotedMessagePreview.setCompressionResistanceHorizontalLow()
         quotedMessagePreview.accessibilityIdentifier = UIView.accessibilityIdentifier(in: self, name: "quotedMessagePreview")
@@ -972,7 +971,7 @@ public class ConversationInputToolbar: UIView, LinkPreviewViewDraftDelegate, Quo
         return ThreadReplyInfo(timestamp: quotedReply.timestamp, authorAddress: quotedReply.authorAddress)
     }
 
-    func quotedReplyPreviewDidPressCancel(_ preview: QuotedReplyPreview) {
+    func quotedReplyPreviewDidPressCancel() {
         if DebugFlags.internalLogging {
             OWSLogger.info("")
         }

--- a/Signal/src/views/QuotedReplyPreview.swift
+++ b/Signal/src/views/QuotedReplyPreview.swift
@@ -5,13 +5,13 @@
 
 import SignalUI
 
-protocol QuotedReplyPreviewDelegate: AnyObject {
-    func quotedReplyPreviewDidPressCancel(_ preview: QuotedReplyPreview)
+@objc protocol QuotedReplyPreviewCancelDelegate: AnyObject {
+    func quotedReplyPreviewDidPressCancel()
 }
 
 class QuotedReplyPreview: UIView, OWSQuotedMessageViewDelegate {
 
-    public weak var delegate: QuotedReplyPreviewDelegate?
+    private weak var cancelDelegate: QuotedReplyPreviewCancelDelegate!
 
     private let quotedReply: OWSQuotedReplyModel
     private let conversationStyle: ConversationStyle
@@ -28,9 +28,12 @@ class QuotedReplyPreview: UIView, OWSQuotedMessageViewDelegate {
         fatalError("init(frame:) has not been implemented")
     }
 
-    init(quotedReply: OWSQuotedReplyModel, conversationStyle: ConversationStyle) {
+    init(quotedReply: OWSQuotedReplyModel,
+         conversationStyle: ConversationStyle,
+         cancelDelegate: QuotedReplyPreviewCancelDelegate) {
         self.quotedReply = quotedReply
         self.conversationStyle = conversationStyle
+        self.cancelDelegate = cancelDelegate
 
         super.init(frame: .zero)
 
@@ -57,6 +60,7 @@ class QuotedReplyPreview: UIView, OWSQuotedMessageViewDelegate {
         // sizes changes).
         let quotedMessageView = OWSQuotedMessageView(forPreview: quotedReply, conversationStyle: conversationStyle)
         quotedMessageView.delegate = self
+        quotedMessageView.cancelDelegate = self.cancelDelegate
         self.quotedMessageView = quotedMessageView
         quotedMessageView.setContentHuggingHorizontalLow()
         quotedMessageView.setCompressionResistanceHorizontalLow()
@@ -90,10 +94,5 @@ class QuotedReplyPreview: UIView, OWSQuotedMessageViewDelegate {
     @objc
     public func didTapQuotedReply(_ quotedReply: OWSQuotedReplyModel, failedThumbnailDownloadAttachmentPointer attachmentPointer: TSAttachmentPointer) {
         // Do nothing.
-    }
-
-    @objc
-    public func didCancelQuotedReply() {
-        self.delegate?.quotedReplyPreviewDidPressCancel(self)
     }
 }


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 14 simulator
 * Attempted to test with iPad mini but device linking failed with "Invalid response from service." Will research the problem further.

- - - - - - - - - -

### Description

The changes stop a delegate from calling another delegate to cancel a quoted reply preview in the message input toolbar. They relate to what we discuss in #5547, representing one small step forward toward offering navigation and highlighting parity with Signal Desktop, and include the following changes:

- Rename `QuotedReplyPreviewDelegate` to `QuotedReplyPreviewCancelDelegate,` allowing for delegates like `QuotedReplyPreviewNavigationDelegate.`
- Require the cancel delegate on init of `QuotedReplyPreview.`
- Remove unused functions and parameters.

Some choices might not fit into the overall planning for the app and were made according to our limited understanding of its direction.