### PR TITLE
Fixes #5702: Keep unread status on archiving

### DIFF
--- a/SignalServiceKit/src/Contacts/ThreadAssociatedData.swift
+++ b/SignalServiceKit/src/Contacts/ThreadAssociatedData.swift
@@ -147,12 +147,10 @@ public class ThreadAssociatedData: NSObject, Codable, FetchableRecord, Persistab
 
         var isMarkedUnread = isMarkedUnread
 
-        // If we're archiving and we have an existing thread record,
-        // also mark that thread record as read.
-        if isArchived == true {
-            // Also clear marked unread if we're not explicitly setting it.
-            if isMarkedUnread == nil { isMarkedUnread = false }
-            markThreadAsReadIfExists(transaction: transaction)
+        // If we're archiving, we do not want to change the read status of the thread.
+        // The thread's read status should only be changed if explicitly set.
+        if isArchived == true, isMarkedUnread != nil {
+            isMarkedUnread = false
         }
 
         updateWith(updateStorageService: updateStorageService, transaction: transaction) { associatedData in


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iDevice iPhone 15 Pro, iOS 17.1.1
 * iDevice iPhone 14 Pro, iOS 17.1.1

- - - - - - - - - -

### Description

Fixes #5702: Resolved an inconsistency and potential safety issue where archiving messages marked them as read.
I tested this on different simulators within Xcode, as well as my personal iOS devices.

