### PR TITLE
Double tap message to show context menu

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/CV/CVCell.swift
+++ b/Signal/src/ViewControllers/ConversationView/CV/CVCell.swift
@@ -334,6 +334,21 @@ public extension CVRootComponentHost {
                                                              renderItem: renderItem)
     }
 
+    func findDoubleTapHandler(sender: UIGestureRecognizer, componentDelegate: CVComponentDelegate) -> CVDoubleTapHandler? {
+        guard let renderItem = renderItem else {
+            owsFailDebug("Missing renderItem.")
+            return nil
+        }
+        guard let componentView = componentView else {
+            owsFailDebug("Missing componentView.")
+            return nil
+        }
+        return renderItem.rootComponent.findDoubleTapHandler(sender: sender,
+                                                             componentDelegate: componentDelegate,
+                                                             componentView: componentView,
+                                                             renderItem: renderItem)
+    }
+
     func findPanHandler(sender: UIPanGestureRecognizer,
                         componentDelegate: CVComponentDelegate,
                         messageSwipeActionState: CVMessageSwipeActionState) -> CVPanHandler? {

--- a/Signal/src/ViewControllers/ConversationView/CV/CVComponent.swift
+++ b/Signal/src/ViewControllers/ConversationView/CV/CVComponent.swift
@@ -34,6 +34,11 @@ public protocol CVComponent: AnyObject {
                               componentView: CVComponentView,
                               renderItem: CVRenderItem) -> CVLongPressHandler?
 
+    func findDoubleTapHandler(sender: UIGestureRecognizer,
+                              componentDelegate: CVComponentDelegate,
+                              componentView: CVComponentView,
+                              renderItem: CVRenderItem) -> CVDoubleTapHandler?
+
     func findPanHandler(sender: UIPanGestureRecognizer,
                         componentDelegate: CVComponentDelegate,
                         componentView: CVComponentView,
@@ -116,6 +121,14 @@ public class CVComponentBase: NSObject {
                                      componentView: CVComponentView,
                                      renderItem: CVRenderItem) -> CVLongPressHandler? {
         Logger.verbose("Ignoring long press.")
+        return nil
+    }
+
+    public func findDoubleTapHandler(sender: UIGestureRecognizer,
+                                     componentDelegate: CVComponentDelegate,
+                                     componentView: CVComponentView,
+                                     renderItem: CVRenderItem) -> CVDoubleTapHandler? {
+        Logger.verbose("Ignoring double tap.")
         return nil
     }
 

--- a/Signal/src/ViewControllers/ConversationView/CV/CVComponentDelegate.swift
+++ b/Signal/src/ViewControllers/ConversationView/CV/CVComponentDelegate.swift
@@ -66,6 +66,33 @@ public protocol CVComponentDelegate: AnyObject, AudioMessageViewDelegate {
 
     func didCancelLongPress(_ itemViewModel: CVItemViewModelImpl)
 
+    // MARK: - Double Tap
+
+    func didDoubleTapTextViewItem(_ cell: CVCell,
+                                  itemViewModel: CVItemViewModelImpl,
+                                  shouldAllowReply: Bool)
+
+    func didDoubleTapMediaViewItem(_ cell: CVCell,
+                                   itemViewModel: CVItemViewModelImpl,
+                                   shouldAllowReply: Bool)
+
+    func didDoubleTapQuote(_ cell: CVCell,
+                           itemViewModel: CVItemViewModelImpl,
+                           shouldAllowReply: Bool)
+
+    func didDoubleTapSystemMessage(_ cell: CVCell,
+                                   itemViewModel: CVItemViewModelImpl)
+
+    func didDoubleTapSticker(_ cell: CVCell,
+                             itemViewModel: CVItemViewModelImpl,
+                             shouldAllowReply: Bool)
+
+    func didDoubleTapPaymentMessage(
+        _ cell: CVCell,
+        itemViewModel: CVItemViewModelImpl,
+        shouldAllowReply: Bool
+    )
+
     // MARK: -
 
     func didTapReplyToItem(_ itemViewModel: CVItemViewModelImpl)

--- a/Signal/src/ViewControllers/ConversationView/CV/CVComponents/CVComponentBodyText.swift
+++ b/Signal/src/ViewControllers/ConversationView/CV/CVComponents/CVComponentBodyText.swift
@@ -647,6 +647,30 @@ public class CVComponentBodyText: CVComponentBase, CVComponent {
                                   gestureLocation: .bodyText(item: item))
     }
 
+    public override func findDoubleTapHandler(sender: UIGestureRecognizer,
+                                              componentDelegate: CVComponentDelegate,
+                                              componentView: CVComponentView,
+                                              renderItem: CVRenderItem) -> CVDoubleTapHandler? {
+
+        guard let componentView = componentView as? CVComponentViewBodyText else {
+            owsFailDebug("Unexpected componentView.")
+            return nil
+        }
+
+        guard !shouldIgnoreEvents else {
+            return nil
+        }
+
+        let bodyTextLabel = componentView.bodyTextLabel
+        guard let item = bodyTextLabel.itemForGesture(sender: sender) else {
+            return nil
+        }
+        bodyTextLabel.animate(selectedItem: item)
+        return CVDoubleTapHandler(delegate: componentDelegate,
+                                  renderItem: renderItem,
+                                  gestureLocation: .bodyText(item: item))
+    }
+
     // MARK: -
 
     fileprivate class BodyTextRootView: ManualStackView {}

--- a/Signal/src/ViewControllers/ConversationView/CV/CVComponents/CVComponentSystemMessage.swift
+++ b/Signal/src/ViewControllers/ConversationView/CV/CVComponents/CVComponentSystemMessage.swift
@@ -495,6 +495,15 @@ public class CVComponentSystemMessage: CVComponentBase, CVRootComponent {
                                   gestureLocation: .systemMessage)
     }
 
+    public override func findDoubleTapHandler(sender: UIGestureRecognizer,
+                                              componentDelegate: CVComponentDelegate,
+                                              componentView: CVComponentView,
+                                              renderItem: CVRenderItem) -> CVDoubleTapHandler? {
+        return CVDoubleTapHandler(delegate: componentDelegate,
+                                  renderItem: renderItem,
+                                  gestureLocation: .systemMessage)
+    }
+
     // MARK: -
 
     // Used for rendering some portion of an Conversation View item.

--- a/Signal/src/ViewControllers/ConversationView/CVViewState.swift
+++ b/Signal/src/ViewControllers/ConversationView/CVViewState.swift
@@ -119,6 +119,11 @@ public class CVViewState: NSObject {
 
     public let collectionViewTapGestureRecognizer = UITapGestureRecognizer()
     public let collectionViewLongPressGestureRecognizer = UILongPressGestureRecognizer()
+    public let collectionViewDoubleTapGestureRecognizer: UITapGestureRecognizer = {
+        let collectionViewDoubleTapGestureRecognizer = UITapGestureRecognizer()
+        collectionViewDoubleTapGestureRecognizer.numberOfTapsRequired = 2
+        return collectionViewDoubleTapGestureRecognizer
+    }()
     public let collectionViewContextMenuGestureRecognizer = UILongPressGestureRecognizer()
     public var collectionViewContextMenuSecondaryClickRecognizer: UITapGestureRecognizer?
 
@@ -298,6 +303,9 @@ extension ConversationViewController {
     }
     var collectionViewLongPressGestureRecognizer: UILongPressGestureRecognizer {
         viewState.collectionViewLongPressGestureRecognizer
+    }
+    var collectionViewDoubleTapGestureRecognizer: UITapGestureRecognizer {
+        viewState.collectionViewDoubleTapGestureRecognizer
     }
     var collectionViewContextMenuGestureRecognizer: UILongPressGestureRecognizer {
         viewState.collectionViewContextMenuGestureRecognizer

--- a/Signal/src/ViewControllers/ConversationView/ConversationViewController+CVComponentDelegate.swift
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewController+CVComponentDelegate.swift
@@ -113,6 +113,63 @@ extension ConversationViewController: CVComponentDelegate {
         collectionViewActiveContextMenuInteraction?.initiatingGestureRecognizerDidEnd()
     }
 
+    // MARK: - Double Tap
+
+    public func didDoubleTapTextViewItem(_ cell: CVCell, itemViewModel: CVItemViewModelImpl, shouldAllowReply: Bool) {
+        AssertIsOnMainThread()
+
+        let messageActions = MessageActions.textActions(itemViewModel: itemViewModel,
+                                                        shouldAllowReply: shouldAllowReply,
+                                                        delegate: self)
+        self.presentContextMenu(with: messageActions, focusedOn: cell, andModel: itemViewModel)
+    }
+
+    public func didDoubleTapMediaViewItem(_ cell: CVCell, itemViewModel: CVItemViewModelImpl, shouldAllowReply: Bool) {
+        AssertIsOnMainThread()
+
+        let messageActions = MessageActions.mediaActions(itemViewModel: itemViewModel,
+                                                         shouldAllowReply: shouldAllowReply,
+                                                         delegate: self)
+        self.presentContextMenu(with: messageActions, focusedOn: cell, andModel: itemViewModel)
+    }
+
+    public func didDoubleTapQuote(_ cell: CVCell, itemViewModel: CVItemViewModelImpl, shouldAllowReply: Bool) {
+        AssertIsOnMainThread()
+
+        let messageActions = MessageActions.quotedMessageActions(itemViewModel: itemViewModel,
+                                                                 shouldAllowReply: shouldAllowReply,
+                                                                 delegate: self)
+        self.presentContextMenu(with: messageActions, focusedOn: cell, andModel: itemViewModel)
+    }
+
+    public func didDoubleTapSystemMessage(_ cell: CVCell, itemViewModel: CVItemViewModelImpl) {
+        AssertIsOnMainThread()
+
+        let messageActions = MessageActions.infoMessageActions(itemViewModel: itemViewModel,
+                                                               delegate: self)
+        self.presentContextMenu(with: messageActions, focusedOn: cell, andModel: itemViewModel)
+    }
+
+    public func didDoubleTapSticker(_ cell: CVCell, itemViewModel: CVItemViewModelImpl, shouldAllowReply: Bool) {
+        AssertIsOnMainThread()
+
+        let messageActions = MessageActions.mediaActions(itemViewModel: itemViewModel,
+                                                         shouldAllowReply: shouldAllowReply,
+                                                         delegate: self)
+        self.presentContextMenu(with: messageActions, focusedOn: cell, andModel: itemViewModel)
+    }
+
+    public func didDoubleTapPaymentMessage(_ cell: CVCell, itemViewModel: CVItemViewModelImpl, shouldAllowReply: Bool) {
+        AssertIsOnMainThread()
+
+        let messageActions = MessageActions.paymentActions(
+            itemViewModel: itemViewModel,
+            shouldAllowReply: shouldAllowReply,
+            delegate: self
+        )
+        self.presentContextMenu(with: messageActions, focusedOn: cell, andModel: itemViewModel)
+    }
+
     // MARK: -
 
     public func didTapReplyToItem(_ itemViewModel: CVItemViewModelImpl) {

--- a/Signal/src/ViewControllers/EditHistoryTableSheetViewController.swift
+++ b/Signal/src/ViewControllers/EditHistoryTableSheetViewController.swift
@@ -312,6 +312,20 @@ extension EditHistoryTableSheetViewController: CVComponentDelegate {
 
     func didCancelLongPress(_ itemViewModel: CVItemViewModelImpl) {}
 
+    // MARK: - Double Tap
+
+    func didDoubleTapTextViewItem(_ cell: CVCell, itemViewModel: CVItemViewModelImpl, shouldAllowReply: Bool) {}
+
+    func didDoubleTapMediaViewItem(_ cell: CVCell, itemViewModel: CVItemViewModelImpl, shouldAllowReply: Bool) {}
+
+    func didDoubleTapQuote(_ cell: CVCell, itemViewModel: CVItemViewModelImpl, shouldAllowReply: Bool) {}
+
+    func didDoubleTapSystemMessage(_ cell: CVCell, itemViewModel: CVItemViewModelImpl) {}
+
+    func didDoubleTapSticker(_ cell: CVCell, itemViewModel: CVItemViewModelImpl, shouldAllowReply: Bool) {}
+
+    func didDoubleTapPaymentMessage(_ cell: CVCell, itemViewModel: CVItemViewModelImpl, shouldAllowReply: Bool) {}
+
     // MARK: -
 
     func didTapReplyToItem(_ itemViewModel: CVItemViewModelImpl) {}

--- a/Signal/src/ViewControllers/MessageDetailViewController.swift
+++ b/Signal/src/ViewControllers/MessageDetailViewController.swift
@@ -1035,6 +1035,20 @@ extension MessageDetailViewController: CVComponentDelegate {
     // TODO:
     func didCancelLongPress(_ itemViewModel: CVItemViewModelImpl) {}
 
+    // MARK: - Double Tap
+
+    func didDoubleTapTextViewItem(_ cell: CVCell, itemViewModel: CVItemViewModelImpl, shouldAllowReply: Bool) {}
+
+    func didDoubleTapMediaViewItem(_ cell: CVCell, itemViewModel: CVItemViewModelImpl, shouldAllowReply: Bool) {}
+
+    func didDoubleTapQuote(_ cell: CVCell, itemViewModel: CVItemViewModelImpl, shouldAllowReply: Bool) {}
+
+    func didDoubleTapSystemMessage(_ cell: CVCell, itemViewModel: CVItemViewModelImpl) {}
+
+    func didDoubleTapSticker(_ cell: CVCell, itemViewModel: CVItemViewModelImpl, shouldAllowReply: Bool) {}
+
+    func didDoubleTapPaymentMessage(_ cell: CVCell, itemViewModel: CVItemViewModelImpl, shouldAllowReply: Bool) {}
+
     // MARK: -
 
     // TODO:

--- a/Signal/src/views/MockConversationView.swift
+++ b/Signal/src/views/MockConversationView.swift
@@ -302,6 +302,20 @@ extension MockConversationView: CVComponentDelegate {
 
     func didCancelLongPress(_ itemViewModel: CVItemViewModelImpl) {}
 
+    // MARK: - Double Tap
+
+    func didDoubleTapTextViewItem(_ cell: CVCell, itemViewModel: CVItemViewModelImpl, shouldAllowReply: Bool) {}
+
+    func didDoubleTapMediaViewItem(_ cell: CVCell, itemViewModel: CVItemViewModelImpl, shouldAllowReply: Bool) {}
+
+    func didDoubleTapQuote(_ cell: CVCell, itemViewModel: CVItemViewModelImpl, shouldAllowReply: Bool) {}
+
+    func didDoubleTapSystemMessage(_ cell: CVCell, itemViewModel: CVItemViewModelImpl) {}
+
+    func didDoubleTapSticker(_ cell: CVCell, itemViewModel: CVItemViewModelImpl, shouldAllowReply: Bool) {}
+
+    func didDoubleTapPaymentMessage(_ cell: CVCell, itemViewModel: CVItemViewModelImpl, shouldAllowReply: Bool) {}
+
     // MARK: -
 
     func didTapReplyToItem(_ itemViewModel: CVItemViewModelImpl) {}


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 14 Pro, iOS 17.4

- - - - - - - - - -

### Description

In the conversation view, long pressing a message presents the context view for that cell, allowing the user to add reactions, reply, delete the message, etc. To match the behavior that iOS users are accustomed to in iMessage, Signal should also allow double-tapping messages to present this menu. This can also be faster, since double-tapping doesn't have the same time delay that long press gestures have.

The code changes implemented all followed the same patterns as the tap and long press gesture recognizers on that view, so even though it's a few hundred lines it's mostly copy-paste from that and just tweaking the relevant parts.