### PR TITLE
Fixed Navigation Bar disappearing on zooming in and out.

### DIFF
--- a/Signal/src/ViewControllers/MediaGallery/MediaItemViewController.swift
+++ b/Signal/src/ViewControllers/MediaGallery/MediaItemViewController.swift
@@ -9,9 +9,9 @@ import SignalUI
 import YYImage
 
 protocol MediaItemViewControllerDelegate: AnyObject {
-
     func mediaItemViewControllerDidTapMedia(_ viewController: MediaItemViewController)
     func mediaItemViewControllerWillBeginZooming(_ viewController: MediaItemViewController)
+    func mediaItemViewControllerFullyZoomedOut(_ viewController: MediaItemViewController)
 }
 
 protocol VideoPlaybackStatusProvider: AnyObject {
@@ -403,6 +403,13 @@ extension MediaItemViewController: UIScrollViewDelegate {
         delegate?.mediaItemViewControllerWillBeginZooming(self)
     }
 
+    //This is called at the end of whenever we zoom in, or zoom out. "Zooming" in this context means both zooming in and out.
+    func scrollViewDidEndZooming(_ scrollView: UIScrollView, with view: UIView?, atScale scale: CGFloat) {
+        if scale <= scrollView.minimumZoomScale {
+            delegate?.mediaItemViewControllerFullyZoomedOut(self)
+        }
+    }
+    
     func scrollViewDidZoom(_ scrollView: UIScrollView) {
         updateZoomScaleAndConstraints()
         view.layoutIfNeeded()

--- a/Signal/src/ViewControllers/MediaGallery/MediaPageViewController.swift
+++ b/Signal/src/ViewControllers/MediaGallery/MediaPageViewController.swift
@@ -725,13 +725,17 @@ extension MediaPageViewController: MediaGalleryDelegate {
 }
 
 extension MediaPageViewController: MediaItemViewControllerDelegate {
-
+    
     func mediaItemViewControllerDidTapMedia(_ viewController: MediaItemViewController) {
         setShouldHideToolbars(!shouldHideToolbars, animated: true)
     }
 
     func mediaItemViewControllerWillBeginZooming(_ viewController: MediaItemViewController) {
         setShouldHideToolbars(true, animated: true)
+    }
+    
+    func mediaItemViewControllerFullyZoomedOut(_ viewController: MediaItemViewController) {
+        setShouldHideToolbars(false, animated: true)
     }
 }
 


### PR DESCRIPTION
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 16, iOS 18.2

- - - - - - - - - -

### Description
Fixed a bug causing the navigation bar to disappear and not able to reappear while specifically zooming on the MediaPageViewController. I tested this by repeatedly trying different combinations of tapping and zooming in and out of an image to make the navigation bar appear and disappear. This `fixes #5889`.

https://github.com/user-attachments/assets/da8a175b-4b09-492e-9501-5fec68ded184
