### PR TITLE
#5488 Drag and Drop Images

### DIFF
--- a/Signal/ConversationView/ConversationViewController+Delegates.swift
+++ b/Signal/ConversationView/ConversationViewController+Delegates.swift
@@ -223,6 +223,19 @@ extension ConversationViewController: ConversationHeaderViewDelegate {
 // MARK: -
 
 extension ConversationViewController: ConversationInputTextViewDelegate {
+    
+    public func didAttemptToDropAttachments(_ attachments: [SignalAttachment]) {
+        //We only want one attachment (image for now)
+        if let firstAttachment = attachments.first {
+            if firstAttachment.isBorderless {
+                tryToSendAttachments([ firstAttachment ], messageBody: nil)
+            } else {
+                dismissKeyBoard()
+                showApprovalDialog(forAttachment: firstAttachment)
+            }
+        }
+    }
+    
     public func didAttemptAttachmentPaste() {
         ModalActivityIndicatorViewController.present(fromViewController: self) { modal in
             let attachment: SignalAttachment? = await SignalAttachment.attachmentFromPasteboard()

--- a/SignalServiceKit/Attachments/SignalAttachment.swift
+++ b/SignalServiceKit/Attachments/SignalAttachment.swift
@@ -1387,3 +1387,17 @@ public class SignalAttachment: NSObject {
         return attachment
     }
 }
+
+
+extension SignalAttachment : NSItemProviderReading {
+    
+    public static var readableTypeIdentifiersForItemProvider: [String] {
+        return Array(inputImageUTISet) //Only support images for now
+    }
+    
+    public static func object(withItemProviderData data: Data, typeIdentifier: String) throws -> Self {
+        let dataSource = DataSourceValue(data, utiType: typeIdentifier)
+        return SignalAttachment.attachment(dataSource: dataSource, dataUTI: typeIdentifier) as! Self
+    }
+    
+}

--- a/SignalServiceKit/Attachments/SignalAttachment.swift
+++ b/SignalServiceKit/Attachments/SignalAttachment.swift
@@ -1397,7 +1397,7 @@ extension SignalAttachment : NSItemProviderReading {
     
     public static func object(withItemProviderData data: Data, typeIdentifier: String) throws -> Self {
         let dataSource = DataSourceValue(data, utiType: typeIdentifier)
-        return SignalAttachment.attachment(dataSource: dataSource, dataUTI: typeIdentifier) as! Self
+        return imageAttachment(dataSource: dataSource, dataUTI: typeIdentifier, isBorderless: dataSource?.hasStickerLikeProperties ?? false) as! Self
     }
     
 }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 12 iOS 18.4.1

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

This pull request introduces (`fixes #5488`) a common feature in many chatting applications, but is not currently present in Signal. This feature allows the user to drag and drop images straight into any conversation thread. I tested this by dragging and dropping different image UTIs (pngs, jpegs, etc) along with images that are and arent sticker size (images below 512 pixels).

Test dragging into text input bar

https://github.com/user-attachments/assets/4b94dc2c-4b76-45df-8642-269d18b70927

Test dragging into conversation view controller view

https://github.com/user-attachments/assets/2782bf20-488c-4304-9310-0a543f458986