### PR TITLE
Fix typo in comment in ECKeyPair.swift

### DIFF
--- a/SignalServiceKit/Curve25519/ECKeyPair.swift
+++ b/SignalServiceKit/Curve25519/ECKeyPair.swift
@@ -17,7 +17,7 @@ public final class ECKeyPair: NSObject, NSSecureCoding {
 
     /**
      * Build a keypair from existing key data.
-     * If you need a *new* keypair, user `ECKeyPair.generateKeyPair` instead.
+     * If you need a *new* keypair, use `ECKeyPair.generateKeyPair` instead.
      */
     convenience init(publicKeyData: Data, privateKeyData: Data) throws {
         let publicKey = try PublicKey(keyData: publicKeyData)


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [ ] Tested on any IOS device
       - (only a comment change)

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->
Fix a typo / grammar issue in SignalServiceKit/Curve25519/ECKeyPair.swift
``user `ECKeyPair.generateKeyPair` instead.``  ->  ``use `ECKeyPair.generateKeyPair` instead.``