### PR TITLE
Fixes 5564 - Sending a message does not reset the keyboard input pane

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/ConversationInputToolbar.swift
+++ b/Signal/src/ViewControllers/ConversationView/ConversationInputToolbar.swift
@@ -2066,7 +2066,14 @@ extension ConversationInputToolbar {
             return
         }
 
+        resetKeyboardToAlphabet()
         inputToolbarDelegate.sendButtonPressed()
+    }
+
+    @objc
+    private func resetKeyboardToAlphabet() {
+        inputTextView.keyboardType = .alphabet
+        inputTextView.reloadInputViews()
     }
 
     @objc


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 13 Pro, iOS 17.0.2
 * iPhone 14 Pro, iOS 17.0.1

- - - - - - - - - -

### Description
Fixes #5564 - Credit to @ahmermughal for the `.alphabet` line. (I was using `.system` to no avail)

Created a method for this in the spirit of self documenting code.