### PR TITLE
Fixed ConversationViewControllers collectionview from snapping upwards

### DIFF
--- a/Signal/ConversationView/ConversationViewController+OWS.swift
+++ b/Signal/ConversationView/ConversationViewController+OWS.swift
@@ -149,7 +149,10 @@ extension ConversationViewController {
 
                 // This offset change will be animated by UIKit's UIView animation block
                 // which updateContentInsets() is called within
-                collectionView.setContentOffset(newOffset, animated: false)
+                //Keyboard check hack. We need to invest time in cleaning all of this up. This is way too complicated for checking for offsets to move a scrollviews insets and offsets. It is not sustainable
+                if keyboardOverlap > 40 || keyboardOverlap < 5 {
+                    collectionView.setContentOffset(newOffset, animated: false)
+                }
             }
         }
     }


### PR DESCRIPTION

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 16, iOS 18.2
 * iPad Pro 13-inch, iOS 18.2

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->


Created a workaround to prevent the collection view from snapping upwards upon scrolling the on-screen keyboard down. This `fixes #5854`. We need to invest a considerable amount of time to refactor all of this logic as continuing to add to it is unsustainable. Maybe we can invest time in converting ConversationViewController to SwiftUI?