### PR TITLE
Fix issue that shows send button when all the text is cut.

### DIFF
--- a/SignalUI/Views/BodyRanges/BodyRangesTextView.swift
+++ b/SignalUI/Views/BodyRanges/BodyRangesTextView.swift
@@ -772,6 +772,7 @@ extension BodyRangesTextView {
         editableBody.replaceCharacters(in: selectedRange, with: "", selectedRange: selectedRange)
         editableBody.endEditing()
         self.selectedRange = NSRange(location: selectedRange.location, length: 0)
+        textViewDidChange(self)
     }
 
     public class func copyToPasteboard(_ text: CVTextValue) {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 15 Pro Max, iOS 17.5

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->
By notifying the UITextViewDelegate that the content of the cell changed, we make sure the right buttons are shown to the user after a cut action is performed.

Closes #5804
