### PR TITLE
Sort images by recent instead of creation date

### DIFF
--- a/Signal/src/ViewControllers/Photos/MediaControls.swift
+++ b/Signal/src/ViewControllers/Photos/MediaControls.swift
@@ -1270,12 +1270,8 @@ class MediaPickerThumbnailButton: UIButton {
 
         // Async Fetch last image
         DispatchQueue.global(qos: .userInteractive).async {
-            let fetchOptions = PHFetchOptions()
-            fetchOptions.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
-            fetchOptions.fetchLimit = 1
-
-            let fetchResult = PHAsset.fetchAssets(with: PHAssetMediaType.image, options: fetchOptions)
-            if fetchResult.count > 0, let asset = fetchResult.firstObject {
+            let fetchResult = PHAsset.fetchAssets(with: PHAssetMediaType.image, options: nil)
+            if let asset = fetchResult.lastObject {
                 let targetImageSize = CGSize(square: MediaPickerThumbnailButton.visibleSize)
                 PHImageManager.default().requestImage(for: asset, targetSize: targetImageSize, contentMode: .aspectFill, options: nil) { (image, _) in
                     if let image = image {


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * 2018 iPad Pro 11-inch, iOS 16.4.1

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->
Photos in the app are currently always sorted by the creation date. While this is how the "Library" tab of the photos app works, this is not how the rest of Photos app works and can make it difficult to find the right image. The "Recents" album in the photos app sorts by most recently added, not most recently created, which can be different for certain images downloaded from the internet, or can be manually set by the user.

#### Issues
+ If a user downloads a new image or video and it has metadata about a creation date in the past, it will not appear at the front of the Recents picker in Signal as the user would expect.
+ If a user manually sorts an album, the manual sorting does not appear in the Signal photo picker.

#### Solution

By removing the sort descriptors from asset fetch, PhotoKit will return assets sorted the same way they are in the Photos app.

#### Examples

The photos with a year printed have their creation date metadata set to that year, but that is not the order they were saved to the device.

| Before  | After |
| --- | --- |
| ![Before Recents](https://user-images.githubusercontent.com/10291615/236090583-352312ba-bcbe-42e6-94f3-3e4b9765517e.png) | ![After Recents](https://user-images.githubusercontent.com/10291615/236090666-5c3bfb14-b773-433e-b6d7-3b5cc1d56f0b.png) |
| ![Before album](https://user-images.githubusercontent.com/10291615/236090849-b77052ff-ffe0-4575-899e-7e41264f3e27.png) | ![After album](https://user-images.githubusercontent.com/10291615/236090804-3a52d88c-5e6f-4557-a507-8a5d9f6d6195.png) |

#### Notes on code changes

None of the [PHAsset fetch options](https://developer.apple.com/documentation/photokit/phfetchoptions) are for sorting "the way the Photos app does". The way to do that is to have no sort descriptors on the fetch request. But once the sort descriptor is removed, we can't pass `ascending` into it anymore, which means we have to manually flip the results if we want to sort by descending (the changes to `PhotoCollectionContents.asset(at:)`). _That_ then means that setting a fetch limit will be limiting the results from the wrong end of the results, so the fetch limit also has to be handled by `PhotoCollectionContents`. Based on the [documentation for `PHFetchResult`](https://developer.apple.com/documentation/photokit/phfetchresult), it caches accessed `PHAssets` which implies that they are fetched lazily, so not having a limit on the original fetch and instead limiting the accessed assets inside of `PhotoCollectionContents` should not have much of a performance hit.

I decided to make `PhotoCollectionContents.fetchResult` private as it was not accessed anywhere else in the app, and it could lead to confusion if it were to be, as the assets would not be sorted descending as expected if it were initialized with `ascending` as false. While I was at it, I removed `localizedTitle` which was never used.