### PR TITLE
Do not ignore 'shouldAutoPlayVideo' function parameter in MediaPageViewController.

### DIFF
--- a/Signal/src/ViewControllers/MediaGallery/MediaPageViewController.swift
+++ b/Signal/src/ViewControllers/MediaGallery/MediaPageViewController.swift
@@ -240,7 +240,7 @@ class MediaPageViewController: UIPageViewController {
         }
 
         let mediaPage = buildGalleryPage(galleryItem: item)
-        mediaPage.shouldAutoPlayVideo = true
+        mediaPage.shouldAutoPlayVideo = shouldAutoPlayVideo
         setViewControllers([mediaPage], direction: direction, animated: animated) { _ in
             self.didTransitionToNewPage(animated: animated)
         }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 7, iOS 15.7.9

- - - - - - - - - -

### Description
Currently when `MediaPageViewController.setCurrentItem` is invoked `shouldAutoPlayVideo` parameter is ignored and `MediaItemViewController.shouldAutoPlayVideo` property is always set to true inside function.
In this PR I changed only part related to behaviour in `MediaPageViewController.setCurrentItem` but MediaPageViewController have several calls to `setCurrentItem` where this parameter is not used explicitly and its default to `false` which may alter desired final behaviour as currently `MediaItemViewController.shouldAutoPlayVideo` is always true. I would gladly change all places where `setCurrentItem` but I do not know specs.
