### PR TITLE
#5876 Switched file decryption priority to be original file extension

### DIFF
--- a/SignalServiceKit/Messages/Attachments/V2/AttachmentStream.swift
+++ b/SignalServiceKit/Messages/Attachments/V2/AttachmentStream.swift
@@ -87,13 +87,13 @@ public class AttachmentStream {
     /// will instead be inferred from the file contents) and made url-safe AND user-friendly. If nil, a random file name is used.
     public func makeDecryptedCopy(filename: String?) throws -> URL {
         var pathExtension: String = {
-            if let pathExtension = MimeTypeUtil.fileExtensionForMimeType(mimeType) {
-                return pathExtension
-            } else if
+            if
                 let filename,
                 let filenameUrl = URL(string: filename),
                 let pathExtension = filenameUrl.pathExtension.nilIfEmpty
             {
+                return pathExtension
+            } else if let pathExtension = MimeTypeUtil.fileExtensionForMimeType(mimeType) {
                 return pathExtension
             } else {
                 return "bin"


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 16, iOS 18.2

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

This PR `fixes #5876` by changing the file decryption priority to be the files original extension instead of the detected files mime type.

However I do see some value in decrypting the file as its mime type to see the raw file; I think losing the ability to send the file to the respective application its used for comes second to that. Perhaps in the future the UI/UX will be redesigned to accommodate path viewing the raw file and being able to use the original files extension.

https://github.com/user-attachments/assets/9c3c14a2-14e1-4759-a00e-aacb2e53d9be