### PR TITLE
#5953 Fix for conversation animation when keyboard is shown

### DIFF
--- a/Signal/ConversationView/ConversationViewController+OWS.swift
+++ b/Signal/ConversationView/ConversationViewController+OWS.swift
@@ -74,7 +74,7 @@ extension ConversationViewController {
         updateContentInsetsEvent.requestNotify()
     }
 
-    internal func updateContentInsets() {
+    internal func updateContentInsets(animationDuration: TimeInterval = UIView.inheritedAnimationDuration) {
         AssertIsOnMainThread()
 
         guard !isMeasuringKeyboardHeight, !isSwitchingKeyboard else {
@@ -93,9 +93,13 @@ extension ConversationViewController {
                 return
             }
         }
-
-        view.layoutIfNeeded()
-
+        
+        // Layout changes have to be animated to prevent items that move out of the frame
+        // to fade out instead of moving with the whole collection.
+        UIView.animate(withDuration: animationDuration) {
+            self.view.layoutIfNeeded()
+        }
+        
         let oldInsets = collectionView.contentInset
         var newInsets = oldInsets
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 16 Pro, iOS 18.3.2

- - - - - - - - - -

### Description
This fixes issue #5953 when opening the keyboard on a conversation. What is happening is that items that will be pushed out of the frame are removed before the system animation begins so when it starts they are faded out as removed items. With this fix, those elements are added to the animation queue so they are present when the animation beings. 

Before :

https://github.com/user-attachments/assets/1000ad72-db70-4224-a2d4-f9a41c646e43

After:

https://github.com/user-attachments/assets/afca1512-fe77-4813-a369-dd53bdd1f918



I added a new parameter to the signature of the `updateContentInset` function for the animation duration with a default value of the inherited duration temporarily. The final implementation should contemplate updating the `InputAccessoryViewPlaceholderDelegate` protocol, adding the animation duration argument to the methods `inputAccessoryPlaceholderKeyboardDidPresent` and `inputAccessoryPlaceholderKeyboardDidDismiss` functions in order to pass that value to the `updateContentInset` method. I avoided this in order to keep this PR short and have room for discussion. 

