### PR TITLE
#6069 - Double encoding Open Graph Characters

### DIFF
--- a/SignalUI/LinkPreview/HTMLMetadata.swift
+++ b/SignalUI/LinkPreview/HTMLMetadata.swift
@@ -102,7 +102,23 @@ extension HTMLMetadata {
         guard let attributedString = try? NSAttributedString(data: data, options: options, documentAttributes: nil) else {
             return nil
         }
-        return attributedString.string
+        
+        var decodedString = attributedString.string
+        //Attempt recursive decode iteratively a maximum of three times.
+        for _ in 0..<3 {
+            let decodedStringAsData = Data(decodedString.utf8)
+            guard let redecodedAttributedString = try? NSAttributedString(data: decodedStringAsData, options: options, documentAttributes: nil) else {
+                return decodedString
+            }
+            let redecodedString  = redecodedAttributedString.string
+            if redecodedString == decodedString {
+                break
+            }
+            else {
+                decodedString = redecodedString
+            }
+        }
+        return decodedString
     }
 }
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 12, iOS 18.4

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

This pull request `fixes #6069` by redecoding a string containing OpenGraph characters. Originally, a string that looks like:

> Not quoted, &amp;quot;Quoted&amp;quot; and &quot;Better quoted&quot;

Was encoded as:

> Not quoted, &quot;Quoted&quot; and \"Better quoted\"

However, there are still OpenGraph (&quot) tags in the string. This PR redecodes a string up to a maximum of 3 times to make sure that all OpenGraph tags have been consumed.

Before:
![Screenshot 2025-06-20 at 10 25 50 PM](https://github.com/user-attachments/assets/f4e0723c-d6dd-4a8b-b2c8-87132189f19a)

After:
![Screenshot 2025-06-20 at 10 27 01 PM](https://github.com/user-attachments/assets/cfa85384-e4c8-47c4-b219-5eb59b72f0b5)

