### PR TITLE
Add Mutipath TCP (MPTCP) support

### DIFF
--- a/SignalServiceKit/Network/ContentProxy.swift
+++ b/SignalServiceKit/Network/ContentProxy.swift
@@ -25,6 +25,7 @@ public class ContentProxy: NSObject {
             "HTTPSProxy": proxyHost,
             "HTTPSPort": proxyPort
         ]
+        configuration.multipathServiceType = .handover
         return configuration
     }
 

--- a/SignalServiceKit/Network/OWSUrlSession.swift
+++ b/SignalServiceKit/Network/OWSUrlSession.swift
@@ -81,13 +81,16 @@ public class OWSURLSession: NSObject, OWSURLSessionProtocol {
     }
 
     public static var defaultConfigurationWithCaching: URLSessionConfiguration {
-        .ephemeral
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.multipathServiceType = .handover
+        return configuration
     }
 
     public static var defaultConfigurationWithoutCaching: URLSessionConfiguration {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.urlCache = nil
         configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        configuration.multipathServiceType = .handover
         return configuration
     }
 

--- a/SignalServiceKit/Subscriptions/Stripe.swift
+++ b/SignalServiceKit/Subscriptions/Stripe.swift
@@ -270,11 +270,17 @@ fileprivate extension Stripe {
         : "pk_test_sngOd8FnXNkpce9nPXawKrJD00kIDngZkD"
 
     static let authorizationHeader = "Basic \(Data("\(publishableKey):".utf8).base64EncodedString())"
+    
+    static let configuration: URLSessionConfiguration{
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.multipathServiceType = .handover
+        return configuration
+    }
 
     static let urlSession = OWSURLSession(
         baseUrl: URL(string: "https://api.stripe.com/v1/")!,
         securityPolicy: OWSURLSession.defaultSecurityPolicy,
-        configuration: URLSessionConfiguration.ephemeral
+        configuration: configuration
     )
 
     struct API {

--- a/SignalUI/LinkPreview/LinkPreviewFetcher.swift
+++ b/SignalUI/LinkPreview/LinkPreviewFetcher.swift
@@ -102,6 +102,7 @@ public class LinkPreviewFetcherImpl: LinkPreviewFetcher {
         let sessionConfig = URLSessionConfiguration.ephemeral
         sessionConfig.urlCache = nil
         sessionConfig.requestCachePolicy = .reloadIgnoringLocalCacheData
+        sessionConfig.multipathServiceType = .handover
 
         // Twitter doesn't return OpenGraph tags to Signal
         // `curl -A Signal "https://twitter.com/signalapp/status/1280166087577997312?s=20"`

--- a/SignalUI/Payments/MobileCoinAPI+Configuration.swift
+++ b/SignalUI/Payments/MobileCoinAPI+Configuration.swift
@@ -723,6 +723,7 @@ final class MobileCoinHttpRequester: NSObject, HttpRequester {
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = 30
         config.timeoutIntervalForResource = 30
+        config.multipathServiceType = .handover
         return config
     }()
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [ ] I have tested my contribution on these devices:
 * iDevice A, iOS X.Y.Z
 * iDevice B, iOS Z.Y

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

MPTCP is a TCP extension allowing to improve network reliabilty by using mutiple network interface for the same TCP connection. Check https://www.mptcp.dev and https://developer.apple.com/documentation/foundation/urlsessionconfiguration/improving_network_reliability_using_multipath_tcp for details. Changes to this repository consists in setting the multipathServiceType of URLSessionConfiguration to Handover, allowing a seamless transition of interface in case of deterioration of the connection.
