### PR TITLE
Fix for constraint SafeArea loop crash.

### DIFF
--- a/SignalUI/ViewControllers/ActionSheetController.swift
+++ b/SignalUI/ViewControllers/ActionSheetController.swift
@@ -151,11 +151,16 @@ open class ActionSheetController: OWSViewController {
         // Depending on the number of actions, the sheet may need
         // to scroll to allow access to all options.
         view.addSubview(scrollView)
+        
+        // Set the top margin for the scrollview to avoid hugging the top of the view
+        let topMargin: CGFloat = 59
         scrollView.clipsToBounds = false
         scrollView.showsVerticalScrollIndicator = false
-        scrollView.autoPinEdge(toSuperviewEdge: .bottom)
+        
+        // Adjust ScrollView to fit within the safeArea
+        scrollView.autoPinEdge(toSuperviewSafeArea: .bottom)
         scrollView.autoHCenterInSuperview()
-        scrollView.autoMatch(.height, to: .height, of: view, withOffset: 0, relation: .lessThanOrEqual)
+        scrollView.autoMatch(.height, to: .height, of: view, withOffset: -topMargin, relation: .lessThanOrEqual)
 
         // Prefer to be full width, but don't exceed the maximum width
         scrollView.autoSetDimension(.width, toSize: 414, relation: .lessThanOrEqual)
@@ -164,19 +169,17 @@ open class ActionSheetController: OWSViewController {
             scrollView.autoPinWidthToSuperview()
         }
 
-        let topMargin: CGFloat = 18
-
         scrollView.addSubview(contentView)
         contentView.autoPinWidthToSuperview()
-        contentView.autoPinEdge(toSuperviewEdge: .top, withInset: topMargin)
+        contentView.autoPinEdge(toSuperviewEdge: .top)
         contentView.autoPinEdge(toSuperviewEdge: .bottom)
         contentView.autoMatch(.width, to: .width, of: scrollView)
 
         // If possible, the scrollview should be as tall as the content (no scrolling)
         // but if it doesn't fit on screen, it's okay to be greater than the scroll view.
-        contentView.autoMatch(.height, to: .height, of: scrollView, withOffset: -topMargin, relation: .greaterThanOrEqual)
+        contentView.autoMatch(.height, to: .height, of: scrollView, withOffset: 0, relation: .greaterThanOrEqual)
         NSLayoutConstraint.autoSetPriority(.defaultHigh) {
-            contentView.autoMatch(.height, to: .height, of: scrollView, withOffset: -topMargin)
+            contentView.autoMatch(.height, to: .height, of: scrollView)
         }
 
         // The backdrop view needs to extend from the top of the scroll view content to the bottom of the scroll view
@@ -192,13 +195,14 @@ open class ActionSheetController: OWSViewController {
         contentView.addSubview(backgroundView)
         backgroundView.autoPinWidthToSuperview()
         backgroundView.autoPinEdge(.top, to: .top, of: contentView)
-        scrollView.frameLayoutGuide.bottomAnchor.constraint(equalTo: backgroundView.bottomAnchor).isActive = true
+        //Make sure the background is pinned to the bottom of the view as the scrollview avoids the safeArea
+        backgroundView.autoPinEdge(.bottom, to: .bottom, of: view)
 
         // Stack views don't support corner masking pre-iOS 14
         // Instead we add our stack view to a wrapper view with masksToBounds: true
         let stackViewContainer = UIView()
         contentView.addSubview(stackViewContainer)
-        stackViewContainer.autoPinEdgesToSuperviewSafeArea()
+        stackViewContainer.autoPinEdgesToSuperviewEdges()
 
         stackViewContainer.addSubview(stackView)
         stackView.autoPinEdgesToSuperviewEdges()


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 15 Pro, iOS 17.0
 * iPhone 15 Pro Max, iOS 17.0
 * iPhone 15 SE, iOS 17.0

- - - - - - - - - -

### Description
This is to fix a crash that occurs on specific devices in landscape. There was an edge case  issue with constraints and safeArea causing the views layout to loop and eventually crash.

Steps to reproduce the crash:
- Use iOS 16.6.1 or 17.0 (I did not test other versions).
- Use a Max device (ex. iPhone 12 Pro Max or iPhone 15 Pro Max)
1) Rotate the device to be in landscape
2) Compose a new message from the Chat Tab
3) Tap New Group
4) Tap Skip
5) Enter a name for the group (The name does not matter)
6) Tap Create
7) Tap "Enable and Share Link"

The share sheet will not present and memory will constantly grow. The app will eventually crash.

To Verify the reason for the crash you can add `-UIViewLayoutFeedbackLoopDebuggingThreshold 50` to the apps run arguments and set an all exceptions breakpoint with the following action `po [_UIViewLayoutFeedbackLoopDebugger layoutFeedbackLoopDebugger]`

Issue:
The constraints on the actionSheets scrollView subviews would adjust to to avoid the safeArea, this in turn would resize the scrollview. In most cases this works correctly but if the size of the subview was within a small range of the maximum scrollView size a constraint loop would occur where resizing the scrollView would relayout the subviews which would no longer be affected by the safeArea causing the scrollView to resize again. This would continue to infinitely resize these views in a layout loop.

Solution:
To solve this issue I moved the handling of the safeArea to the scrollView and altered a few layout parameters to compensate for this change.