### PR TITLE
#5725 Video stories don't pause another application's audio properly

### DIFF
--- a/Signal/src/ViewControllers/HomeView/Stories/Context View/StoryPageViewController.swift
+++ b/Signal/src/ViewControllers/HomeView/Stories/Context View/StoryPageViewController.swift
@@ -40,7 +40,7 @@ class StoryPageViewController: UIPageViewController {
     private let hiddenStoryFilter: Bool?
     private lazy var interactiveDismissCoordinator = StoryInteractiveTransitionCoordinator(pageViewController: self)
 
-    private let audioActivity = AudioActivity(audioDescription: "StoriesViewer", behavior: .playbackMixWithOthers)
+    private let audioActivity = AudioActivity(audioDescription: "StoriesViewer", behavior: .playback)
 
     private var isUserDraggingScrollView: Bool {
         guard let scrollView = viewIfLoaded?.subviews.compactMap({ $0 as? UIScrollView }).first else {


### PR DESCRIPTION

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 6s, 15.7.5

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

PROBLEM:
When playing a story when another application is playing audio, both applications will overlap audio.

SOLUTION:
Change StoryPageViewController from .playbackWithMixWIthOthers to .playback.

TEST:
The following was tested on an iPhone 6s with 15.7.5:
* When no other audio is playing on device, story plays as expected.
* When youtube is playing in the background and then a story plays, youtube is paused for the duration of the single story and then resumes youtube upon completion of a single story or multiple stories from the same user.