### PR TITLE
#6050 - Add Check For Delete For Everyone In Notes To Self

### DIFF
--- a/Signal/ConversationView/ConversationViewController+Selection.swift
+++ b/Signal/ConversationView/ConversationViewController+Selection.swift
@@ -365,7 +365,7 @@ extension ConversationViewController {
             }
         }
 
-        if canDeleteForEveryone {
+        if canDeleteForEveryone && !thread.isNoteToSelf {
             let deleteForEveryoneAction = ActionSheetAction(
                 title: CommonStrings.deleteForEveryoneButton,
                 style: .destructive


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 12, iOS 18.4.1

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

This PR `fixes #6050` by adding a check to see if the current thread is a note-to-self thread, thereby removing the delete for everyone action.


https://github.com/user-attachments/assets/42a43536-62f4-4123-8af4-258b416099d0

