### PR TITLE
Fix for keyboard resets to alphabet when send pressed

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/ConversationInputToolbar.swift
+++ b/Signal/src/ViewControllers/ConversationView/ConversationInputToolbar.swift
@@ -1949,7 +1949,11 @@ extension ConversationInputToolbar {
             inputToolbarDelegate.sendVoiceMemoDraft(voiceMemoDraft)
             return
         }
-
+        
+        // keyboard is set to alphabet again when send button is pressed
+        inputTextView.keyboardType = .alphabet
+        inputTextView.reloadInputViews()
+        
         inputToolbarDelegate.sendButtonPressed()
     }
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 11 Pro, iOS 16.1

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->
Fixed the issue [#5564](https://github.com/signalapp/Signal-iOS/issues/5564). After typing a special character and pressing the send button, keyboard does not change back to alphabets. This behavior is present in other messaging apps like iMessages or Whatsapp. Please refer to the issue link for more details.

### Solution
On sendButtonPressed objc function, inputTextView's keyboard type is set back to alphabets.

### Note
It is my first time contributing. Please let me know if any changes are required.
