### PR TITLE
Allow the user to open truncated messages in EditHistoryViewController

### DIFF
--- a/Signal/src/ViewControllers/EditHistoryTableSheetViewController.swift
+++ b/Signal/src/ViewControllers/EditHistoryTableSheetViewController.swift
@@ -189,8 +189,8 @@ class EditHistoryTableSheetViewController: OWSTableSheetViewController {
     @objc
     func didTapCell(_ recognizer: UITapGestureRecognizer) {
         guard
-            let index = recognizer.view?.tag,
-            let item = renderItems[safe: index],
+            let view = recognizer.view as? CVCellView,
+            let item = view.renderItem,
             item.itemModel.componentState.displayableBodyText?.isTextTruncated == true
         else {
             return


### PR DESCRIPTION


<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 16 iOS 18.2

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

This small change `fixes #5774` by allowing the user to open older messages and the beginning message when they have truncated content in them. I tested this by having several edited messages with truncated content and being able to open each one. 
