### PR TITLE
Fix handling of PNG attachments for editor (addresses #5761)

### DIFF
--- a/SignalMessaging/attachments/SignalAttachment.swift
+++ b/SignalMessaging/attachments/SignalAttachment.swift
@@ -522,9 +522,14 @@ public class SignalAttachment: NSObject {
     }
 
     public var isAnimatedImage: Bool {
-        if dataUTI == (kUTTypePNG as String),
-            dataSource.imageMetadata.isAnimated {
-            return true
+        if dataUTI == (kUTTypePNG as String) {
+            // PNGs need special handling based solely on their internal metadata, not whether 
+            // they appear in the set of known animated image types
+            if dataSource.imageMetadata.isAnimated {
+                return true
+            } else {
+                return false
+            }
         }
 
         return SignalAttachment.animatedImageUTISet.contains(dataUTI)

--- a/SignalServiceKit/src/Util/MIMETypeUtil.m
+++ b/SignalServiceKit/src/Util/MIMETypeUtil.m
@@ -579,7 +579,7 @@ NSString *const kLottieStickerFileExtension = @"lottiesticker";
     static NSSet<NSString *> *result = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken,
-        ^{ result = [self utiTypesForMIMETypes:[self supportedMaybeAnimatedMIMETypesToExtensionTypes].allKeys]; });
+        ^{ result = [self utiTypesForMIMETypes:[self supportedDefinitelyAnimatedMIMETypesToExtensionTypes].allKeys]; });
     return result;
 }
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] My commits are rebased on the latest main branch
- [X] My commits are in nice logical chunks
- [X] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 15 Pro, iOS 17.3

- - - - - - - - - -

### Description
These changes are meant to address #5761 by ensuring that `isAnimatedImage` for any PNG attachment is always determined by internal metadata, not whether it's in a list of MIME types, since PNGs can be either animated or not; and also to define the authoritative list of animated UTI types from those that are "definitely" animated after the a97772265d4ea83e92de0f5067c14ff1142caaaf refactor, not those that are "maybe" animated.