### PR TITLE
Swiftify `probableCountryCodeForCallingCode`

### DIFF
--- a/SignalServiceKit/src/Contacts/PhoneNumberUtil.h
+++ b/SignalServiceKit/src/Contacts/PhoneNumberUtil.h
@@ -14,9 +14,6 @@ NS_ASSUME_NONNULL_BEGIN
 // This property should only be accessed by Swift.
 @property (nonatomic, readonly) PhoneNumberUtilWrapper *phoneNumberUtilWrapper;
 
-// Returns the most likely country code for a calling code based on population.
-- (NSString *)probableCountryCodeForCallingCode:(NSString *)callingCode;
-
 + (NSUInteger)translateCursorPosition:(NSUInteger)offset
                                  from:(NSString *)source
                                    to:(NSString *)target

--- a/SignalServiceKit/src/Contacts/PhoneNumberUtil.m
+++ b/SignalServiceKit/src/Contacts/PhoneNumberUtil.m
@@ -24,14 +24,6 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (NSString *)probableCountryCodeForCallingCode:(NSString *)callingCode
-{
-    OWSAssertDebug(callingCode.length > 0);
-
-    NSArray<NSString *> *countryCodes = [self countryCodesFromCallingCode:callingCode];
-    return (countryCodes.count > 0 ? countryCodes[0] : nil);
-}
-
 // black  magic
 + (NSUInteger)translateCursorPosition:(NSUInteger)offset
                                  from:(NSString *)source

--- a/SignalServiceKit/src/Contacts/PhoneNumberUtil.swift
+++ b/SignalServiceKit/src/Contacts/PhoneNumberUtil.swift
@@ -201,6 +201,13 @@ extension PhoneNumberUtil {
         }
     }
 
+    /// Returns the most likely country code for a calling code based on population.
+    /// If no country codes are found, returns the empty string.
+    @objc(probableCountryCodeForCallingCode:)
+    public func probableCountryCode(forCallingCode callingCode: String) -> String {
+        return countryCodes(fromCallingCode: callingCode).first ?? ""
+    }
+
     private class func does(_ string: String, matchQuery query: String) -> Bool {
         let searchOptions: String.CompareOptions = [.caseInsensitive, .anchored]
 

--- a/SignalServiceKit/tests/Contacts/PhoneNumberUtilTest.swift
+++ b/SignalServiceKit/tests/Contacts/PhoneNumberUtilTest.swift
@@ -7,6 +7,11 @@ import XCTest
 import SignalServiceKit
 
 class PhoneNumberUtilTestSwift: SSKBaseTestSwift {
+    func test_probableCountryCode() {
+        XCTAssertEqual(phoneNumberUtil.probableCountryCode(forCallingCode: "+1"), "US")
+        XCTAssertEqual(phoneNumberUtil.probableCountryCode(forCallingCode: "+44"), "GB")
+        XCTAssertEqual(phoneNumberUtil.probableCountryCode(forCallingCode: "+0"), "")
+    }
 
     func test_callingCodeFromCountryCode() {
         XCTAssertEqual("+1", phoneNumberUtil.callingCode(fromCountryCode: "US"))


### PR DESCRIPTION
This change should have no user impact, and is not urgent.

I started by testing the existing behavior (ef285f19974677d6b315d7b021a2e849c153516f) and then converted it to Swift (c7f124df320ab1f1ddb45a1a3b784c69e2a93fb9).