### PR TITLE
FIX - broken Development Guide wiki URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ We use GitHub for bug tracking. Please search [existing issues](https://github.c
 
 ## Contributing Code
 
-Instructions on how to setup your development environment and build Signal-iOS can be found in [BUILDING.md](https://github.com/signalapp/Signal-iOS/blob/main/BUILDING.md). Other useful instructions for development can be found in the [Development Guide wiki page](https://github.com/signalapp/Signal-iOS/wiki/Development-Guide). We also recommend reading the [contribution guidelines](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md).
+Instructions on how to setup your development environment and build Signal-iOS can be found in [BUILDING.md](https://github.com/signalapp/Signal-iOS/blob/main/BUILDING.md). We also recommend reading the [contribution guidelines](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md). Other useful instructions for development can be found by cloning the Development Guide wiki page.
+```
+git clone https://github.com/signalapp/Signal-iOS.wiki.git
+```
 
 ## Contributing Ideas
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on this device:
 * iPhone 14 simulator, iOS 16.4.0

- - - - - - - - - -

### Description

Fixes broken Development Guide wiki page URL by referencing cloning the wiki instead.

I've seen that other commits like https://github.com/signalapp/Signal-iOS/commit/3d815a14fb509e7d0d41d9ac4f390ef14add8753 have removed references to the wiki, but saw in [Community | List of wiki pages](https://community.signalusers.org/t/list-of-wiki-pages/14858) that it is still available.

Also switched the order to leave the wiki reference as the last one in this paragraph.
