### PR TITLE
#5769 - Pause all audio attachments if receiving an incoming call.

### DIFF
--- a/Signal/Calls/UserInterface/CallUIAdapter.swift
+++ b/Signal/Calls/UserInterface/CallUIAdapter.swift
@@ -97,6 +97,9 @@ public class CallUIAdapter: NSObject {
         }
         Logger.info("remoteAddress: \(caller)")
 
+        // make sure we dont have any audio playing as that will bug audio when it interacts with the call service
+        AppEnvironment.shared.cvAudioPlayerRef.pauseAll()
+        
         // make sure we don't terminate audio session during call
         _ = SUIEnvironment.shared.audioSessionRef.startAudioActivity(call.commonState.audioActivity)
 

--- a/Signal/ConversationView/CVAudioPlayback.swift
+++ b/Signal/ConversationView/CVAudioPlayback.swift
@@ -248,6 +248,14 @@ public class CVAudioPlayer: NSObject {
         audioPlayback.stop()
         self.audioPlayback = nil
     }
+    
+    //pause all function
+    public func pauseAll() {
+        guard let audioPlayback = self.audioPlayback else {
+            return
+        }
+        audioPlayback.pause()
+    }
 }
 
 extension CVAudioPlayer: AudioPlayerDelegate {
@@ -395,6 +403,12 @@ private class CVAudioPlayback: NSObject, AudioPlayerDelegate {
 
     deinit {
         stop()
+    }
+    
+    fileprivate func pause() {
+        AssertIsOnMainThread()
+        
+        audioPlayer.pause()
     }
 
     fileprivate func stop() {

--- a/SignalUI/AV/AudioPlayer.swift
+++ b/SignalUI/AV/AudioPlayer.swift
@@ -195,6 +195,7 @@ public class AudioPlayer: NSObject {
         MainActor.assumeIsolated {
             DependenciesBridge.shared.deviceSleepManager?.removeBlock(blockObject: sleepBlockObject)
         }
+        teardownRemoteCommandCenter()
     }
 
     public func setupAudioPlayer() {


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 12, iOS 18.4.1
 * iPhone 16, iOS 18.4.1

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

This PR `fixes #5769` by making sure that audio attachments don't interfere with signal calls. This problem stems from audio attachments that are playing while an incoming call happens, have their audio controls captured by NowPlayingInforCenter and RemoteCommandCenter, switch subsequently blocks audio coming from a signal call.

I tested this by playing audio attachments and then initiating an incoming call. Additionally, I tested to make sure that audio attachments still interrupt music playing in the background, and subsequently resume upon the audio attachment pausing or completing.