### PR TITLE
#6023: Add "Go to Message" Feature to Media Viewer

### DIFF
--- a/Signal/src/ViewControllers/MediaGallery/MediaPageViewController.swift
+++ b/Signal/src/ViewControllers/MediaGallery/MediaPageViewController.swift
@@ -345,6 +345,16 @@ class MediaPageViewController: UIPageViewController {
         ))
         contextMenuActions.append(UIAction(
             title: OWSLocalizedString(
+                "MEDIA_VIEWER_GO_TO_MESSAGE",
+                comment: "Context menu item in media viewer. Refers to going to the position in conversation of that photo/video."
+            ),
+            image: Theme.iconImage(.arrowRight),
+            handler: { [weak self] _ in
+                self?.presentConversationForCurrentMedia()
+            }
+        ))
+        contextMenuActions.append(UIAction(
+            title: OWSLocalizedString(
                 "MEDIA_VIEWER_DELETE_MEDIA_ACTION",
                 comment: "Context menu item in media viewer. Refers to deleting currently displayed photo/video."
             ),
@@ -524,6 +534,28 @@ class MediaPageViewController: UIPageViewController {
         actionSheet.addAction(deleteAction)
 
         presentActionSheet(actionSheet)
+    }
+    
+    private func presentConversationForCurrentMedia() {
+        guard let currentItem = currentItem else { return }
+        
+        dismissSelf(animated: true) {
+            
+            // Present the conversation and scroll to the message
+            SignalApp.shared.presentConversationForThread(
+                threadUniqueId: currentItem.message.uniqueThreadId,
+                focusMessageId: currentItem.message.uniqueId,
+                animated: true
+            )
+            
+            if let conversationVC = SignalApp.shared.conversationSplitViewController?.selectedConversationViewController {
+                conversationVC.ensureInteractionLoadedThenScrollToInteraction(
+                    currentItem.message.uniqueId,
+                    alignment: .centerIfNotEntirelyOnScreen,
+                    isAnimated: true
+                )
+            }
+        }
     }
 
     // MARK: Dynamic Header

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -4433,6 +4433,9 @@
 "MEDIA_VIEWER_DELETE_MEDIA_ACTION" = "Delete";
 
 /* Context menu item in media viewer. Refers to saving currently displayed photo/video to the Photos app. */
+"MEDIA_VIEWER_GO_TO_MESSAGE" = "Go to message";
+
+/* Context menu item in media viewer. Refers to saving currently displayed photo/video to the Photos app. */
 "MEDIA_VIEWER_SAVE_MEDIA_ACTION" = "Save";
 
 /* button title to snooze a megaphone */


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [ ] My contribution is fully baked and is ready to be merged as is
- [ ] I have tested my contribution on these devices:
 * iDevice A, iOS X.Y.Z
 * iDevice B, iOS Z.Y

- - - - - - - - - -

### Description

This fixes https://github.com/signalapp/Signal-iOS/issues/6023 by adding the view media in conversation functionality.

- Added new "Go to Message" option in media viewer context menu
- Implemented navigation from media viewer to the source message in conversation
- Added automatic scrolling to the message position when returning to conversation


- [Needs Translations]

<img src="https://github.com/user-attachments/assets/6a2a833d-02b9-4b90-a1c3-f49334f29d26" width="200" height="450" />

https://github.com/user-attachments/assets/75fdcd94-c45b-4947-86e0-23242fac2302

<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->
