### PR TITLE
Added phone number of blocked content to tableviewcell.

### DIFF
--- a/Signal/src/ViewControllers/AppSettings/Privacy/BlockListViewController.swift
+++ b/Signal/src/ViewControllers/AppSettings/Privacy/BlockListViewController.swift
@@ -99,6 +99,7 @@ class BlockListViewController: OWSTableViewController2 {
                         address: address,
                         localUserDisplayMode: .asUser
                     )
+                    config.accessoryMessage = address.phoneNumber //Is there a function to prettify a phone number?
                     if self != nil {
                         SSKEnvironment.shared.databaseStorageRef.read { transaction in
                             cell.configure(configuration: config, transaction: transaction)


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 12, iOS 18.3.2

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

This `fixes #4914` by adding in the phone number of the blocked contact to the blocked contacts view. I'm uncertain whether the UI/UX engineer thinks it should be in this layout (Does there happen to be a function to prettify the phone number?) or not. I've provided a picture so that you don't have to pull and run this branch.

![Screenshot 2025-03-31 at 8 05 00 PM](https://github.com/user-attachments/assets/ecff1d89-3b86-41f6-b8fa-a12cb80b56d1)

