### PR TITLE
#6008 Fixed placement errors for get started banner and first conversation

### DIFF
--- a/Signal/src/ViewControllers/GetStartedBannerViewController.swift
+++ b/Signal/src/ViewControllers/GetStartedBannerViewController.swift
@@ -111,11 +111,11 @@ class GetStartedBannerViewController: UIViewController, UICollectionViewDelegate
         header.autoPinEdge(toSuperviewMargin: .trailing, relation: .lessThanOrEqual)
         header.autoPinEdge(.top, to: .top, of: opaqueBackdrop, withOffset: 8)
 
-        collectionView.preservesSuperviewLayoutMargins = true
         collectionView.autoSetDimension(.height, toSize: 180)
         collectionView.autoPinEdge(.top, to: .bottom, of: header, withOffset: 12)
         collectionView.autoPinWidthToSuperview()
         collectionView.autoPinBottomToSuperviewMargin()
+        collectionView.layoutMargins = UIEdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16)
         collectionView.clipsToBounds = false
 
         self.view = view

--- a/Signal/src/ViewControllers/HomeView/Chat List/ChatListViewController.swift
+++ b/Signal/src/ViewControllers/HomeView/Chat List/ChatListViewController.swift
@@ -76,7 +76,7 @@ public class ChatListViewController: OWSViewController, HomeTabViewController {
             navigationController.view.addSubview(firstConversationCueView)
             
             // This inset bakes in assumptions about UINavigationBar layout, but I'm not sure
-            // there's a better way to do it, since it isn't safe to use iOS auto layout with
+            // if there's a better way to do it, since it isn't safe to use iOS auto layout with
             // UINavigationBar contents.
             firstConversationCueView.autoPinEdge(toSuperviewMargin: .top, withInset: 35)
             firstConversationCueView.autoPinEdge(toSuperviewEdge: .trailing, withInset: 6)

--- a/Signal/src/ViewControllers/HomeView/Chat List/ChatListViewController.swift
+++ b/Signal/src/ViewControllers/HomeView/Chat List/ChatListViewController.swift
@@ -72,14 +72,16 @@ public class ChatListViewController: OWSViewController, HomeTabViewController {
         emptyInboxView.autoAlignAxis(.horizontal, toSameAxisOf: view, withMultiplier: 0.85)
 
         // First Conversation Cue
-        view.addSubview(firstConversationCueView)
-        firstConversationCueView.autoPin(toTopLayoutGuideOf: self, withInset: 0)
-        // This inset bakes in assumptions about UINavigationBar layout, but I'm not sure
-        // there's a better way to do it, since it isn't safe to use iOS auto layout with
-        // UINavigationBar contents.
-        firstConversationCueView.autoPinEdge(toSuperviewEdge: .trailing, withInset: 6)
-        firstConversationCueView.autoPinEdge(toSuperviewEdge: .leading, withInset: 10, relation: .greaterThanOrEqual)
-        firstConversationCueView.autoPinEdge(toSuperviewMargin: .bottom, relation: .greaterThanOrEqual)
+        if let navigationController = self.navigationController {
+            navigationController.view.addSubview(firstConversationCueView)
+            
+            // This inset bakes in assumptions about UINavigationBar layout, but I'm not sure
+            // there's a better way to do it, since it isn't safe to use iOS auto layout with
+            // UINavigationBar contents.
+            firstConversationCueView.autoPinEdge(toSuperviewMargin: .top, withInset: 35)
+            firstConversationCueView.autoPinEdge(toSuperviewEdge: .trailing, withInset: 6)
+            firstConversationCueView.autoPinEdge(toSuperviewEdge: .leading, withInset: 10, relation: .greaterThanOrEqual)
+        }
 
         // Search
         navigationItem.searchController = viewState.searchController
@@ -240,6 +242,7 @@ public class ChatListViewController: OWSViewController, HomeTabViewController {
         super.viewWillDisappear(animated)
 
         isViewVisible = false
+        firstConversationCueView.isHidden = true
         searchResultsController.viewWillDisappear(animated)
     }
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 16 Pro

- - - - - - - - - -

### Description
This fixes issue #6008 for the placement of the get started banner and first conversation cue. The get started banner was inheriting the margins from the chat list view, which after opening a conversation gets modified by the navigation, for instance when showing the search bar. This change just breaks that link and passes a fixed value for the leading a trailing margins which are changed by matching the width of the superview, necessary to create the sliding from the right effect of the banner. The conversation cue position was being modified in the same way, so this change places the cue as a subview of the navigation, preventing it from being moved or getting below the navigation. 


https://github.com/user-attachments/assets/09c3bc76-ace1-4c32-8ea7-ec0b7dc417a3

