### PR TITLE
Context menu entry for media view: Show in Chat

### DIFF
--- a/Signal/AppLaunch/SignalApp.swift
+++ b/Signal/AppLaunch/SignalApp.swift
@@ -158,7 +158,8 @@ extension SignalApp {
         _ thread: TSThread,
         action: ConversationViewAction = .none,
         focusMessageId: String? = nil,
-        animated: Bool
+        animated: Bool,
+        forceReload: Bool = false
     ) {
         AssertIsOnMainThread()
 
@@ -179,7 +180,7 @@ extension SignalApp {
                 }
                 return
             }
-            conversationSplitViewController.presentThread(thread, action: action, focusMessageId: focusMessageId, animated: animated)
+            conversationSplitViewController.presentThread(thread, action: action, focusMessageId: focusMessageId, animated: animated, forceReload: forceReload)
         }
     }
 

--- a/Signal/src/ViewControllers/HomeView/Chat List/ChatListViewController+Actions.swift
+++ b/Signal/src/ViewControllers/HomeView/Chat List/ChatListViewController+Actions.swift
@@ -54,7 +54,8 @@ extension ChatListViewController {
             thread,
             action: action,
             focusMessageId: focusMessageId,
-            animated: animated
+            animated: animated,
+            forceReload: false
         )
     }
 }

--- a/Signal/src/ViewControllers/HomeView/ConversationSplitViewController.swift
+++ b/Signal/src/ViewControllers/HomeView/ConversationSplitViewController.swift
@@ -125,7 +125,7 @@ class ConversationSplitViewController: UISplitViewController, ConversationSplit 
         }
     }
 
-    func presentThread(_ thread: TSThread, action: ConversationViewAction, focusMessageId: String?, animated: Bool) {
+    func presentThread(_ thread: TSThread, action: ConversationViewAction, focusMessageId: String?, animated: Bool, forceReload: Bool = false) {
         AssertIsOnMainThread()
 
         // On iOS 13, there is a bug with UISplitViewController that causes the `isCollapsed` state to
@@ -137,14 +137,14 @@ class ConversationSplitViewController: UISplitViewController, ConversationSplit 
             owsFailDebug("check if this still happens")
             // Reset this to avoid getting stuck in a loop. We're becoming active.
             lastActiveInterfaceOrientation = windowScene.interfaceOrientation
-            DispatchQueue.main.async { self.presentThread(thread, action: action, focusMessageId: focusMessageId, animated: animated) }
+            DispatchQueue.main.async { self.presentThread(thread, action: action, focusMessageId: focusMessageId, animated: animated, forceReload: forceReload) }
             return
         }
 
         if homeVC.selectedHomeTab != .chatList {
             guard homeVC.presentedViewController == nil else {
                 homeVC.dismiss(animated: true) {
-                    self.presentThread(thread, action: action, focusMessageId: focusMessageId, animated: animated)
+                    self.presentThread(thread, action: action, focusMessageId: focusMessageId, animated: animated, forceReload: forceReload)
                 }
                 return
             }
@@ -153,7 +153,7 @@ class ConversationSplitViewController: UISplitViewController, ConversationSplit 
             homeVC.selectedHomeTab = .chatList
         }
 
-        guard selectedThread?.uniqueId != thread.uniqueId else {
+        guard ((selectedThread?.uniqueId != thread.uniqueId) || forceReload) else {
             // If this thread is already selected, pop to the thread if
             // anything else has been presented above the view.
             guard let selectedConversationVC = selectedConversationViewController else { return }
@@ -684,3 +684,4 @@ extension ConversationSplitViewController: DeviceTransferServiceObserver {
 
     func deviceTransferServiceDidRequestAppRelaunch() {}
 }
+

--- a/Signal/src/ViewControllers/MediaGallery/MediaGallery.swift
+++ b/Signal/src/ViewControllers/MediaGallery/MediaGallery.swift
@@ -300,7 +300,7 @@ class MediaGallery {
     typealias Update = Sections.Update
     typealias Journal = [JournalingOrderedDictionaryChange<Sections.ItemChange>]
 
-    private let thread: TSThread
+    let thread: TSThread
 
     // Used for filtering.
     private(set) var mediaFilter: AllMediaFilter

--- a/Signal/src/ViewControllers/MediaGallery/MediaPageViewController.swift
+++ b/Signal/src/ViewControllers/MediaGallery/MediaPageViewController.swift
@@ -344,6 +344,17 @@ class MediaPageViewController: UIPageViewController {
                 self?.deleteCurrentMedia()
             }
         ))
+
+        contextMenuActions.append(UIAction(
+            title: OWSLocalizedString(
+                "MEDIA_VIEWER_JUMP_TO_CONVERSATION",
+                comment: "Context menu item in media viewer. Jumps to position in conversation."
+            ),
+            image: Theme.iconImage(.arrowUp),
+            handler: { [weak self] _ in
+                self?.jumpToConversation()
+            }
+        ))
         contextMenuButton.setActions(actions: contextMenuActions)
     }
 
@@ -491,6 +502,16 @@ class MediaPageViewController: UIPageViewController {
         }
         let sender = fromNavigationBar ? barButtonShareMedia : bottomMediaPanel
         AttachmentSharing.showShareUI(for: attachmentStream, sender: sender)
+    }
+    
+    private func jumpToConversation() {
+        SignalApp.shared.presentConversationForThread(
+            mediaGallery.thread,
+            focusMessageId: currentViewController?.galleryItem.message.uniqueId,
+            animated: true,
+            forceReload: true
+        )
+        self.dismiss(animated: false)
     }
 
     private func deleteCurrentMedia() {
@@ -870,3 +891,4 @@ extension MediaPageViewController: UINavigationBarDelegate {
         dismissSelf(animated: true)
     }
 }
+

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -4168,6 +4168,9 @@
 /* Context menu item in media viewer. Refers to deleting currently displayed photo/video. */
 "MEDIA_VIEWER_DELETE_MEDIA_ACTION" = "Delete";
 
+/* Context menu item in media viewer, Refers to jumping to position in conversation*/
+"MEDIA_VIEWER_JUMP_TO_CONVERSATION" = "Show in Chat";
+
 /* button title to snooze a megaphone */
 "MEGAPHONE_REMIND_LATER" = "Remind Me Later";
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 16 Simulator, iOS 18.0

- - - - - - - - - -

### Description

It is possible to jump to a certain message in a conversation via the searchbar, but currently it is not possible to jump to images, this PR makes this also possible:


https://github.com/user-attachments/assets/d9bb7f1a-dbe2-48df-bc9b-9c8d0df0e7c5



I found this request online:
https://www.reddit.com/r/signal/comments/u4vryt/view_image_in_chat_history/

