### PR TITLE
Prevent video stop in MediaPageViewController when new attachment arrives.

### DIFF
--- a/Signal/src/ViewControllers/MediaGallery/MediaPageViewController.swift
+++ b/Signal/src/ViewControllers/MediaGallery/MediaPageViewController.swift
@@ -692,7 +692,10 @@ extension MediaPageViewController: MediaGalleryDelegate {
             dismissSelf(animated: true)
             return
         }
-        setCurrentItem(reloadedItem, direction: .forward, animated: false)
+
+        if attachment.uniqueId != reloadedItem.attachmentStream.uniqueId {
+            setCurrentItem(reloadedItem, direction: .forward, animated: false)
+        }
     }
 
     func mediaGalleryShouldDeferUpdate(_ mediaGallery: MediaGallery) -> Bool {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 7, iOS 15.7.9

- - - - - - - - - -

### Description
When user opens video attachment, `MediaPageViewController` presents it and play it. If in this moment user receives new attachment - audio or video then video stops playing.
Solution is to reload attachment only if it is different then current one.

Steps to reproduce:
Assuming that phone1 received video attachment (say 20 seconds long) at some point
1. on phone1 open mentioned video attachment
2. on phone2 send to phone1 photo or audio message
3. video on phone1 stops playing 
