### PR TITLE
a11y: Provide message delivery status through VoiceOver

### DIFF
--- a/Signal/ConversationView/Components/CVComponentFooter.swift
+++ b/Signal/ConversationView/Components/CVComponentFooter.swift
@@ -52,6 +52,9 @@ public class CVComponentFooter: CVComponentBase, CVComponent {
     public var timestampText: String {
         footerState.timestampText
     }
+    public var footerAccessibilityLabel: String? {
+        footerState.accessibilityLabel
+    }
     private var statusIndicator: StatusIndicator? {
         footerState.statusIndicator
     }

--- a/Signal/ConversationView/Components/CVComponentMessage.swift
+++ b/Signal/ConversationView/Components/CVComponentMessage.swift
@@ -1303,11 +1303,15 @@ public class CVComponentMessage: CVComponentBase, CVRootComponent {
 
         elements.append(contents.joined(separator: ", "))
 
+        if let footerAccessibilityLabel = standaloneFooter?.footerAccessibilityLabel {
+            elements.append(footerAccessibilityLabel)
+        }
+
         // NOTE: In the interest of keeping the accessibility label short,
         // we do not include information that is usually presented in the
         // following components:
         //
-        // * footer (message send status, disappearing message status).
+        // * footer (disappearing message status).
         //   We _do_ include time but not date. Dates are in the date headers.
         // * senderName
         // * senderAvatar

--- a/Signal/ConversationView/Components/CVComponentMessage.swift
+++ b/Signal/ConversationView/Components/CVComponentMessage.swift
@@ -1300,12 +1300,12 @@ public class CVComponentMessage: CVComponentBase, CVRootComponent {
             )
         }
         contents.append(timestampText)
-
-        elements.append(contents.joined(separator: ", "))
-
+        
         if let footerAccessibilityLabel = standaloneFooter?.footerAccessibilityLabel {
-            elements.append(footerAccessibilityLabel)
+            contents.append(footerAccessibilityLabel)
         }
+        
+        elements.append(contents.joined(separator: ", "))
 
         // NOTE: In the interest of keeping the accessibility label short,
         // we do not include information that is usually presented in the


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 15 Pro, iOS 18.5
 * Simulator, iOS 18.2

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->
This commit modifies the accessibility label for an outgoing message to provide information on the message delivery status (delivered, sent, read, etc):

<img width="410" alt="A screenshot of the Xcode accessibility inspector overlaid on top of a iPhone simulator running Signal. The accessibility inspector is highlighting a message, the accessibility label reads 'You sent: Test, 42 minutes ago, Read'" src="https://github.com/user-attachments/assets/fdba45a8-f500-47b5-be58-71defcfdb60d" />

This has been reported in multiple issues by VoiceOver users and in the Signal forums:
 - https://github.com/signalapp/Signal-iOS/issues/3955 (closed due to inactivity / stale)
 - https://github.com/signalapp/Signal-iOS/issues/5883 (closed due to inactivity / stale)
 - https://community.signalusers.org/t/improve-signal-for-voiceover-users/68130

It seems based on comments in the code that the omission of this data was on purpose to keep the accessibility label short. I would suggest that users who rely on VoiceOver deserve to get the same level of information that can be obtained by sighted users who are glancing at the message.

Omitting this info from the accessibility label forces VoiceOver users to drill down into submenus and navigate to the message details screen, something a sighted person doesn't have to do to obtain the same information.

By placing this information at the end of the accessibility label, the user can choose to skip to the next element and stop listening if they don't wish to hear this extra information. 