### PR TITLE
Do not play animated GIFs, stickers when Reduce Motion is on

### DIFF
--- a/Signal/ConversationView/CVItemViewModelImpl.swift
+++ b/Signal/ConversationView/CVItemViewModelImpl.swift
@@ -236,6 +236,10 @@ extension CVItemViewModelImpl {
         AttachmentSharing.showShareUI(for: attachments, sender: sender)
     }
 
+    var isSticker: Bool {
+        return messageCellType == .stickerMessage
+    }
+
     var canForwardMessage: Bool {
         guard !isViewOnce else {
             return false

--- a/Signal/ConversationView/CellViews/CVMediaView.swift
+++ b/Signal/ConversationView/CellViews/CVMediaView.swift
@@ -155,7 +155,7 @@ public class CVMediaView: ManualLayoutViewWithLayer {
         mediaView.backgroundColor = isBorderless ? .clear : Theme.washColor
 
         if !addProgressIfNecessary() {
-            if reusableMediaView.isVideo {
+            if reusableMediaView.needsPlayButton {
                 addVideoPlayButton()
             }
         }

--- a/Signal/ConversationView/CellViews/ReusableMediaView.swift
+++ b/Signal/ConversationView/CellViews/ReusableMediaView.swift
@@ -65,6 +65,21 @@ public class ReusableMediaView: NSObject {
         mediaViewAdapter is MediaViewAdapterVideo
     }
 
+    var needsPlayButton: Bool {
+        mediaViewAdapter is MediaViewAdapterVideo
+        || (
+            UIAccessibility.isReduceMotionEnabled
+            && (
+                mediaViewAdapter is MediaViewAdapterLoopingVideo
+                || (
+                    mediaViewAdapter is MediaViewAdapterSticker
+                    && mediaViewAdapter.shouldBeRenderedByYY
+                )
+                || mediaViewAdapter is MediaViewAdapterAnimated
+            )
+        )
+    }
+
     // MARK: - LoadState
 
     // Thread-safe access to load state.
@@ -332,6 +347,7 @@ class MediaViewAdapterAnimated: MediaViewAdapterSwift {
             return
         }
         imageView.image = image
+        imageView.autoPlayAnimatedImage = !UIAccessibility.isReduceMotionEnabled
     }
 
     func unloadMedia() {
@@ -567,6 +583,9 @@ public class MediaViewAdapterSticker: NSObject, MediaViewAdapterSwift {
             guard let image = media as? YYImage else {
                 owsFailDebug("Media has unexpected type: \(type(of: media))")
                 return
+            }
+            if let yyView = imageView as? CVAnimatedImageView {
+                yyView.autoPlayAnimatedImage = !UIAccessibility.isReduceMotionEnabled
             }
             imageView.image = image
         } else {

--- a/Signal/ConversationView/ConversationViewController+MessageActions.swift
+++ b/Signal/ConversationView/ConversationViewController+MessageActions.swift
@@ -122,6 +122,7 @@ extension ConversationViewController: ContextMenuInteractionDelegate {
                     .showPaymentDetails,
                     .speak,
                     .stopSpeaking,
+                    .showStickerPack,
                     .info,
                     .delete
                 ]

--- a/Signal/ConversationView/ConversationViewController+MessageActionsDelegate.swift
+++ b/Signal/ConversationView/ConversationViewController+MessageActionsDelegate.swift
@@ -278,4 +278,10 @@ extension ConversationViewController: MessageActionsDelegate {
         let paymentsDetailViewController = PaymentsDetailViewController(paymentItem: paymentHistoryItem)
         navigationController?.pushViewController(paymentsDetailViewController, animated: true)
     }
+
+    func messageActionsShowStickerPack(_ itemViewModel: CVItemViewModelImpl) {
+        if let stickerMetadata = itemViewModel.stickerMetadata {
+            didTapStickerPack(stickerMetadata.packInfo)
+        }
+    }
 }

--- a/Signal/ConversationView/MessageActions.swift
+++ b/Signal/ConversationView/MessageActions.swift
@@ -15,6 +15,7 @@ protocol MessageActionsDelegate: AnyObject {
     func messageActionsStopSpeakingItem(_ itemViewModel: CVItemViewModelImpl)
     func messageActionsEditItem(_ itemViewModel: CVItemViewModelImpl)
     func messageActionsShowPaymentDetails(_ itemViewModel: CVItemViewModelImpl)
+    func messageActionsShowStickerPack(_ itemViewModel: CVItemViewModelImpl)
 }
 
 // MARK: -
@@ -151,6 +152,19 @@ struct MessageActionBuilder {
             }
         )
     }
+
+    static func showStickerPack(itemViewModel: CVItemViewModelImpl, delegate: MessageActionsDelegate) -> MessageAction {
+        MessageAction(
+            .showStickerPack,
+            accessibilityLabel: OWSLocalizedString("MESSAGE_ACTION_SHOW_STICKER_PACK", comment: "Action sheet accessibility label"),
+            accessibilityIdentifier: UIView.accessibilityIdentifier(containerName: "message_action", name: "show_sticker_pack"),
+            contextMenuTitle: OWSLocalizedString("CONTEXT_MENU_SHOW_STICKER_PACK", comment: "Context menu button title"),
+            contextMenuAttributes: [],
+            block: { [weak delegate] _ in
+                delegate?.messageActionsShowStickerPack(itemViewModel)
+            }
+        )
+    }
 }
 
 class MessageActions: NSObject {
@@ -227,6 +241,11 @@ class MessageActions: NSObject {
         if itemViewModel.canEditMessage {
             let editAction = MessageActionBuilder.editMessage(itemViewModel: itemViewModel, delegate: delegate)
             actions.append(editAction)
+        }
+
+        if itemViewModel.isSticker {
+            let showPackAction = MessageActionBuilder.showStickerPack(itemViewModel: itemViewModel, delegate: delegate)
+            actions.append(showPackAction)
         }
 
         let selectAction = MessageActionBuilder.selectMessage(itemViewModel: itemViewModel, delegate: delegate)

--- a/Signal/src/ViewControllers/MediaGallery/MediaItemViewController.swift
+++ b/Signal/src/ViewControllers/MediaGallery/MediaItemViewController.swift
@@ -206,7 +206,7 @@ class MediaItemViewController: OWSViewController, VideoPlaybackStatusProvider {
         guard mediaView == nil else { return }
 
         let view: UIView
-        if attachmentStream.contentType.isVideo, galleryItem.renderingFlag == .shouldLoop {
+        if attachmentStream.contentType.isVideo, galleryItem.renderingFlag == .shouldLoop, !UIAccessibility.isReduceMotionEnabled {
             if attachmentStream.contentType.isVideo, let loopingVideoPlayerView = buildLoopingVideoPlayerView() {
                 loopingVideoPlayerView.delegate = self
                 view = loopingVideoPlayerView
@@ -331,7 +331,7 @@ class MediaItemViewController: OWSViewController, VideoPlaybackStatusProvider {
     private var hasAutoPlayedVideo = false
 
     private var isVideo: Bool {
-        galleryItem.isVideo
+        galleryItem.isVideo || galleryItem.isAnimated
     }
 
     private func playVideo() {

--- a/Signal/src/ViewControllers/MessageActionsToolbar.swift
+++ b/Signal/src/ViewControllers/MessageActionsToolbar.swift
@@ -26,6 +26,7 @@ public class MessageAction: NSObject {
         case stopSpeaking
         case edit
         case showPaymentDetails
+        case showStickerPack
     }
 
     let actionType: MessageActionType
@@ -70,6 +71,8 @@ public class MessageAction: NSObject {
                 return .contextMenuEdit
             case .showPaymentDetails:
                 return .settingsPayments
+            case .showStickerPack:
+                return .contextMenuSticker
             }
         }()
         return Theme.iconImage(icon)

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -1469,6 +1469,9 @@
 "CONTEXT_MENU_SHARE_MEDIA" = "Share";
 
 /* Context menu button title */
+"CONTEXT_MENU_SHOW_STICKER_PACK" = "Show Sticker Pack";
+
+/* Context menu button title */
 "CONTEXT_MENU_SPEAK_MESSAGE" = "Speak";
 
 /* Context menu button title */
@@ -4398,6 +4401,9 @@
 
 /* Action sheet button title */
 "MESSAGE_ACTION_SHARE_MEDIA" = "Share Media";
+
+/* Aciton sheet button title */
+"MESSAGE_ACTION_SHOW_STICKER_PACK" = "Show Sticker Pack";
 
 /* Action sheet accessibility label */
 "MESSAGE_ACTION_SPEAK_MESSAGE" = "Speak Message";

--- a/SignalUI/Appearance/Theme+Icons.swift
+++ b/SignalUI/Appearance/Theme+Icons.swift
@@ -126,6 +126,7 @@ public enum ThemeIcon: UInt {
     case contextMenuVoiceCall
     case contextMenuVideoCall
     case contextMenuMessage
+    case contextMenuSticker
 
     case composeNewGroupLarge
     case composeFindByUsernameLarge
@@ -444,6 +445,8 @@ public extension Theme {
             return "video-light"
         case .contextMenuMessage:
             return "chat-light"
+        case .contextMenuSticker:
+            return "sticker"
 
             // Empty chat list
         case .composeNewGroupLarge:

--- a/SignalUI/Stickers/StickerView.swift
+++ b/SignalUI/Stickers/StickerView.swift
@@ -78,6 +78,7 @@ public class StickerView {
             let yyView = YYAnimatedImageView()
             yyView.alwaysInfiniteLoop = true
             yyView.contentMode = .scaleAspectFit
+            yyView.autoPlayAnimatedImage = !UIAccessibility.isReduceMotionEnabled
             yyView.image = stickerImage
             stickerView = yyView
         }

--- a/SignalUI/Views/LoopingVideoView.swift
+++ b/SignalUI/Views/LoopingVideoView.swift
@@ -146,7 +146,9 @@ public class LoopingVideoView: UIView {
                     }
                     let playerItem = AVPlayerItem(asset: asset, automaticallyLoadedAssetKeys: ["tracks"])
                     self.player.replaceCurrentItem(with: playerItem)
-                    self.player.play()
+                    if !UIAccessibility.isReduceMotionEnabled {
+                        self.player.play()
+                    }
                 }.done(on: DispatchQueue.main) { [weak self] in
                     guard let self = self else {
                         return


### PR DESCRIPTION

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
- [X] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] My commits are rebased on the latest main branch
- [X] My commits are in nice logical chunks
- [X] My contribution is fully baked and is ready to be merged as is
- [X] I have tested my contribution on these devices:
 * iPhone 14 Pro, iOS 18.3.1

- - - - - - - - - -

### Description
This fixes https://github.com/signalapp/Signal-iOS/issues/5949 by:
- Disabling autoplay for GIFs, animated images, and animated stickers when Reduce Motion is enabled
- Changing the `handleTap` behavior for stickers to play/pause the animation when the sticker is animated and Reduce Motion is enabled
- Adding a new “Show Sticker Pack” item to the context menu when long-pressing a sticker, so that it’s still possible to see the pack when Reduce motion is enabled
- Adding play button icons on top of GIFs and animated stickers when Reduce Motion is enabled to indicate that tapping will play the animation

This also adds 2 new translation strings (for the “Show Sticker Pack” menu item). Unfortunately, I only know English, so that’s the only language I’ve added the translations to.

This is also my first contribution to the Signal codebase, so please let me know if I should’ve done something a different way! I tried to make my changes as minimally disruptive as possible, and I don’t know whether I’ve done that at the expense of following existing style/conventions.