### PR TITLE
Fix attachment names from using the wrong year

### DIFF
--- a/SignalServiceKit/Attachments/SignalAttachment.swift
+++ b/SignalServiceKit/Attachments/SignalAttachment.swift
@@ -440,7 +440,7 @@ public class SignalAttachment: NSObject {
             let kDefaultAttachmentName = "signal"
 
             let dateFormatter = DateFormatter()
-            dateFormatter.dateFormat = "YYYY-MM-dd-HHmmss"
+            dateFormatter.dateFormat = "yyyy-MM-dd-HHmmss"
             let dateString = dateFormatter.string(from: Date())
 
             let withoutExtension = "\(kDefaultAttachmentName)-\(dateString)"


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 16, iOS 18.2

- - - - - - - - - -

### Description
This bug `fixes #5932`. This bug originated from using YYYY (Week of Year) instead of yyyy (The calendar year). According to Apple's documentation, both of them for the most part deliver the same result; however, there are certain occasions when it can produce different ones.

To test that my fix has worked I changed my system time to the reported time used in the bug report. I then performed the step for the bug and the bug did not happen anymore.