### PR TITLE
Fix forward messages not showing

### DIFF
--- a/Signal.xcodeproj/xcshareddata/xcschemes/SignalServiceKit.xcscheme
+++ b/Signal.xcodeproj/xcshareddata/xcschemes/SignalServiceKit.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1540"
-   version = "1.7">
+   version = "1.8">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"

--- a/SignalServiceKit/Messages/MessageReceiver.swift
+++ b/SignalServiceKit/Messages/MessageReceiver.swift
@@ -2103,9 +2103,14 @@ class MessageReceiverRequest {
     }
 
     private static func isDuplicate(_ decryptedEnvelope: DecryptedIncomingEnvelope, tx: SDSAnyReadTransaction) -> Bool {
+        guard let serverGuid = decryptedEnvelope.envelope.serverGuid else {
+            return true
+        }
+    
         return InteractionFinder.existsIncomingMessage(
             timestamp: decryptedEnvelope.timestamp,
             sourceAci: decryptedEnvelope.sourceAci,
+            serverGuid: serverGuid,
             transaction: tx
         )
     }

--- a/SignalServiceKit/Storage/Database/Records/InteractionFinder.swift
+++ b/SignalServiceKit/Storage/Database/Records/InteractionFinder.swift
@@ -48,6 +48,7 @@ public class InteractionFinder: NSObject {
     public class func existsIncomingMessage(
         timestamp: UInt64,
         sourceAci: Aci,
+        serverGuid: String
         transaction: SDSAnyReadTransaction
     ) -> Bool {
         let sql = """
@@ -55,6 +56,7 @@ public class InteractionFinder: NSObject {
                 SELECT 1
                 FROM \(InteractionRecord.databaseTableName)
                 WHERE \(interactionColumn: .timestamp) = ?
+                AND \(interactionColumn: .serverGuid) = ?
                 AND (
                     \(interactionColumn: .authorUUID) = ?
                     OR (
@@ -67,6 +69,7 @@ public class InteractionFinder: NSObject {
         let arguments: StatementArguments = [
             timestamp,
             sourceAci.serviceIdUppercaseString,
+            serverGuid,
             SignalServiceAddress(sourceAci).phoneNumber
         ]
         do {


### PR DESCRIPTION
forwarding multiple messages will have the same timestamp and will be considered as duplicates so adding serverGuid when checking for duplicates will fix the issue
