### PR TITLE
#5954 Fixes the keyboard not respecting sticker settings

### DIFF
--- a/Signal/ConversationView/ConversationInputTextView.swift
+++ b/Signal/ConversationView/ConversationInputTextView.swift
@@ -46,6 +46,9 @@ class ConversationInputTextView: BodyRangesTextView {
 
         contentMode = .redraw
         dataDetectorTypes = []
+        // Fixes https://github.com/signalapp/Signal-iOS/issues/5954
+        // Weird iOS undocumented behavior where it force enables stickers/memojis
+        // For reference https://stackoverflow.com/questions/79699798/uitextview-enabling-paste-force-enables-memojis-stickers/79700557#79700557
         if #available(iOS 18.0, *) {
             supportsAdaptiveImageGlyph = false
         }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 15 Pro A, iOS 18.5


- - - - - - - - - -

### Description
The keyboard was always showing the sticker/memoji tabs despite them being disabled in the iOS settings. Turned out this was coming from a iOS 18 only property called `supportsAdaptiveImageGlyph` which by default seems to be true. After disabling it, it correctly behaves respecting user settings.

Closes #5954 