### PR TITLE
remove manual imageInsets for centering icon in playButton

### DIFF
--- a/SignalUI/Views/VideoEditor/VideoEditorView.swift
+++ b/SignalUI/Views/VideoEditor/VideoEditorView.swift
@@ -39,8 +39,6 @@ class VideoEditorView: UIView {
                                                            comment: "Accessibility label for button to start media playback")
         // this makes the blur circle 72 pts in diameter
         playButton.contentEdgeInsets = UIEdgeInsets(margin: 26)
-        // play button must be slightly off-center to appear centered
-        playButton.imageEdgeInsets = UIEdgeInsets(top: 0, leading: 3, bottom: 0, trailing: -3)
         playButton.addTarget(self, action: #selector(playButtonTapped), for: .touchUpInside)
         return playButton
     }()


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- - - - - - - - - -

### Problem
Since the introduction of the new icon set, the play-icon is now positioned correctly in its own frame. In the past, this was not the case, so a manual code adjustment was made to fix its offset in `VideoEditorView`.

### Proposed changes
However, with the new icon set, this code adjustment is no longer needed. Therefore, it should be removed to ensure that the new icon appears centered as intended.

![Screenshot 2023-07-13 at 15 57 08](https://github.com/signalapp/Signal-iOS/assets/45589096/a92bc376-3986-4a32-8ea6-ae2e6180cda5)
(left: before, right: after)

#### Note: the manual code correction was only made in `VideoEditorView`. Therefore no other adjustments needed to fix this issue.