### PR TITLE
#5921 photo picker for stories cannot pick new photos

### DIFF
--- a/Signal/src/ViewControllers/Photos/ImagePickerController.swift
+++ b/Signal/src/ViewControllers/Photos/ImagePickerController.swift
@@ -92,12 +92,7 @@ class ImagePickerGridController: UICollectionViewController, PhotoLibraryDelegat
         cancelButton.tintColor = Theme.darkThemePrimaryColor
         navigationItem.leftBarButtonItem = cancelButton
         
-        let privacyButton: UIBarButtonItem = .button(icon: .settingsPrivacy, style: .plain) { [weak self] in
-            guard let self else { return }
-            
-        }
-        privacyButton.menu = UIMenu(children: [createSelectMoreActionForPrivacyButton(), createSettingsActionForPrivacyButton()])
-        //privacyButton.showsMenuAsPrimaryAction
+        let privacyButton: UIBarButtonItem = .button(icon: .settingsPrivacy, children: [createSelectMoreActionForPrivacyButton(), createSettingsActionForPrivacyButton()])
         privacyButton.tintColor = Theme.darkThemePrimaryColor
         navigationItem.rightBarButtonItem = privacyButton
 

--- a/Signal/src/ViewControllers/Photos/ImagePickerController.swift
+++ b/Signal/src/ViewControllers/Photos/ImagePickerController.swift
@@ -95,8 +95,9 @@ class ImagePickerGridController: UICollectionViewController, PhotoLibraryDelegat
         let privacyButton: UIBarButtonItem = .button(icon: .settingsPrivacy, children: [createSelectMoreActionForPrivacyButton(), createSettingsActionForPrivacyButton()])
         privacyButton.tintColor = Theme.darkThemePrimaryColor
         navigationItem.rightBarButtonItem = privacyButton
+        updatePrivacyButtonVisibility()
 
-        view.addSubview(doneButton) //Why do we have a done button despite us having a cancel button in the navigation view?
+        view.addSubview(doneButton)
         doneButton.autoPinBottomToSuperviewMargin(withInset: UIDevice.current.hasIPhoneXNotch ? 8 : 16)
         doneButton.autoPinTrailingToSuperviewMargin()
 
@@ -105,6 +106,8 @@ class ImagePickerGridController: UICollectionViewController, PhotoLibraryDelegat
         self.selectionPanGesture = selectionPanGesture
         collectionView.addGestureRecognizer(selectionPanGesture)
     }
+    
+
     
     private func createSelectMoreActionForPrivacyButton() -> UIAction {
         let selectMoreAction = UIAction(
@@ -131,6 +134,18 @@ class ImagePickerGridController: UICollectionViewController, PhotoLibraryDelegat
             }
         }
         return settingsAction
+    }
+    
+    private func updatePrivacyButtonVisibility() {
+        if isPhotoPermissionLimited {
+            navigationItem.rightBarButtonItem?.isEnabled = true
+        } else {
+            navigationItem.rightBarButtonItem?.isEnabled = false
+        }
+    }
+    
+    private var isPhotoPermissionLimited: Bool {
+        return PHPhotoLibrary.authorizationStatus(for: .readWrite) == .limited
     }
     
     private var selectionPanGesture: UIPanGestureRecognizer?
@@ -347,6 +362,8 @@ class ImagePickerGridController: UICollectionViewController, PhotoLibraryDelegat
         collectionView.reloadData()
         collectionView.layoutIfNeeded()
     }
+    
+
 
     // MARK: - Actions
 
@@ -413,6 +430,7 @@ class ImagePickerGridController: UICollectionViewController, PhotoLibraryDelegat
     func photoLibraryDidChange(_ photoLibrary: PhotoLibrary) {
         photoAlbumContents = photoAlbum.contents()
         reloadData()
+        updatePrivacyButtonVisibility()
     }
 
     // MARK: - PhotoCollectionPicker Presentation

--- a/Signal/src/ViewControllers/Photos/ImagePickerController.swift
+++ b/Signal/src/ViewControllers/Photos/ImagePickerController.swift
@@ -5,6 +5,7 @@
 
 import Photos
 import SignalServiceKit
+import UIKit
 import SignalUI
 
 protocol ImagePickerGridControllerDelegate: AnyObject {
@@ -91,11 +92,12 @@ class ImagePickerGridController: UICollectionViewController, PhotoLibraryDelegat
         cancelButton.tintColor = Theme.darkThemePrimaryColor
         navigationItem.leftBarButtonItem = cancelButton
         
-        let privacyButton: UIBarButtonItem = .button(icon: .settingsPrivacy, style: .done) { [weak self] in
+        let privacyButton: UIBarButtonItem = .button(icon: .settingsPrivacy, style: .plain) { [weak self] in
             guard let self else { return }
             
         }
-        //privacyButton.menu =
+        privacyButton.menu = UIMenu(children: [createSelectMoreActionForPrivacyButton(), createSettingsActionForPrivacyButton()])
+        //privacyButton.showsMenuAsPrimaryAction
         privacyButton.tintColor = Theme.darkThemePrimaryColor
         navigationItem.rightBarButtonItem = privacyButton
 
@@ -116,34 +118,26 @@ class ImagePickerGridController: UICollectionViewController, PhotoLibraryDelegat
                 comment: "Button in a context menu from the 'privacy' button in attachment panel that allows to select more photos/videos to give Signal access to"),
             image: UIImage(named: "album-tilt-light")
         ) { _ in
-            
+            guard let frontmostVC = CurrentAppContext().frontmostViewController() else { return }
+            PHPhotoLibrary.shared().presentLimitedLibraryPicker(from: frontmostVC)
         }
         return selectMoreAction
     }
     
-//    let selectMoreAction = UIAction(
-//        title: OWSLocalizedString(
-//            "ATTACHMENT_KEYBOARD_CONTEXT_MENU_BUTTON_SELECT_MORE",
-//            comment: "Button in a context menu from the 'manage' button in attachment panel that allows to select more photos/videos to give Signal access to"
-//        ),
-//        image: UIImage(named: "album-tilt-light")
-//    ) { _ in
-//        guard let frontmostVC = CurrentAppContext().frontmostViewController() else { return }
-//        PHPhotoLibrary.shared().presentLimitedLibraryPicker(from: frontmostVC)
-//    }
-//    let settingsAction = UIAction(
-//        title: OWSLocalizedString(
-//            "ATTACHMENT_KEYBOARD_CONTEXT_MENU_BUTTON_SYSTEM_SETTINGS",
-//            comment: "Button in a context menu from the 'manage' button in attachment panel that opens the iOS system settings for Signal to update access permissions"
-//        ),
-//        image: UIImage(named: "settings-light")
-//    ) { _ in
-//        let openSettingsURL = URL(string: UIApplication.openSettingsURLString)!
-//        UIApplication.shared.open(openSettingsURL)
-//    }
-//    button.menu = UIMenu(children: [selectMoreAction, settingsAction])
-//    button.showsMenuAsPrimaryAction = true
-
+    private func createSettingsActionForPrivacyButton() -> UIAction {
+        let settingsAction = UIAction(
+            title: OWSLocalizedString(
+                "ATTACHMENT_KEYBOARD_CONTEXT_MENU_BUTTON_SYSTEM_SETTINGS",
+                comment: "Button in a context menu from the 'privacy' button in attachment panel that opens the iOS system settings for Signal to update access permissions"),
+            image: UIImage(named: "settings-light")
+        ) { _ in
+            if let openSettingsURL = URL(string: UIApplication.openSettingsURLString) {
+                UIApplication.shared.open(openSettingsURL)
+            }
+        }
+        return settingsAction
+    }
+    
     private var selectionPanGesture: UIPanGestureRecognizer?
     private enum BatchSelectionGestureMode {
         case select, deselect

--- a/Signal/src/ViewControllers/Photos/ImagePickerController.swift
+++ b/Signal/src/ViewControllers/Photos/ImagePickerController.swift
@@ -90,8 +90,16 @@ class ImagePickerGridController: UICollectionViewController, PhotoLibraryDelegat
         }
         cancelButton.tintColor = Theme.darkThemePrimaryColor
         navigationItem.leftBarButtonItem = cancelButton
+        
+        let privacyButton: UIBarButtonItem = .button(icon: .settingsPrivacy, style: .done) { [weak self] in
+            guard let self else { return }
+            
+        }
+        //privacyButton.menu =
+        privacyButton.tintColor = Theme.darkThemePrimaryColor
+        navigationItem.rightBarButtonItem = privacyButton
 
-        view.addSubview(doneButton)
+        view.addSubview(doneButton) //Why do we have a done button despite us having a cancel button in the navigation view?
         doneButton.autoPinBottomToSuperviewMargin(withInset: UIDevice.current.hasIPhoneXNotch ? 8 : 16)
         doneButton.autoPinTrailingToSuperviewMargin()
 
@@ -100,6 +108,41 @@ class ImagePickerGridController: UICollectionViewController, PhotoLibraryDelegat
         self.selectionPanGesture = selectionPanGesture
         collectionView.addGestureRecognizer(selectionPanGesture)
     }
+    
+    private func createSelectMoreActionForPrivacyButton() -> UIAction {
+        let selectMoreAction = UIAction(
+            title: OWSLocalizedString(
+                "ATTACHMENT_KEYBOARD_CONTEXT_MENU_BUTTON_SELECT_MORE",
+                comment: "Button in a context menu from the 'privacy' button in attachment panel that allows to select more photos/videos to give Signal access to"),
+            image: UIImage(named: "album-tilt-light")
+        ) { _ in
+            
+        }
+        return selectMoreAction
+    }
+    
+//    let selectMoreAction = UIAction(
+//        title: OWSLocalizedString(
+//            "ATTACHMENT_KEYBOARD_CONTEXT_MENU_BUTTON_SELECT_MORE",
+//            comment: "Button in a context menu from the 'manage' button in attachment panel that allows to select more photos/videos to give Signal access to"
+//        ),
+//        image: UIImage(named: "album-tilt-light")
+//    ) { _ in
+//        guard let frontmostVC = CurrentAppContext().frontmostViewController() else { return }
+//        PHPhotoLibrary.shared().presentLimitedLibraryPicker(from: frontmostVC)
+//    }
+//    let settingsAction = UIAction(
+//        title: OWSLocalizedString(
+//            "ATTACHMENT_KEYBOARD_CONTEXT_MENU_BUTTON_SYSTEM_SETTINGS",
+//            comment: "Button in a context menu from the 'manage' button in attachment panel that opens the iOS system settings for Signal to update access permissions"
+//        ),
+//        image: UIImage(named: "settings-light")
+//    ) { _ in
+//        let openSettingsURL = URL(string: UIApplication.openSettingsURLString)!
+//        UIApplication.shared.open(openSettingsURL)
+//    }
+//    button.menu = UIMenu(children: [selectMoreAction, settingsAction])
+//    button.showsMenuAsPrimaryAction = true
 
     private var selectionPanGesture: UIPanGestureRecognizer?
     private enum BatchSelectionGestureMode {

--- a/SignalUI/UIKitExtensions/UIButton+SignalUI.swift
+++ b/SignalUI/UIKitExtensions/UIButton+SignalUI.swift
@@ -205,10 +205,6 @@ public extension UIBarButtonItem {
             self.handler = handler
         }
     }
-    /*
-     Instead of having all of these different kinds of methods for the different kinds of combinatins of buttons, invest in turning
-     all of this into either a builder or a fluent builder. https://www.geeksforgeeks.org/builder-fluent-builder-and-faceted-builder-method-design-pattern-in-java/
-     */
     
     /// Creates a bar button with the given title that performs the action in the provided closure.
     static func button(

--- a/SignalUI/UIKitExtensions/UIButton+SignalUI.swift
+++ b/SignalUI/UIKitExtensions/UIButton+SignalUI.swift
@@ -205,7 +205,11 @@ public extension UIBarButtonItem {
             self.handler = handler
         }
     }
-
+    /*
+     Instead of having all of these different kinds of methods for the different kinds of combinatins of buttons, invest in turning
+     all of this into either a builder or a fluent builder. https://www.geeksforgeeks.org/builder-fluent-builder-and-faceted-builder-method-design-pattern-in-java/
+     */
+    
     /// Creates a bar button with the given title that performs the action in the provided closure.
     static func button(
         title: String,

--- a/SignalUI/UIKitExtensions/UIButton+SignalUI.swift
+++ b/SignalUI/UIKitExtensions/UIButton+SignalUI.swift
@@ -227,6 +227,14 @@ public extension UIBarButtonItem {
     ) -> UIBarButtonItem {
         ClosureBarButtonItem(image: Theme.iconImage(icon), style: style, action: action)
     }
+    
+    /// Creates a bar button with the given icon that opens the provided context menu children
+    static func button(
+        icon: ThemeIcon,
+        children: [UIMenuElement]
+    ) -> UIBarButtonItem {
+        return UIBarButtonItem(image: Theme.iconImage(icon), menu: UIMenu(children: children))
+    }
 
     // Keep this static function public instead of exposing ClosureBarButtonItem
     // because ClosureBarButtonItem will only function properly if using its


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 16, iOS 18.2
 * iPad Pro 13-inch, iOS 18.2

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

**Pull Request Description**
 
This pull request proposes a solution to the issue where the photo picker for stories in Signal cannot pick new photos. The current custom photo picker only enumerates photos for which Signal has been granted access, limiting users to selecting only previously granted photos. 

**Solution Overview**
 
The proposed solution is to use the native iOS image picker, allowing users to easily select and pick any photo on their device. This change aims to improve the user experience by providing a more streamlined and intuitive way to select photos for stories, while maintaining user control over their privacy settings. 

**Specifically, this pull request addresses the issue of Signal's custom photo picker not being able to pick new photos, as reported in #5921.**

**Testing and Verification**

To ensure the effectiveness of this solution, I conducted thorough testing on both iPhone and iPad devices. I varied the photo access permissions to simulate different user scenarios, verifying that the intended behavior was achieved. Specifically, I confirmed that when photo access permissions are limited, users can interact with the button to select more photos from the limited photo picker.