### PR TITLE
[#5846] Remove custom user agent to fix captcha failure loop

### DIFF
--- a/SignalUI/Views/CaptchaView.swift
+++ b/SignalUI/Views/CaptchaView.swift
@@ -71,7 +71,6 @@ public class CaptchaView: UIView {
 
         let webView = WKWebView(frame: .zero, configuration: configuration)
         webView.allowsBackForwardNavigationGestures = false
-        webView.customUserAgent = OWSURLSession.userAgentHeaderValueSignalIos
         webView.allowsLinkPreview = false
         webView.scrollView.contentInset = .zero
         webView.layoutMargins = .zero


### PR DESCRIPTION
### Contributor checklist
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 15 Pro, iOS 17.6.1

- - - - - - - - - -

### Description
I was also hit by the bug filed as #5846, where I get stuck in an infinite "Something went wrong" captcha failure loop on registration with notifications unavailable. 

After [some debugging](https://github.com/signalapp/Signal-iOS/issues/5846#issuecomment-2329881697), comparing iOS and Android, it turns out this traces back to hCaptcha not liking the custom user agent of the WebView used for the CAPTCHA view 

Once I removed the custom user agent so that the WebView goes back to the default user agent, I am able to successfully get out of the failure loop. 