### PR TITLE
Changed NavigationBar color for HostingViewControllers

### DIFF
--- a/SignalUI/SwiftUIExtensions/HostingController.swift
+++ b/SignalUI/SwiftUIExtensions/HostingController.swift
@@ -128,7 +128,7 @@ extension HostingController: OWSNavigationChildController {
     }
 
     public var navbarBackgroundColorOverride: UIColor? {
-        usesSolidNavbarStyle ? Theme.navbarBackgroundColor : nil
+        usesSolidNavbarStyle ? UIColor.Signal.background : nil
     }
 }
 

--- a/SignalUI/SwiftUIExtensions/HostingController.swift
+++ b/SignalUI/SwiftUIExtensions/HostingController.swift
@@ -128,7 +128,7 @@ extension HostingController: OWSNavigationChildController {
     }
 
     public var navbarBackgroundColorOverride: UIColor? {
-        usesSolidNavbarStyle ? UIColor.Signal.groupedBackground : nil
+        usesSolidNavbarStyle ? Theme.navbarBackgroundColor : nil
     }
 }
 


### PR DESCRIPTION


<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 16, iOS 18.2

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

This pull request `fixed #5941` by changing color for the navigation bars in hostingviewcontrollers. Since we have Theme presets now we should retire these UIColor extensions. I tested this by previewing the RequestPermissionViewController in both dark mode and light more to make sure that it is colored correctly.
