### PR TITLE
One address for crash reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -69,7 +69,7 @@ To get a crash log:
 7.b iOS 9&10 users, long press to see the option to highlight text and select the entire text of the log. It will end in EOF.
 8. Once the text is selected, tap Copy.
 9. Paste the copied text into an email.
-10. Send the email to support@signal.org with a subject like:
+10. Send the email to support@whispersystems.org with a subject like:
   * "iOS Crash Log: (your github issue)"
   * Example subject: iOS Crash Log: Crash on launch #111
   * Example subject: iOS Crash Log: Crash when sending video #222


### PR DESCRIPTION
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x ] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices: N/A

### Description

Fixes an inconsistency with email addresses in bug reporting. Now one address is shown, instead of two.