### PR TITLE
Replace recursive call with while loop to prevent stack overflow.

### DIFF
--- a/Signal/Attachments/AttachmentDownloadRetryRunner.swift
+++ b/Signal/Attachments/AttachmentDownloadRetryRunner.swift
@@ -81,10 +81,10 @@ public class AttachmentDownloadRetryRunner {
         }
 
         private func run() async {
-            do {
-                self.isRunning = true
-                defer { self.isRunning = false }
-
+            self.isRunning = true
+            defer { self.isRunning = false }
+            // Run while there is a next timestamp.
+            while true {
                 let nextTimestamp = db.read { tx in
                     return try? self.attachmentDownloadStore.nextRetryTimestamp(tx: tx.asV2Read)
                 }
@@ -102,9 +102,6 @@ public class AttachmentDownloadRetryRunner {
                 // Kick the tires to start any downloads.
                 attachmentDownloadManager.beginDownloadingIfNecessary()
             }
-
-            // Run again to wait for the next timestamp.
-            await self.run()
         }
     }
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * Simulator iPhone 16 PRO , iOS 18.0

- - - - - - - - - -

### Description
- Recursive call might cause stack overflow if called to many times.
- Improvement: replace recursive call with while loop, that won't be affected by the issue.

P.S. I had no stack overflow with old/new code when tested - there was no recursive calls. I picked it as a small first contribution.
