### PR TITLE
Allow emoji to be used in emoji picker search bar

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/Emoji Picker/EmojiPickerCollectionView.swift
+++ b/Signal/src/ViewControllers/ConversationView/Emoji Picker/EmojiPickerCollectionView.swift
@@ -174,11 +174,11 @@ class EmojiPickerCollectionView: UICollectionView {
         var newRecentEmoji = recentEmoji
 
         // Remove any existing entries for this emoji
-        newRecentEmoji.removeAll { emoji == $0 }
+        newRecentEmoji.removeAll { emoji.baseEmoji == $0.baseEmoji }
         // Insert the selected emoji at the start of the list
         newRecentEmoji.insert(emoji, at: 0)
         // Truncate the recent emoji list to a maximum of 50 stored
-        newRecentEmoji = Array(newRecentEmoji[0..<min(50, newRecentEmoji.count)])
+        newRecentEmoji = Array(newRecentEmoji.suffix(50))
 
         EmojiPickerCollectionView.keyValueStore.setObject(
             newRecentEmoji.map { $0.rawValue },
@@ -218,6 +218,11 @@ class EmojiPickerCollectionView: UICollectionView {
     private func searchResults(_ searchText: String?) -> [EmojiWithSkinTones] {
         guard let searchText = searchText else {
             return []
+        }
+
+        if searchText.count == 1,
+           let searchEmoji = EmojiWithSkinTones(rawValue: searchText) {
+            return [searchEmoji]
         }
 
         return allSendableEmoji.filter { emoji in
@@ -318,6 +323,7 @@ extension EmojiPickerCollectionView: UICollectionViewDelegate {
 
         SDSDatabaseStorage.shared.asyncWrite { transaction in
             self.recordRecentEmoji(emoji, transaction: transaction)
+            emoji.baseEmoji.setPreferredSkinTones(emoji.skinTones, transaction: transaction)
         }
 
         pickerDelegate?.emojiPicker(self, didSelectEmoji: emoji)


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * 2018 iPad Pro 11-inch, iOS 16.2

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->
Allows users to use an emoji react by entering the emoji directly into the search bar. This makes it easier to react with a specific emoji a user has saved in their system keyboard. Demonstration:

https://user-images.githubusercontent.com/10291615/235821622-bc905247-41e1-4bdd-b9ea-2cdc77fb7e3e.mp4

Potential code consideration:
- The preferred skin tone for an emoji is now saved every time it is selected from the emoji picker. If this was not done, selecting a skin-tone-modified emoji entered into the search bar would not have its preference saved. Given that the recent emoji store is written to on every picked emoji and that this is able to be done in the same transaction, it did not seem to be a concern to me.