### PR TITLE
#5400 - Removed bottom margin for replies that just include media.

### DIFF
--- a/Signal/ConversationView/Components/CVComponentMessage.swift
+++ b/Signal/ConversationView/Components/CVComponentMessage.swift
@@ -1095,7 +1095,7 @@ public class CVComponentMessage: CVComponentBase, CVRootComponent {
             if previousSectionItems.isEmpty,
                quotedReply != nil {
                 applyTopMargin = true
-                applyBottomMargin = bodyText == nil && standaloneFooter == nil
+                applyBottomMargin = bodyText == nil && standaloneFooter == nil && bodyMedia == nil
             } else if let previousSectionItem = previousSectionItems.last,
                       previousSectionItem.componentKey == .linkPreview,
                       quotedReply != nil {


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 12, iOS 18.3.2

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

This PR `fixes #5400` by simply adding another check to see if we should apply a bottom margin to a reply that only contains media.

![Screenshot 2025-04-24 at 8 56 24 PM](https://github.com/user-attachments/assets/ab9fac40-4494-450c-a3ce-348099318470)
