### PR TITLE
#5399 Do not use .defaultToSpeaker for shared AudioSession

### DIFF
--- a/SignalUI/AV/AudioSession.swift
+++ b/SignalUI/AV/AudioSession.swift
@@ -172,7 +172,6 @@ public class AudioSession: NSObject {
                 .playAndRecord,
                 mode: .default,
                 options: [
-                    .defaultToSpeaker,
                     .allowBluetoothHFP,
                     .allowBluetoothA2DP
                 ]


### PR DESCRIPTION
It seems using .defaultToSpeaker causes issues when recording with AirPods. By disabling this line it audio recording is automatically routed to the appropriate device

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [X] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] My commits are rebased on the latest main branch
- [X] My commits are in nice logical chunks
- [X] My contribution is fully baked and is ready to be merged as is
- [X] I have tested my contribution on these devices:
 * iPhone 16 Pro, iOS 18.5

- - - - - - - - - -

### Description
Fixes #5399 where audio is routed through the device microphone despite it being connected to other Bluetooth device. Such as AirPods. If the session is re-used maybe this could mess playback? Not super familiar with the codebase, but at least the behavior would be consistent with WhatsApp where even when connected to Bluetooth speaker, messages are played there.

The alternative would be to use two AudioSessions maybe? One for recording and one for playback