### PR TITLE
Fix #5992 - Update group name length error

### DIFF
--- a/Signal/src/ViewControllers/ThreadSettings/GroupAttributesEditorHelper.swift
+++ b/Signal/src/ViewControllers/ThreadSettings/GroupAttributesEditorHelper.swift
@@ -343,12 +343,20 @@ struct GroupAvatar {
 extension GroupAttributesEditorHelper: UITextFieldDelegate {
     public func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString: String) -> Bool {
         // Truncate the replacement to fit.
-        return TextFieldHelper.textField(
-            textField,
-            shouldChangeCharactersInRange: range,
-            replacementString: replacementString.withoutBidiControlCharacters(),
-            maxGlyphCount: GroupManager.maxGroupNameGlyphCount
-        )
+        let isValidChange = TextFieldHelper.textField(
+                textField,
+                shouldChangeCharactersInRange: range,
+                replacementString: replacementString.withoutBidiControlCharacters(),
+                maxGlyphCount: GroupManager.maxGroupNameGlyphCount
+            )
+            
+            if replacementString.glyphCount > GroupManager.maxGroupNameGlyphCount &&
+                textField.text?.isEmpty == false
+                {
+                textFieldDidChange(textField)
+            }
+
+            return isValidChange
     }
 }
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
  * iPhone X, iOS 16.7.10

- - - - - - - - - -

### Description
Fixes #5992

This PR resolves an issue where pasting a group name longer than 33 characters resulted in an incorrect error message ("You have to give a name to the group") instead of the expected "Group name cannot exceed 33 characters". The root cause was that when pasting text exceeding the 33-character limit, the `textFieldDidChange` method was not called, leaving the group name variable unupdated and preventing group creation.

**Changes:**
- Updated `GroupAttributesEditorHelper.textField(_:shouldChangeCharactersIn:replacementString:)` to call `textFieldDidChange` when pasting text exceeds `GroupManager.maxGroupNameGlyphCount` and the text field is not empty.
- This ensures the group name is properly truncated and updated, allowing group creation to proceed with the correct error message when applicable.

**Testing:**
- Tested on iPhone X (iOS 16.7.10, Signal 7.51.0):
  1. Started creating a new group.
  2. Pasted a 34-character string into the group name field.
  3. Verified that the input is truncated to 33 characters, the variable updates, and group creation succeeds without the incorrect error message.
  4. Confirmed the expected error message appears only when appropriate (e.g., empty name).