### PR TITLE
#5911 message overlaps input bar

### DIFF
--- a/Signal/ConversationView/ConversationViewController+MessageActions.swift
+++ b/Signal/ConversationView/ConversationViewController+MessageActions.swift
@@ -221,7 +221,9 @@ extension ConversationViewController: ContextMenuInteractionDelegate {
             overlayView.addSubview(snapShottedInputBar)
             overlayView.addSubview(snapShottedNavigationBar)
                         
+            snapShottedInputBar.frame.x = window.bounds.width - snapShottedInputBar.frame.width
             snapShottedInputBar.frame.y = window.bounds.height - snapShottedInputBar.frame.height //Do we have a method buried somewhere in the code for this?
+            snapShottedNavigationBar.frame.x = window.bounds.width - snapShottedNavigationBar.frame.width
             snapShottedNavigationBar.frame.y = navigationBar.frame.y
             
             return overlayView

--- a/Signal/ConversationView/ConversationViewController+MessageActions.swift
+++ b/Signal/ConversationView/ConversationViewController+MessageActions.swift
@@ -206,6 +206,10 @@ extension ConversationViewController: ContextMenuInteractionDelegate {
 
         }
     }
+    
+    public func contextMenuInteraction(_ interaction: ContextMenuInteraction, overlayForPreviewWithConfiguration configuration: ContextMenuConfiguration) -> UIView? {
+        return nil
+    }
 
     public func contextMenuInteraction(_ interaction: ContextMenuInteraction, willDisplayMenuForConfiguration: ContextMenuConfiguration) {
         // Reset scroll view pan gesture recognizer, so CV does not scroll behind context menu post presentation on user swipe

--- a/Signal/ConversationView/ConversationViewController+MessageActions.swift
+++ b/Signal/ConversationView/ConversationViewController+MessageActions.swift
@@ -212,7 +212,7 @@ extension ConversationViewController: ContextMenuInteractionDelegate {
     private func createOverlayViewForContextMenuTargetedPreview() -> UIView? {
         if
             let snapShottedInputBar = inputToolbar?.snapshotView(afterScreenUpdates: false),
-            let navigationBar = navigationController?.navigationBar,
+            let navigationBar = navigationController?.navigationBar as? OWSNavigationBar,
             let snapShottedNavigationBar = navigationBar.snapshotView(afterScreenUpdates: false) {
             guard let window = view.window else { return nil }
             

--- a/Signal/ConversationView/ConversationViewController+MessageActions.swift
+++ b/Signal/ConversationView/ConversationViewController+MessageActions.swift
@@ -212,17 +212,17 @@ extension ConversationViewController: ContextMenuInteractionDelegate {
     private func createOverlayViewForContextMenuTargetedPreview() -> UIView? {
         if
             let snapShottedInputBar = inputToolbar?.snapshotView(afterScreenUpdates: false),
-            let navigationBar = navigationController?.navigationBar as? OWSNavigationBar,
-            let snapShottedNavigationBarView = navigationBar.snapshotView(afterScreenUpdates: false) {
-            guard let windowDimensions = view.window?.bounds else { return nil }
+            let navigationBar = navigationController?.navigationBar,
+            let snapShottedNavigationBar = navigationBar.snapshotView(afterScreenUpdates: false) {
+            guard let window = view.window else { return nil }
             
-            let overlayView = UIView(frame: windowDimensions)
+            let overlayView = UIView(frame: window.bounds)
             overlayView.backgroundColor = nil
             overlayView.addSubview(snapShottedInputBar)
-            
-            snapShottedInputBar.frame.y = windowDimensions.height - snapShottedInputBar.frame.height //Do we have a method buried somewhere in the code for this?
-            
-            
+            overlayView.addSubview(snapShottedNavigationBar)
+                        
+            snapShottedInputBar.frame.y = window.bounds.height - snapShottedInputBar.frame.height //Do we have a method buried somewhere in the code for this?
+            snapShottedNavigationBar.frame.y = navigationBar.frame.y
             
             return overlayView
         }

--- a/Signal/ConversationView/ConversationViewController+MessageActions.swift
+++ b/Signal/ConversationView/ConversationViewController+MessageActions.swift
@@ -4,6 +4,7 @@
 //
 
 public import SignalServiceKit
+import SignalUI
 
 extension ConversationViewController {
 
@@ -209,6 +210,22 @@ extension ConversationViewController: ContextMenuInteractionDelegate {
     }
     
     private func createOverlayViewForContextMenuTargetedPreview() -> UIView? {
+        if
+            let snapShottedInputBar = inputToolbar?.snapshotView(afterScreenUpdates: false),
+            let navigationBar = navigationController?.navigationBar as? OWSNavigationBar,
+            let snapShottedNavigationBarView = navigationBar.snapshotView(afterScreenUpdates: false) {
+            guard let windowDimensions = view.window?.bounds else { return nil }
+            
+            let overlayView = UIView(frame: windowDimensions)
+            overlayView.backgroundColor = nil
+            overlayView.addSubview(snapShottedInputBar)
+            
+            snapShottedInputBar.frame.y = windowDimensions.height - snapShottedInputBar.frame.height //Do we have a method buried somewhere in the code for this?
+            
+            
+            
+            return overlayView
+        }
         return nil
     }
     

--- a/Signal/ConversationView/ConversationViewController+MessageActions.swift
+++ b/Signal/ConversationView/ConversationViewController+MessageActions.swift
@@ -200,6 +200,7 @@ extension ConversationViewController: ContextMenuInteractionDelegate {
         if let componentView = cell.componentView, let contentView = componentView.contextMenuContentView?() {
             let preview = ContextMenuTargetedPreview(view: contentView, alignment: alignment, accessoryViews: accessories)
             preview?.auxiliaryView = componentView.contextMenuAuxiliaryContentView?()
+            preview?.overlayView = createOverlayViewForContextMenuTargetedPreview()
             return preview
         } else {
             return ContextMenuTargetedPreview(view: cell, alignment: alignment, accessoryViews: accessories)
@@ -207,10 +208,10 @@ extension ConversationViewController: ContextMenuInteractionDelegate {
         }
     }
     
-    public func contextMenuInteraction(_ interaction: ContextMenuInteraction, overlayForPreviewWithConfiguration configuration: ContextMenuConfiguration) -> UIView? {
+    private func createOverlayViewForContextMenuTargetedPreview() -> UIView? {
         return nil
     }
-
+    
     public func contextMenuInteraction(_ interaction: ContextMenuInteraction, willDisplayMenuForConfiguration: ContextMenuConfiguration) {
         // Reset scroll view pan gesture recognizer, so CV does not scroll behind context menu post presentation on user swipe
         collectionView.panGestureRecognizer.isEnabled = false

--- a/Signal/src/ViewControllers/ContextMenus/CustomContextMenus/ContextMenuConfiguration.swift
+++ b/Signal/src/ViewControllers/ContextMenus/CustomContextMenus/ContextMenuConfiguration.swift
@@ -168,6 +168,7 @@ public class ContextMenuTargetedPreview {
     public let previewView: UIView
     public let previewViewSourceFrame: CGRect
     public var auxiliarySnapshot: UIView?
+    public var overlayView: UIView?
 
     /// The horizontal edge to which accessory views should be aligned.
     /// - Note

--- a/Signal/src/ViewControllers/ContextMenus/CustomContextMenus/ContextMenuController.swift
+++ b/Signal/src/ViewControllers/ContextMenus/CustomContextMenus/ContextMenuController.swift
@@ -602,8 +602,6 @@ class ContextMenuController: OWSViewController, ContextMenuViewDelegate, UIGestu
         let dispatchGroup = DispatchGroup()
         animationState = .animateOut
         
-        self.contextMenuPreview.overlayView?.isHidden = false
-        
         dispatchGroup.enter()
         UIView.animate(withDuration: animationDuration) {
             if self.renderBackgroundBlur {
@@ -617,6 +615,7 @@ class ContextMenuController: OWSViewController, ContextMenuViewDelegate, UIGestu
             case .fade:
                 self.previewView?.alpha = 1
             }
+            
         } completion: { _ in
             dispatchGroup.leave()
         }
@@ -661,6 +660,8 @@ class ContextMenuController: OWSViewController, ContextMenuViewDelegate, UIGestu
                 dispatchGroup.leave()
             }
         }
+        
+        self.overlayView?.isHidden = false
 
         dispatchGroup.notify(queue: .main) {
             self.contextMenuPreview.view.isHidden = false

--- a/Signal/src/ViewControllers/ContextMenus/CustomContextMenus/ContextMenuInteraction.swift
+++ b/Signal/src/ViewControllers/ContextMenus/CustomContextMenus/ContextMenuInteraction.swift
@@ -14,7 +14,6 @@ public protocol ContextMenuInteractionDelegate: AnyObject {
     func contextMenuInteraction(
         _ interaction: ContextMenuInteraction,
         previewForHighlightingMenuWithConfiguration configuration: ContextMenuConfiguration) -> ContextMenuTargetedPreview?
-    func contextMenuInteraction(_ interaction: ContextMenuInteraction, overlayForPreviewWithConfiguration configuration: ContextMenuConfiguration) -> UIView?
     func contextMenuInteraction(_ interaction: ContextMenuInteraction,
                                 willDisplayMenuForConfiguration: ContextMenuConfiguration)
     func contextMenuInteraction(_ interaction: ContextMenuInteraction,

--- a/Signal/src/ViewControllers/ContextMenus/CustomContextMenus/ContextMenuInteraction.swift
+++ b/Signal/src/ViewControllers/ContextMenus/CustomContextMenus/ContextMenuInteraction.swift
@@ -14,6 +14,7 @@ public protocol ContextMenuInteractionDelegate: AnyObject {
     func contextMenuInteraction(
         _ interaction: ContextMenuInteraction,
         previewForHighlightingMenuWithConfiguration configuration: ContextMenuConfiguration) -> ContextMenuTargetedPreview?
+    func contextMenuInteraction(_ interaction: ContextMenuInteraction, overlayForPreviewWithConfiguration configuration: ContextMenuConfiguration) -> UIView?
     func contextMenuInteraction(_ interaction: ContextMenuInteraction,
                                 willDisplayMenuForConfiguration: ContextMenuConfiguration)
     func contextMenuInteraction(_ interaction: ContextMenuInteraction,

--- a/Signal/src/ViewControllers/HomeView/Stories/Replies & Views Sheets/Group Reply Sheet/StoryGroupReplyViewController.swift
+++ b/Signal/src/ViewControllers/HomeView/Stories/Replies & Views Sheets/Group Reply Sheet/StoryGroupReplyViewController.swift
@@ -396,10 +396,6 @@ extension StoryGroupReplyViewController: ContextMenuInteractionDelegate {
         return targetedPreview
     }
     
-    func contextMenuInteraction(_ interaction: ContextMenuInteraction, overlayForPreviewWithConfiguration configuration: ContextMenuConfiguration) -> UIView? {
-        return nil
-    }
-
     func contextMenuInteraction(_ interaction: ContextMenuInteraction, willDisplayMenuForConfiguration: ContextMenuConfiguration) {}
 
     func contextMenuInteraction(_ interaction: ContextMenuInteraction, willEndForConfiguration: ContextMenuConfiguration) {}

--- a/Signal/src/ViewControllers/HomeView/Stories/Replies & Views Sheets/Group Reply Sheet/StoryGroupReplyViewController.swift
+++ b/Signal/src/ViewControllers/HomeView/Stories/Replies & Views Sheets/Group Reply Sheet/StoryGroupReplyViewController.swift
@@ -395,6 +395,10 @@ extension StoryGroupReplyViewController: ContextMenuInteractionDelegate {
 
         return targetedPreview
     }
+    
+    func contextMenuInteraction(_ interaction: ContextMenuInteraction, overlayForPreviewWithConfiguration configuration: ContextMenuConfiguration) -> UIView? {
+        return nil
+    }
 
     func contextMenuInteraction(_ interaction: ContextMenuInteraction, willDisplayMenuForConfiguration: ContextMenuConfiguration) {}
 

--- a/SignalUI/Views/OWSNavigationBar.swift
+++ b/SignalUI/Views/OWSNavigationBar.swift
@@ -321,6 +321,30 @@ internal struct OWSNavigationBarAppearance: Equatable {
     }
 }
 
+extension OWSNavigationBar {
+    
+    public override func snapshotView(afterScreenUpdates: Bool) -> UIView? {
+        if
+            let navigationBackground = subviews.first(where: {
+                String(describing: type(of: $0)) == "_UIBarBackground"
+            }),
+            let navigationContentView = subviews.first(where: {
+                String(describing: type(of: $0)) == "_UINavigationBarContentView"
+            }),
+            let snapShottedBackground = navigationBackground.snapshotView(afterScreenUpdates: afterScreenUpdates),
+            let snapShottedContentView = navigationContentView.snapshotView(afterScreenUpdates: afterScreenUpdates) {
+            let navigationBarViewContainer = UIView(frame: CGRect(origin: .zero, size: self.bounds.size))
+            navigationBarViewContainer.addSubview(snapShottedBackground)
+            navigationBarViewContainer.addSubview(snapShottedContentView)
+            
+            snapShottedBackground.frame.y = navigationBackground.frame.y
+            return navigationBarViewContainer
+        }
+        return nil
+    }
+    
+}
+
 fileprivate extension UIVisualEffectView {
 
     var tintingView: UIView? {


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iDevice A, iOS X.Y.Z
 * iDevice B, iOS Z.Y

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

This PR `fixes #5911` by providing an overlay view for ContextMenuHostView while its animations are playing. The overlay view ensures that whenever a message is cut off at the top or bottom of a message, the message slides behind the top or bottom bar respectively.

https://github.com/user-attachments/assets/9a413089-63ae-451d-b446-c9642e2ad755

There is one nit with this current implementation, and its that the bottom bar doesn't retain its visualeffectview for some reason, but its definitely better than the previous UX with the message going on top of the bottom bar.