### PR TITLE
#6045 - Attachment Keyboard Permissions

### DIFF
--- a/Signal/ConversationView/ConversationViewController+Delegates.swift
+++ b/Signal/ConversationView/ConversationViewController+Delegates.swift
@@ -33,8 +33,9 @@ extension ConversationViewController: AttachmentApprovalViewControllerDelegate {
     }
 
     public func attachmentApprovalDidCancel() {
-        dismiss(animated: true, completion: nil)
-        self.openAttachmentKeyboard()
+        dismiss(animated: true) {
+            self.openAttachmentKeyboard()
+        }
     }
 
     public func attachmentApproval(_ attachmentApproval: AttachmentApprovalViewController,


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 12, iOS 18.4.1

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

This pull request `fixes #6045`. The problem originated from commit [9986b21](https://github.com/signalapp/Signal-iOS/commit/9986b21238bcc16cd6736abf683fed0e89b0fcba), which introduced new functionality to reopen the attachment keyboard after a user cancelled sending a photo or video. However, this change inadvertently introduced a bug when a user pasted a photo or video.

To understand the bug, it's essential to explain the inner workings of the input text bar, where users type text to send messages. Below the input text bar lies the "keyboard," which can take different forms. Currently, Signal has three types of keyboards: the standard QWERTY keyboard, an attachment keyboard for quick photo selection, and a sticker keyboard. When switching between keyboards, the current keyboard must relinquish its input listening responsibility, and the new keyboard must request input listening responsibility from the system.

The bug doesn't occur in the following scenario: when a user switches to the attachment keyboard, selects a photo, proceeds to the approval view, and then exits to return to the thread view, the attachment keyboard retains input listening responsibility. However, if the user repeats these steps but pastes a photo or video instead, the attachment keyboard is not open and does not have input listening responsibility.

When the approval view is dismissed, it attempts to gain input listening responsibility, but this fails because the app is transitioning from the approval view to the thread view. The attachment keyboard code checks the current privacy level and loads the corresponding view (either photos or a prompt for limited photos) only if it successfully gains input listening responsibility, which it does not in this case.

This pull request resolves the issue by ensuring that the app has completed the transition from the approval view to the thread view before attempting to gain input listening responsibility. This allows the attachment keyboard to successfully load the user's photos, respecting the privacy limits.

https://github.com/user-attachments/assets/297e7e4f-78a3-498d-b41b-4ba7176c3deb

