### PR TITLE
Fixes 5399 - voice memo recording does not use microphone from connected headphones

### DIFF
--- a/SignalUI/Utils/AudioSession.swift
+++ b/SignalUI/Utils/AudioSession.swift
@@ -177,7 +177,8 @@ public class AudioSession: NSObject {
                 mode: .default,
                 options: [
                     .defaultToSpeaker,
-                    .allowBluetooth
+                    .allowBluetooth,
+                    .allowBluetoothA2DP
                 ]
             )
             try avAudioSession.setAllowHapticsAndSystemSoundsDuringRecording(true)

--- a/SignalUI/Utils/AudioSession.swift
+++ b/SignalUI/Utils/AudioSession.swift
@@ -176,7 +176,8 @@ public class AudioSession: NSObject {
                 .playAndRecord,
                 mode: .default,
                 options: [
-                    .defaultToSpeaker
+                    .defaultToSpeaker,
+                    .allowBluetooth
                 ]
             )
             try avAudioSession.setAllowHapticsAndSystemSoundsDuringRecording(true)


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 14 Pro, iOS 17.1.1

- - - - - - - - - -

### Description
My PR fixes the following reported, confirmed, bug by me: https://github.com/signalapp/Signal-iOS/issues/5399

**Issue**

- If you record a voice memo and use (in my case) airpods, the microphone of the device (iPhone) is used instead of the airpods microphone. This does not happen with voice calls.

**Solution**

- add allowBluetooth to the AudioSession
- I've also added allowBluetoothA2DP, similar like in the "CallAudioService". 

I've tested the implementation by building the app via xcode on my iPhone 14 pro. Before, i could reproduce the issue, after adding allowBluetooth and sending another voice memo, it did work like expected.

**Note**

It is my first time contributing. Please let me know if any changes are required.

