### PR TITLE
#5945 Modified OWSProfileManager to allow bio and bio emojis to be nil.

### DIFF
--- a/SignalServiceKit/Profiles/OWSProfileManager.swift
+++ b/SignalServiceKit/Profiles/OWSProfileManager.swift
@@ -460,17 +460,16 @@ extension OWSProfileManager: ProfileManager {
             } catch {
                 Logger.warn("Couldn't decrypt profile name: \(error)")
             }
+            //Bio and BioEmoji are allowed to be nil
             do {
-                if let bio = try decryptedProfile.bio.get() {
-                    bioChange = .setTo(bio)
-                }
+                let bio = try decryptedProfile.bio.get()
+                bioChange = .setTo(bio)
             } catch {
                 Logger.warn("Couldn't decrypt profile bio: \(error)")
             }
             do {
-                if let bioEmoji = try decryptedProfile.bioEmoji.get() {
-                    bioEmojiChange = .setTo(bioEmoji)
-                }
+                let bioEmoji = try decryptedProfile.bioEmoji.get()
+                bioEmojiChange = .setTo(bioEmoji)
             } catch {
                 Logger.warn("Couldn't decrypt profile bio emoji: \(error)")
             }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 16, iOS 18.2

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

This change `fixes #5945` by allowing the bio and/or bio emoji to be nil. This would happen if the user removes their bio and/or bio emoji.