### PR TITLE
#5666 Added in extra check if the image is already a png.

### DIFF
--- a/SignalServiceKit/Attachments/SignalAttachment.swift
+++ b/SignalServiceKit/Attachments/SignalAttachment.swift
@@ -928,7 +928,7 @@ public class SignalAttachment: NSObject {
             // transparent pixels (all screenshots fall into this bucket)
             // and there is not a simple, performant way, to check if there
             // are any transparent pixels in an image.
-            if dataSource.hasStickerLikeProperties {
+            if dataSource.hasStickerLikeProperties || attachment.fileExtension == "png" {
                 dataFileExtension = "png"
                 dataType = .png
             } else {


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 12, iOS 18.3.2

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

This PR `fixes #5666` by adding an additional check to ensure that incoming images with a PNG extension are handled correctly, preserving their transparent background. This resolves an issue where images shared from the iOS Photos app with a selected subject would have a white background instead of a transparent one, both in the preview and when received. 

https://github.com/user-attachments/assets/798a5d08-1202-4984-b23c-83ee4bc33720

