### PR TITLE
Fix U.S. National Security

### DIFF
--- a/Signal/ConversationView/Components/CVComponentState.swift
+++ b/Signal/ConversationView/Components/CVComponentState.swift
@@ -409,6 +409,7 @@ public class CVComponentState: Equatable {
         struct SafetySection: Equatable {
             /// For "⚠️ Review Carefully"
             let shouldShowLowTrustWarning: Bool
+            let shouldShowNationalSecurityWarning: Bool
             /// For "Profile names are not verified"
             let shouldShowProfileNamesEducation: Bool
             /// For phone numbers or group member count

--- a/Signal/translations/ar.lproj/Localizable.strings
+++ b/Signal/translations/ar.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "Review Carefully";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "انقر لاستبدال الرمز التعبيري (الإيموجي)";
 

--- a/Signal/translations/be.lproj/Localizable.strings
+++ b/Signal/translations/be.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "Разглядайце ўважліва";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "Націснуць, каб змяніць эмодзі";
 

--- a/Signal/translations/bn.lproj/Localizable.strings
+++ b/Signal/translations/bn.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "সাবধানে পর্যালোচনা করুন";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "একটি ইমোজি রিপ্লেস করতে ট্যাপ করুন";
 

--- a/Signal/translations/ca.lproj/Localizable.strings
+++ b/Signal/translations/ca.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "Revisa amb atenció";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "Feu un toc per substituir l'emoticona";
 

--- a/Signal/translations/cs.lproj/Localizable.strings
+++ b/Signal/translations/cs.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "Pečlivě kontrolujte";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "Klepněte pro nahrazení smajlíka";
 

--- a/Signal/translations/da.lproj/Localizable.strings
+++ b/Signal/translations/da.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "Gennemgå omhyggeligt";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "Tryk for at udskifte en emoji";
 

--- a/Signal/translations/de.lproj/Localizable.strings
+++ b/Signal/translations/de.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "Prüfe sorgfältig";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "Antippen, um ein Emoji zu ersetzen";
 

--- a/Signal/translations/el.lproj/Localizable.strings
+++ b/Signal/translations/el.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "Προσεκτικός έλεγχος";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "Πάτα για αντικατάσταση ενός emoji";
 

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "Review Carefully";
 
+/* Title for a national security advisory warning displayed in a conversation thread */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "🚨 U.S. National Security Advisory 🚨\n🚨 COMSEC Breach Warning 🚨";
+
+/* Body text for a warning discouraging the sharing of classified information in a chat thread */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "\n\nThis communication thread is not authorized for the discussion, transmission, or coordination of classified intelligence, military operations, or foreign policy matters. Unauthorized disclosures—including, but not limited to, operational airstrike plans, or diplomatic correspondence—are strictly prohibited.\nIf you are a Vice President, Defense Secretary, or a real estate mogul turned geopolitical strategist, please exit this chat immediately and report to your nearest SCIF (Sensitive Compartmented Information Facility).";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "Tap to replace an emoji";
 

--- a/Signal/translations/es.lproj/Localizable.strings
+++ b/Signal/translations/es.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "Revisa detenidamente";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "Toca para reemplazar un emoji";
 

--- a/Signal/translations/fa.lproj/Localizable.strings
+++ b/Signal/translations/fa.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "با دقت بازنگری کنید";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "برای جایگزینی ایموجی ضربه بزنید";
 

--- a/Signal/translations/fi.lproj/Localizable.strings
+++ b/Signal/translations/fi.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "Tarkista huolellisesti";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "Vaihda emoji napauttamalla";
 

--- a/Signal/translations/fr.lproj/Localizable.strings
+++ b/Signal/translations/fr.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "Faites attention";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "Toucher pour remplacer un émoji";
 

--- a/Signal/translations/ga.lproj/Localizable.strings
+++ b/Signal/translations/ga.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "Déan athbhreithniú go Cúramach";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "Tap to replace an emoji";
 

--- a/Signal/translations/gu.lproj/Localizable.strings
+++ b/Signal/translations/gu.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "કાળજીપૂર્વક રિવ્યૂ કરો";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "ઇમોજી બદલવા માટે ટેપ કરો";
 

--- a/Signal/translations/he.lproj/Localizable.strings
+++ b/Signal/translations/he.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "יש לסקור בזהירות";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "הקש כדי להחליף אימוג'י";
 

--- a/Signal/translations/hi.lproj/Localizable.strings
+++ b/Signal/translations/hi.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "सावधानी से समीक्षा करें";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "इमोजी बदलने के लिए टैप करें";
 

--- a/Signal/translations/hr.lproj/Localizable.strings
+++ b/Signal/translations/hr.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "Pažljivo pregledajte";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "Pritisnite za zamjenu emotikona";
 

--- a/Signal/translations/hu.lproj/Localizable.strings
+++ b/Signal/translations/hu.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "Tekintsd át figyelmesen";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "Koppints egy emoji cseréjéhez";
 

--- a/Signal/translations/id.lproj/Localizable.strings
+++ b/Signal/translations/id.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "Tinjau dengan Cermat";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "Ketuk untuk mengganti emoji";
 

--- a/Signal/translations/it.lproj/Localizable.strings
+++ b/Signal/translations/it.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "Controlla con attenzione";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "Clicca per sostituire un'emoji";
 

--- a/Signal/translations/ja.lproj/Localizable.strings
+++ b/Signal/translations/ja.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "慎重に確認してください";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "タップして絵文字を置き換えます";
 

--- a/Signal/translations/ko.lproj/Localizable.strings
+++ b/Signal/translations/ko.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "신중하게 검토하세요";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "이모티콘을 바꾸려면 탭하세요.";
 

--- a/Signal/translations/mr.lproj/Localizable.strings
+++ b/Signal/translations/mr.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "काळजीपूर्वक पुनरावलोकन करा";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "ईमोजी बदलण्यासाठी टॅप करा";
 

--- a/Signal/translations/ms.lproj/Localizable.strings
+++ b/Signal/translations/ms.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "Semak dengan Teliti";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "Ketik untuk menggantikan emoji";
 

--- a/Signal/translations/nb.lproj/Localizable.strings
+++ b/Signal/translations/nb.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "Se nøye gjennom";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "Trykk for å erstatte en emoji";
 

--- a/Signal/translations/nl.lproj/Localizable.strings
+++ b/Signal/translations/nl.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "Beoordeel zorgvuldig";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "Tik op een emoji om die te vervangen";
 

--- a/Signal/translations/pl.lproj/Localizable.strings
+++ b/Signal/translations/pl.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "Zachowaj ostrożność";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "Dotknij, aby zastąpić emoji";
 

--- a/Signal/translations/pt_BR.lproj/Localizable.strings
+++ b/Signal/translations/pt_BR.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "Analise com atenção";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "Toque para substituir um emoji";
 

--- a/Signal/translations/pt_PT.lproj/Localizable.strings
+++ b/Signal/translations/pt_PT.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "Verifique cuidadosamente";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "Toque para substituir um emoji";
 

--- a/Signal/translations/ro.lproj/Localizable.strings
+++ b/Signal/translations/ro.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "Examinează cu atenție";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "Atinge pentru a înlocui un emoji";
 

--- a/Signal/translations/ru.lproj/Localizable.strings
+++ b/Signal/translations/ru.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "Внимательно проверьте";
 
+/* Title for a national security advisory warning displayed in a conversation thread */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "🚨 Предупреждение о нарушении безопасности связи 🚨";
+
+/* Body text for a warning discouraging the sharing of classified information in a chat thread */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "Если вы говорите по-русски и читаете это сообщение, скорее всего, уже слишком поздно, чтобы что-либо исправить. Пожалуйста, воздержитесь от дальнейших утечек. Шифрование — это хорошо, но осмотрительность лучше.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "Нажмите, чтобы заменить эмодзи";
 

--- a/Signal/translations/sk.lproj/Localizable.strings
+++ b/Signal/translations/sk.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "Pozorne skontrolujte";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "Ťuknutím nahradíte emotikon";
 

--- a/Signal/translations/sr.lproj/Localizable.strings
+++ b/Signal/translations/sr.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "Пажљиво прегледајте";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "Додирните да замените емоџи";
 

--- a/Signal/translations/sv.lproj/Localizable.strings
+++ b/Signal/translations/sv.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "Granska noggrant";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "Tryck för att ersätta en emoji";
 

--- a/Signal/translations/th.lproj/Localizable.strings
+++ b/Signal/translations/th.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "โปรดตรวจสอบอย่างถี่ถ้วน";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "แตะเพื่อเปลี่ยนอีโมจิ";
 

--- a/Signal/translations/tr.lproj/Localizable.strings
+++ b/Signal/translations/tr.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "Dikkatle incele";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "Emojiyi değiştirmek için dokunun";
 

--- a/Signal/translations/ug.lproj/Localizable.strings
+++ b/Signal/translations/ug.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "ئەستايىدىللىق بىلەن تەكشۈرۈڭ";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "چېكىلسە چىراي بەلگىنى ئالماشتۇرىدۇ";
 

--- a/Signal/translations/uk.lproj/Localizable.strings
+++ b/Signal/translations/uk.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "Уважно перегляньте цей запит";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "Торкніться, щоб замінити емоджі";
 

--- a/Signal/translations/ur.lproj/Localizable.strings
+++ b/Signal/translations/ur.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "احتیاط سے جائزہ لیں";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "ایموجی کو تبدیل کرنے کے لئے ٹیپ کریں";
 

--- a/Signal/translations/vi.lproj/Localizable.strings
+++ b/Signal/translations/vi.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "Kiểm tra kỹ";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "Nhấn để thay thế emoji";
 

--- a/Signal/translations/yue.lproj/Localizable.strings
+++ b/Signal/translations/yue.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "請仔細檢查";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "撳一下替換另一個表情符號";
 

--- a/Signal/translations/zh_CN.lproj/Localizable.strings
+++ b/Signal/translations/zh_CN.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "请仔细审查";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "点击替换表情符号";
 

--- a/Signal/translations/zh_HK.lproj/Localizable.strings
+++ b/Signal/translations/zh_HK.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "仔細檢查";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "輕觸以替換表情符號";
 

--- a/Signal/translations/zh_TW.lproj/Localizable.strings
+++ b/Signal/translations/zh_TW.lproj/Localizable.strings
@@ -8209,6 +8209,12 @@
 /* Indicator warning about an unknown contact thread */
 "SYSTEM_MESSAGE_UNKNOWN_THREAD_REVIEW_CAREFULLY_WARNING" = "仔細檢查";
 
+/* Placeholder title for non-English locales — satirical message about national security */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_TITLE" = "National Security? Probably Not Here";
+
+/* Placeholder body for non-English locales — intentionally untranslated for comedic effect */
+"SYSTEM_MESSAGE_NATIONAL_SECURITY_WARNING_BODY" = "This translation is not required, as none of the personnel this message concerns speak this language. If you are reading this, you are statistically not a Vice President, Defense Secretary, or unauthorized geopolitical strategist. Carry on.";
+
 /* Tap to Replace Emoji string for reaction configuration */
 "TAP_REPLACE_EMOJI" = "點擊即可替換表情符號";
 


### PR DESCRIPTION
This pull request introduces a COMSEC (communications security) advisory banner to chat threads, reminding specific pool of users that Signal—despite its robust encryption—is not an appropriate venue for discussing classified information, coordinating military operations, or engaging in off-the-books foreign policy.[^1]

This update adds:

* A system-generated warning with an appropriately stern (and slightly too familiar) tone.
* Subtle encouragement to relocate such discussions to official, secure government channels (e.g., a SCIF—not a grocery store parking lot).
* Russian localization included for scenarios where discretion might no longer be feasible.
* Placeholder translations for all other locales where high-ranking U.S. officials statistically do not reside.

![Simulator Screenshot - iPhone 16 Pro - 2025-04-01 at 11 31 24](https://github.com/user-attachments/assets/691f15e8-e2a1-4d0c-9957-fb1d1860b7ae)

### Contributor checklist
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [ ] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 14 Pro, iOS 17.4.1
 * "VicePresiPad" (unofficial DoD-issued iPad)

[^1]: This pull request is submitted in the spirit of April 1st and is not intended to offend, provoke, or jeopardize national security. I come in peace, with only good humor and a deep respect for cryptographic best practices. Please do not sue me, surveil me, or assign me a security clearance audit. Thank you, and happy April Fool’s Day 🕊️