### PR TITLE
Fix for 5561: Apple maintains two stable versions of Xcode, update BUILDING.md to reflect that

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,6 +1,6 @@
 # Building
 
-We typically develop against the latest stable version of Xcode.
+We typically develop against the latest stable version of Xcode on the latest OS.
 
 ## 1. Clone
 


### PR DESCRIPTION
Calling out the latest OS helps disambiguate which stable version we are talking about.

### First-time contributor checklist
- [X] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
- [X] My commits are rebased on the latest main branch
- [X] My commits are in nice logical chunks
- [X] My contribution is fully baked and is ready to be merged as is
- [X] I have tested my contribution on these devices:
 * Macbook Pro: TextMate and Xcode

- - - - - - - - - -

### Description
Apple maintains two stale versions of Xcode when transitioning from one OS to another, so I thought we could specify that we were talking about the latest OS. Stable versions of Xcode 13 will not build Signal but Xcode 14 will.
