### PR TITLE
Update Info.plist

### DIFF
--- a/SignalShareExtension/Info.plist
+++ b/SignalShareExtension/Info.plist
@@ -33,13 +33,6 @@
 				<key>NSThirdPartyExceptionRequiresForwardSecrecy</key>
 				<false/>
 			</dict>
-			<key>signal.org</key>
-			<dict>
-				<key>NSExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-				<key>NSIncludesSubdomains</key>
-				<true/>
-			</dict>
 		</dict>
 	</dict>
 	<key>NSExtension</key>


### PR DESCRIPTION
Remove exception for insecure loading of Signal group chat invites

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [ ] I have tested my contribution on these devices:
 * iDevice A, iOS X.Y.Z
 * iDevice B, iOS Z.Y

- - - - - - - - - -

### Description
<!--
When a user clicks on a group chat invite they are taken to the signal website where it informs the user to open the link with the signal app or to download and install signal to see the group chat. This should not be done in a way where the user's ISP is able to see what group chat they are trying to join.
-->
