### PR TITLE
#5777 - Navigation bar on ChatListTableView Accessibility.

### DIFF
--- a/Signal/src/ViewControllers/HomeView/Chat List/ChatListViewController.swift
+++ b/Signal/src/ViewControllers/HomeView/Chat List/ChatListViewController.swift
@@ -42,6 +42,7 @@ public class ChatListViewController: OWSViewController, HomeTabViewController {
         super.viewDidLoad()
 
         keyboardObservationBehavior = .never
+        self.extendedLayoutIncludesOpaqueBars = true
 
         switch viewState.chatListMode {
         case .inbox:


### PR DESCRIPTION

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 12, iOS 18.3

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

This `fixes #5777` by extending the ChatListViewController to account for a calculation discrepancy in the chat table view, which occurs when the navigation bar is opaque due to UIAccessibility.isReduceTransparencyEnabled being enabled.


https://github.com/user-attachments/assets/31ccaf55-7b07-4569-aecd-c188a063ad26

