### PR TITLE
Fix UI getting stuck when transition animation is interrupted

### DIFF
--- a/SignalUI/ImageEditor/ImageEditorCropViewController.swift
+++ b/SignalUI/ImageEditor/ImageEditorCropViewController.swift
@@ -948,8 +948,7 @@ extension ImageEditorCropViewController {
 
     @objc
     private func didTapCancel() {
-        transitionUI(toState: .initial, animated: true) { finished in
-            guard finished else { return }
+        transitionUI(toState: .initial, animated: true) { _ in
             self.dismiss(animated: false)
         }
     }
@@ -957,8 +956,7 @@ extension ImageEditorCropViewController {
     @objc
     private func didTapDone() {
         model.replace(transform: transform)
-        transitionUI(toState: .initial, animated: true) { finished in
-            guard finished else { return }
+        transitionUI(toState: .initial, animated: true) { _ in
             self.dismiss(animated: false)
         }
     }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [X] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] My commits are rebased on the latest main branch
- [X] My commits are in nice logical chunks
- [X] My contribution is fully baked and is ready to be merged as is
- [X] I have tested my contribution on these devices:
 * iPhone 16 Pro (iOS 18.2, Xcode Simulator)

- - - - - - - - - -

### Description
This is a continuation of the issue in #5976. I encountered two scenarios over the week where after tapping done or cancel the buttons animated away, but the view failed to dismiss. I believe #5977 fixed part of this issue, as I haven't had the same error logged, but it's still possible via this route which doesn't generate an error. I think the frequency at which this occurs on my device is much less than pre-#5977 at least.

The theory here is that the animation is interrupted partway through the cycle and returns false even though the buttons have already been dismissed. I think these problems in general are indicative of a larger issue, but we may be able to provide relief with these workarounds.
