### PR TITLE
#5898 Quick Reply

### DIFF
--- a/Signal/ConversationView/ConversationViewController+GestureRecognizers.swift
+++ b/Signal/ConversationView/ConversationViewController+GestureRecognizers.swift
@@ -364,7 +364,7 @@ public struct CVLongPressHandler {
 
         switch gestureLocation {
         case .`default`:
-            // TODO: Rename from "Text view item" to "default"?
+            // TODO: Rename from "Text view item" to "default"? - "TextViewItem" is more descriptive imho. Lets keep that.
             delegate.didLongPressTextViewItem(cell,
                                               itemViewModel: itemViewModel,
                                               shouldAllowReply: shouldAllowReply)

--- a/Signal/ConversationView/ConversationViewController+GestureRecognizers.swift
+++ b/Signal/ConversationView/ConversationViewController+GestureRecognizers.swift
@@ -364,7 +364,6 @@ public struct CVLongPressHandler {
 
         switch gestureLocation {
         case .`default`:
-            // TODO: Rename from "Text view item" to "default"? - "TextViewItem" is more descriptive imho. Lets keep that.
             delegate.didLongPressTextViewItem(cell,
                                               itemViewModel: itemViewModel,
                                               shouldAllowReply: shouldAllowReply)

--- a/Signal/Notifications/NotificationActionHandler.swift
+++ b/Signal/Notifications/NotificationActionHandler.swift
@@ -120,9 +120,13 @@ public class NotificationActionHandler {
     private class func reply(userInfo: [AnyHashable: Any], replyText: String) throws -> Promise<Void> {
         return firstly { () -> Promise<NotificationMessage> in
             self.notificationMessage(forUserInfo: userInfo)
-        }.then(on: DispatchQueue.global()) { (notificationMessage: NotificationMessage) -> Promise<Void> in
-            let thread = notificationMessage.thread
-            let interaction = notificationMessage.interaction
+        }.then(on: DispatchQueue.global()) { (notificationMessage: NotificationMessage) -> Promise<(DraftQuotedReplyModel?, NotificationMessage)> in
+            return getDraftQuotedReplyModelTupleFromIncomingMessage(notificationMessage: notificationMessage)
+        }.then(on: DispatchQueue.global()) { (informationTuple: (draft: DraftQuotedReplyModel?, notificationMessage: NotificationMessage)) -> Promise<(DraftQuotedReplyModel.ForSending?, NotificationMessage)> in
+            return getDraftQuotedReplyModelForSendingTupleFromDraftAndIncomingMessage(optionalDraftModel: informationTuple.draft, notificationMessage: informationTuple.notificationMessage)
+        }.then(on: DispatchQueue.global()) { (informationTuple: (draft: DraftQuotedReplyModel.ForSending?, notificationMessage: NotificationMessage)) -> Promise<Void> in
+            let thread = informationTuple.notificationMessage.thread
+            let interaction = informationTuple.notificationMessage.interaction
             guard (interaction is TSOutgoingMessage) || (interaction is TSIncomingMessage) else {
                 throw OWSAssertionError("Unexpected interaction type.")
             }
@@ -135,7 +139,7 @@ public class NotificationActionHandler {
                     // If we're replying to a group story reply, keep the reply within that context.
                     if
                         let incomingMessage = interaction as? TSIncomingMessage,
-                        notificationMessage.isGroupStoryReply,
+                        informationTuple.notificationMessage.isGroupStoryReply,
                         let storyTimestamp = incomingMessage.storyTimestamp,
                         let storyAuthorAci = incomingMessage.storyAuthorAci
                     {
@@ -156,7 +160,7 @@ public class NotificationActionHandler {
                         explicitRecipients: [],
                         skippedRecipients: [],
                         transaction: transaction
-                    ))
+                    ), quotedReplyDraft: informationTuple.draft)
                     do {
                         let preparedMessage = try unpreparedMessage.prepare(tx: transaction)
                         return ThreadUtil.enqueueMessagePromise(message: preparedMessage, transaction: transaction)
@@ -169,37 +173,37 @@ public class NotificationActionHandler {
                 SSKEnvironment.shared.notificationPresenterRef.notifyUserOfFailedSend(inThread: thread)
                 throw error
             }.then(on: DispatchQueue.global()) { () -> Promise<Void> in
-                self.markMessageAsRead(notificationMessage: notificationMessage)
+                self.markMessageAsRead(notificationMessage: informationTuple.notificationMessage)
             }
         }
+    }
+            
+    private class func getDraftQuotedReplyModelTupleFromIncomingMessage(notificationMessage: NotificationMessage) -> Promise<(DraftQuotedReplyModel?, NotificationMessage)> {
+        let (promise, future) = Promise<(DraftQuotedReplyModel?, NotificationMessage)>.pending()
+        SSKEnvironment.shared.databaseStorageRef.read { readTransaction in
+            if
+                let incomingMessage = notificationMessage.interaction as? TSIncomingMessage,
+                let draftQuotedReplyModel = DependenciesBridge.shared.quotedReplyManager.buildDraftQuotedReply(originalMessage: incomingMessage, tx: readTransaction.asV2Read) {
+                future.resolve((draftQuotedReplyModel, notificationMessage))
+            }
+            return future.resolve((nil, notificationMessage))
+        }
+        return promise
     }
     
-    private class func getDraftQuotedReplyModelForSendingFromIncomingMessage(notificationMessage: NotificationMessage) throws -> Promise<DraftQuotedReplyModel.ForSending?> {
-        return firstly { () -> Promise<DraftQuotedReplyModel?> in
-            return getDraftQuotedReplyModelFromIncomingMessage(notificationMessage: notificationMessage)
-        }.then(on: DispatchQueue.global()) { (optionalDraftModel: DraftQuotedReplyModel?) -> Promise<DraftQuotedReplyModel.ForSending?> in
-            return firstly(on: DispatchQueue.global()) {
-                if let draftModel = optionalDraftModel {
-                    return try DependenciesBridge.shared.quotedReplyManager.prepareDraftForSending(draftModel)
-                }
-                return nil
-            }
+    private class func getDraftQuotedReplyModelForSendingTupleFromDraftAndIncomingMessage(optionalDraftModel: DraftQuotedReplyModel?, notificationMessage: NotificationMessage) -> Promise<(DraftQuotedReplyModel.ForSending?, NotificationMessage)> {        
+        guard let draftModel = optionalDraftModel else {
+            return Promise.value((nil, notificationMessage))
         }
-    }
-    
-    private class func getDraftQuotedReplyModelFromIncomingMessage(notificationMessage: NotificationMessage) -> Promise<DraftQuotedReplyModel?> {
-        return firstly(on: DispatchQueue.global()) {
-            return SSKEnvironment.shared.databaseStorageRef.read { readTransaction in
-                if
-                    let incomingMessage = notificationMessage.interaction as? TSIncomingMessage,
-                    let draftQuotedReplyModel = DependenciesBridge.shared.quotedReplyManager.buildDraftQuotedReply(originalMessage: incomingMessage, tx: readTransaction.asV2Read) {
-                    return draftQuotedReplyModel
-                }
-                return nil
-            }
-        }
-    }
         
+        do {
+            let draftForSending = try DependenciesBridge.shared.quotedReplyManager.prepareDraftForSending(draftModel)
+            return Promise.value((draftForSending, notificationMessage))
+        } catch {
+            return Promise.value((nil, notificationMessage))
+        }
+    }
+    
     private class func sendReplyToNoficationMessageWithMessageToReplyTo(replyText: String, messageBeingRespondedTo: DraftQuotedReplyModel.ForSending?, notificationMessage: NotificationMessage) throws -> Promise<Void> {
         return SSKEnvironment.shared.databaseStorageRef.write { transaction in
             let builder: TSOutgoingMessageBuilder = .withDefaultValues(thread: notificationMessage.thread)

--- a/Signal/Notifications/NotificationActionHandler.swift
+++ b/Signal/Notifications/NotificationActionHandler.swift
@@ -111,16 +111,15 @@ public class NotificationActionHandler {
 
     private class func markAsRead(userInfo: [AnyHashable: Any]) throws -> Promise<Void> {
         return firstly {
-            self.notificationMessage(forUserInfo: userInfo)
+            self.getNotificationMessage(forUserInfo: userInfo)
         }.then(on: DispatchQueue.global()) { (notificationMessage: NotificationMessage) in
             self.markMessageAsRead(notificationMessage: notificationMessage)
         }
     }
 
     private class func reply(userInfo: [AnyHashable: Any], replyText: String) throws -> Promise<Void> {
-        
         return firstly { () -> Promise<NotificationMessage> in
-            self.notificationMessage(forUserInfo: userInfo)
+            return self.getNotificationMessage(forUserInfo: userInfo)
         }.then(on: DispatchQueue.global()) { (notificationMessage: NotificationMessage) -> Promise<Void> in
             try sendReplyToNotificationMessage(replyText: replyText, notificationMessage: notificationMessage)
         }
@@ -202,7 +201,7 @@ public class NotificationActionHandler {
 
     private class func showThread(userInfo: [AnyHashable: Any]) throws -> Promise<Void> {
         return firstly { () -> Promise<NotificationMessage> in
-            self.notificationMessage(forUserInfo: userInfo)
+            self.getNotificationMessage(forUserInfo: userInfo)
         }.done(on: DispatchQueue.main) { notificationMessage in
             if notificationMessage.isGroupStoryReply {
                 self.showGroupStoryReplyThread(notificationMessage: notificationMessage)
@@ -274,7 +273,7 @@ public class NotificationActionHandler {
 
     private class func reactWithThumbsUp(userInfo: [AnyHashable: Any]) throws -> Promise<Void> {
         return firstly { () -> Promise<NotificationMessage> in
-            self.notificationMessage(forUserInfo: userInfo)
+            self.getNotificationMessage(forUserInfo: userInfo)
         }.then(on: DispatchQueue.global()) { (notificationMessage: NotificationMessage) -> Promise<Void> in
             let thread = notificationMessage.thread
             let interaction = notificationMessage.interaction
@@ -405,7 +404,7 @@ public class NotificationActionHandler {
         let hasPendingMessageRequest: Bool
     }
 
-    private class func notificationMessage(forUserInfo userInfo: [AnyHashable: Any]) -> Promise<NotificationMessage> {
+    private class func getNotificationMessage(forUserInfo userInfo: [AnyHashable: Any]) -> Promise<NotificationMessage> {
         firstly(on: DispatchQueue.global()) { () throws -> NotificationMessage in
             guard let threadId = userInfo[AppNotificationUserInfoKey.threadId] as? String else {
                 throw OWSAssertionError("threadId was unexpectedly nil")

--- a/Signal/Notifications/NotificationActionHandler.swift
+++ b/Signal/Notifications/NotificationActionHandler.swift
@@ -149,7 +149,12 @@ public class NotificationActionHandler {
                         builder.expiresInSeconds = dmConfig.durationSeconds
                         builder.expireTimerVersion = NSNumber(value: dmConfig.timerVersion)
                     }
-
+                    
+                    if let incomingMessage = interaction as? TSIncomingMessage {
+                        let quotedMessage = TSQuotedMessage(timestamp: incomingMessage.serverTimestamp, authorAddress: incomingMessage.authorAddress, body: incomingMessage.body, bodyRanges: incomingMessage.bodyRanges, quotedAttachmentForSending: nil, isGiftBadge: incomingMessage.giftBadge != nil, isTargetMessageViewOnce: false)
+                        builder.quotedMessage = quotedMessage
+                    }
+                    
                     let unpreparedMessage = UnpreparedOutgoingMessage.forMessage(TSOutgoingMessage(
                         outgoingMessageWith: builder,
                         additionalRecipients: [],

--- a/Signal/Notifications/NotificationActionHandler.swift
+++ b/Signal/Notifications/NotificationActionHandler.swift
@@ -118,63 +118,84 @@ public class NotificationActionHandler {
     }
 
     private class func reply(userInfo: [AnyHashable: Any], replyText: String) throws -> Promise<Void> {
+        
         return firstly { () -> Promise<NotificationMessage> in
             self.notificationMessage(forUserInfo: userInfo)
         }.then(on: DispatchQueue.global()) { (notificationMessage: NotificationMessage) -> Promise<Void> in
-            let thread = notificationMessage.thread
-            let interaction = notificationMessage.interaction
-            guard (interaction is TSOutgoingMessage) || (interaction is TSIncomingMessage) else {
-                throw OWSAssertionError("Unexpected interaction type.")
+            try sendReplyToNotificationMessage(replyText: replyText, notificationMessage: notificationMessage)
+        }
+    }
+    
+    private class func sendReplyToNotificationMessage(replyText: String, notificationMessage: NotificationMessage) throws -> Promise<Void> {
+        let thread = notificationMessage.thread
+        let interaction = notificationMessage.interaction
+        guard (interaction is TSOutgoingMessage) || (interaction is TSIncomingMessage) else {
+            throw OWSAssertionError("Unexpected interaction type.")
+        }
+        return firstly(on: DispatchQueue.global()) { () -> Promise<Void> in
+            SSKEnvironment.shared.databaseStorageRef.write { transaction in
+                let builder: TSOutgoingMessageBuilder = .withDefaultValues(thread: thread)
+                builder.messageBody = replyText
+
+                // If we're replying to a group story reply, keep the reply within that context.
+                if
+                    let incomingMessage = interaction as? TSIncomingMessage,
+                    notificationMessage.isGroupStoryReply,
+                    let storyTimestamp = incomingMessage.storyTimestamp,
+                    let storyAuthorAci = incomingMessage.storyAuthorAci
+                {
+                    builder.storyTimestamp = storyTimestamp
+                    builder.storyAuthorAci = storyAuthorAci
+                } else {
+                    // We only use the thread's DM timer for normal messages & 1:1 story
+                    // replies -- group story replies last for the lifetime of the story.
+                    let dmConfigurationStore = DependenciesBridge.shared.disappearingMessagesConfigurationStore
+                    let dmConfig = dmConfigurationStore.fetchOrBuildDefault(for: .thread(thread), tx: transaction.asV2Read)
+                    builder.expiresInSeconds = dmConfig.durationSeconds
+                    builder.expireTimerVersion = NSNumber(value: dmConfig.timerVersion)
+                }
+                
+//                if let incomingMessage = interaction as? TSIncomingMessage {
+//                    let quotedMessage = TSQuotedMessage(timestamp: incomingMessage.serverTimestamp, authorAddress: incomingMessage.authorAddress, body: incomingMessage.body, bodyRanges: incomingMessage.bodyRanges, quotedAttachmentForSending: nil, isGiftBadge: incomingMessage.giftBadge != nil, isTargetMessageViewOnce: false)
+//                    builder.quotedMessage = quotedMessage
+//                }
+                
+                let outgoingMessage = TSOutgoingMessage(
+                    outgoingMessageWith: builder,
+                    additionalRecipients: [],
+                    explicitRecipients: [],
+                    skippedRecipients: [],
+                    transaction: transaction
+                )
+                
+                let unpreparedMessage = UnpreparedOutgoingMessage.forMessage(outgoingMessage)
+                do {
+                    let preparedMessage = try unpreparedMessage.prepare(tx: transaction)
+                    return ThreadUtil.enqueueMessagePromise(message: preparedMessage, transaction: transaction)
+                } catch {
+                    return Promise(error: error)
+                }
             }
-
-            return firstly(on: DispatchQueue.global()) { () -> Promise<Void> in
-                SSKEnvironment.shared.databaseStorageRef.write { transaction in
-                    let builder: TSOutgoingMessageBuilder = .withDefaultValues(thread: thread)
-                    builder.messageBody = replyText
-
-                    // If we're replying to a group story reply, keep the reply within that context.
-                    if
-                        let incomingMessage = interaction as? TSIncomingMessage,
-                        notificationMessage.isGroupStoryReply,
-                        let storyTimestamp = incomingMessage.storyTimestamp,
-                        let storyAuthorAci = incomingMessage.storyAuthorAci
-                    {
-                        builder.storyTimestamp = storyTimestamp
-                        builder.storyAuthorAci = storyAuthorAci
-                    } else {
-                        // We only use the thread's DM timer for normal messages & 1:1 story
-                        // replies -- group story replies last for the lifetime of the story.
-                        let dmConfigurationStore = DependenciesBridge.shared.disappearingMessagesConfigurationStore
-                        let dmConfig = dmConfigurationStore.fetchOrBuildDefault(for: .thread(thread), tx: transaction.asV2Read)
-                        builder.expiresInSeconds = dmConfig.durationSeconds
-                        builder.expireTimerVersion = NSNumber(value: dmConfig.timerVersion)
-                    }
-                    
-                    if let incomingMessage = interaction as? TSIncomingMessage {
-                        let quotedMessage = TSQuotedMessage(timestamp: incomingMessage.serverTimestamp, authorAddress: incomingMessage.authorAddress, body: incomingMessage.body, bodyRanges: incomingMessage.bodyRanges, quotedAttachmentForSending: nil, isGiftBadge: incomingMessage.giftBadge != nil, isTargetMessageViewOnce: false)
-                        builder.quotedMessage = quotedMessage
-                    }
-                    
-                    let unpreparedMessage = UnpreparedOutgoingMessage.forMessage(TSOutgoingMessage(
-                        outgoingMessageWith: builder,
-                        additionalRecipients: [],
-                        explicitRecipients: [],
-                        skippedRecipients: [],
-                        transaction: transaction
-                    ))
-                    do {
-                        let preparedMessage = try unpreparedMessage.prepare(tx: transaction)
-                        return ThreadUtil.enqueueMessagePromise(message: preparedMessage, transaction: transaction)
-                    } catch {
-                        return Promise(error: error)
+        }.recover(on: DispatchQueue.global()) { error -> Promise<Void> in
+            Logger.warn("Failed to send reply message from notification with error: \(error)")
+            SSKEnvironment.shared.notificationPresenterRef.notifyUserOfFailedSend(inThread: thread)
+            throw error
+        }.then(on: DispatchQueue.global()) { () -> Promise<Void> in
+            self.markMessageAsRead(notificationMessage: notificationMessage)
+        }
+    }
+    
+    private class func getDraftQuotedReplyModelForSendingFromIncomingMessage(notificationMessage: NotificationMessage) -> Promise<DraftQuotedReplyModel.ForSending?> {
+        return firstly(on: DispatchQueue.global()) { () -> DraftQuotedReplyModel.ForSending? in
+            var draftQuotedReplayModelForSending: DraftQuotedReplyModel.ForSending?
+            return SSKEnvironment.shared.databaseStorageRef.read { readTransaction in
+                //TODO: I dont know if this is the correct way to create a DraftQuotedReplyModel, but this is what I saw on ConversationViewController+MessageActionsDelegate line 190
+                if let incomingMessage = notificationMessage.interaction as? TSIncomingMessage {
+                    if let draftQuotedReplyModel = DependenciesBridge.shared.quotedReplyManager.buildDraftQuotedReply(originalMessage: incomingMessage, tx: readTransaction.asV2Read) {
+                        draftQuotedReplayModelForSending = try? DependenciesBridge.shared.quotedReplyManager.prepareDraftForSending(draftQuotedReplyModel)
                     }
                 }
-            }.recover(on: DispatchQueue.global()) { error -> Promise<Void> in
-                Logger.warn("Failed to send reply message from notification with error: \(error)")
-                SSKEnvironment.shared.notificationPresenterRef.notifyUserOfFailedSend(inThread: thread)
-                throw error
-            }.then(on: DispatchQueue.global()) { () -> Promise<Void> in
-                self.markMessageAsRead(notificationMessage: notificationMessage)
+                return draftQuotedReplayModelForSending
             }
         }
     }

--- a/Signal/Notifications/NotificationActionHandler.swift
+++ b/Signal/Notifications/NotificationActionHandler.swift
@@ -125,6 +125,7 @@ public class NotificationActionHandler {
         }
     }
         
+    //TODO: Lets invest a lot of time and resources in order to convert promises into using await Task as this below was the problem that await Task was created to solve.
     private class func sendReplyToNotificationMessage(replyText: String, notificationMessage: NotificationMessage) throws -> Promise<Void> {
         let thread = notificationMessage.thread
         let interaction = notificationMessage.interaction


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 16, iOS 18.2

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

This pull request `fixes #5898` by allowing users to see which message they quick replied to. Previously before this PR users were not able to see the message that they replied to by using quick reply in the Notification Content Extension. I tested this PR by performing this user requested feature to make sure that it functioned as laid out in the user issue ticket.


https://github.com/user-attachments/assets/3ef23951-d44f-4c47-b5d5-e4c202feba6e

