### PR TITLE
#5837 Disappearing Navigation Bar

### DIFF
--- a/Signal/ConversationView/ConversationViewController+UI.swift
+++ b/Signal/ConversationView/ConversationViewController+UI.swift
@@ -13,6 +13,12 @@ extension ConversationViewController {
 
         self.title = nil
 
+        //HACK: If you look at issue #5837, the navigation title view is disappering. You can confirm this by looking at the view hierarchy; however, the navigation titleview says that its title view is not nil. Setting active breakpoints in this function prevents the bug from happening. I'm confident that this is a UIKit bug. To get around this we simply remove and add the headerview back again. This seems to only happen with iPad
+        DispatchQueue.main.async { [weak self] in
+            self?.navigationItem.titleView = nil
+            self?.navigationItem.titleView = self?.headerView
+        }
+        
         if thread.isNoteToSelf {
             headerView.titleIcon = Theme.iconImage(.official)
             headerView.titleIconSize = 16


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 16, iOS 18.2
 * iPad Pro 13-inch M4, iOS 18.2

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

This proposal `fixes #5837` by provided a workaround the navigation bar disappearing. Exploring the codebase, there is no location where the navigation bar title view is hidden; however, as explained in the code comment in this PRs only commit, I am confident that this is a UIKit bug. This PR is a workaround until that UIKit bug is patched.