### PR TITLE
Fixes the dark mode display of the payments icon in the settings.

### DIFF
--- a/Signal/Images.xcassets/payment.imageset/Contents.json
+++ b/Signal/Images.xcassets/payment.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 15 Pro, iOS 17.0
 * iPhone 14 Pro, iOS 17.0

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->
The payment image wasn't set to be rendered as a "Template Image", which caused it to display with incorrect color the dark mode tint was applied.

Before
<img width="377" alt="Screenshot 2023-11-23 at 00 06 16" src="https://github.com/signalapp/Signal-iOS/assets/409595/f1826c2b-8ec0-4dde-966a-dc1fce944ba4">

After
<img width="362" alt="Screenshot 2023-11-23 at 00 17 26" src="https://github.com/signalapp/Signal-iOS/assets/409595/21a37fa2-bb65-45bd-a4c6-8796ca98a533">
