### PR TITLE
Properly wait for dismissal before presenting a new view controller

### DIFF
--- a/SignalUI/AttachmentApproval/AttachmentPrepViewController.swift
+++ b/SignalUI/AttachmentApproval/AttachmentPrepViewController.swift
@@ -219,12 +219,15 @@ public class AttachmentPrepViewController: OWSViewController {
     private func presentFullScreen(viewController: UIViewController) {
         if let presentedViewController = presentedViewController {
             owsAssertDebug(false, "Already has presented view controller. [\(presentedViewController)]")
-            presentedViewController.dismiss(animated: false)
+            presentedViewController.dismiss(animated: false) { [weak self] in
+                self?.presentFullScreen(viewController: viewController)
+            }
+            return
         }
 
         viewController.modalPresentationStyle = .fullScreen
         zoomOut(animated: true) { [weak self] in
-            self?.presentFullScreen(viewController, animated: false)
+            self?.present(viewController, animated: false, completion: nil)
         }
     }
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 16 Pro (Xcode Simulator - 18.2)

- - - - - - - - - -

### Description
Potentially fixes #5976 

My theory, given the error in #5976, is that because the original code failed to wait for the dismissal to complete, it would occasionally try to present a new view while an existing view was present. This caused the animation for the navigation buttons in ImageEditorCropViewController and similar image editing views to be left in a state with no bottom navigation buttons. Therefore, the user has to force quit the app in order to exit the view. I think this may stabilize that flow and prevent such situations from occurring.

ImageEditorCropViewController:

I would imagine when encountering the error

`2025/02/20 00:54:25:091 ERR❤️ [AttachmentPrepViewController.swift:221 presentFullScreen(viewController:)]: Already has presented view controller. [<SignalUI.ImageEditorCropViewController: 0x127aef700>`

that it possibly short circuits or resets the logic responsible for summoning the bottom buttons. I was originally fixated on the logic summoning the buttons until I noticed a seemingly correlated error with the occurrence of the bug in AttachmentPrepViewController.

```
override func viewDidAppear(_ animated: Bool) {
        super.viewDidAppear(animated)

        transitionUI(toState: .final, animated: true)
    }
```

```
private func transitionUI(toState state: UIState, animated: Bool, completion: ((Bool) -> Void)? = nil) {
        let layoutGuide: UILayoutGuide = {
            switch state {
            case .initial: return initialStateContentLayoutGuide
            case .final: return finalStateContentLayoutGuide
            }
        }()

        let hideControls = state == .initial
        let setControlsHiddenBlock = {
            let alpha: CGFloat = hideControls ? 0 : 1
            self.footerView.alpha = alpha
            self.cropView.setState(state == .initial ? .initial : .normal, animated: false)
            self.bottomBar.setControls(hidden: hideControls)
        }

        let animationDuration: TimeInterval = 0.15

        let imageCornerRadius: CGFloat = state == .initial ? ImageEditorView.defaultCornerRadius : 0
        if animated {
            let animation = CABasicAnimation(keyPath: #keyPath(CALayer.cornerRadius))
            animation.fromValue = imageView.layer.cornerRadius
            animation.toValue = imageCornerRadius
            animation.duration = animationDuration
            imageView.layer.add(animation, forKey: "cornerRadius")
        }
        imageView.layer.cornerRadius = imageCornerRadius

        if animated {
            UIView.animate(withDuration: animationDuration,
                           animations: {
                setControlsHiddenBlock()
                self.constrainContent(to: layoutGuide)
                self.updateImageViewTransform()
                // Animate layout changes made within bottomBar.setControls(hidden:).
                self.view.setNeedsDisplay()
                self.view.layoutIfNeeded()
            },
                           completion: completion)
        } else {
            setControlsHiddenBlock()
            constrainContent(to: layoutGuide)
            updateImageViewTransform()
            completion?(true)
        }
    }
```
