### PR TITLE
[ISSUE-5608] fix stuck after iPad keyboard dismiss

### DIFF
--- a/SignalUI/Views/ImageEditor/ImageEditorViewController+Text.swift
+++ b/SignalUI/Views/ImageEditor/ImageEditorViewController+Text.swift
@@ -294,6 +294,11 @@ extension ImageEditorViewController: UITextViewDelegate {
             self.textViewContainer.alpha = 0
         }
     }
+    
+    func textViewShouldEndEditing(_ textView: UITextView) -> Bool {
+        finishTextEditing(applyEdits: true)
+        return true
+    }
 }
 
 // MARK: - ImageEditorViewDelegate


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * Simulator iPad Pro (11-inch) A, iOS 16.4

- - - - - - - - - -

### Description
After closing the keyboard using the keyboard button (bottom right button on the iPad), the ImageEditorBottomBar was not being shown again. As a result, the user was unable to navigate away from the screen and had to force quit the app. 
`fixes #5608`

### Video
Before the fix
https://drive.google.com/file/d/1etIlN4yJWoij3qSezFRRU4goN_laRluO/view?usp=sharing

After the fix
https://drive.google.com/file/d/1EcWw6es3bOaMOzStyAnDGm4UKJWjd91G/view?usp=sharing

### Screenshots
![Simulator Screenshot - iPad Pro (11-inch) (4th generation) - 2023-07-17 at 11 15 48](https://github.com/signalapp/Signal-iOS/assets/9166516/77931df1-6a92-4123-9609-a5d13cb72ba1)
