### PR TITLE
#6079 - Double tapping on a quotedmessageview using voiceover

### DIFF
--- a/Signal/ConversationView/Components/CVComponentMessage.swift
+++ b/Signal/ConversationView/Components/CVComponentMessage.swift
@@ -2232,6 +2232,10 @@ public class CVComponentMessage: CVComponentBase, CVRootComponent {
             }
         }
 
+        func focusAccessibility() {
+            UIAccessibility.post(notification: .layoutChanged, argument: self.hInnerStack)
+        }
+        
         // MARK: - Flashing Message Bubble
 
         func performMessageBubbleHighlightAnimation() {

--- a/Signal/ConversationView/ConversationViewController+CVC.swift
+++ b/Signal/ConversationView/ConversationViewController+CVC.swift
@@ -4,6 +4,7 @@
 //
 
 public import Foundation
+public import UIKit
 public import SignalServiceKit
 public import SignalUI
 
@@ -37,6 +38,20 @@ extension ConversationViewController {
         }
         return renderItem.interaction
     }
+    
+    func focusAccessibilityOn(messageId: String) {
+        if let indexPath = indexPath(forInteractionUniqueId: messageId) {
+            guard let cell = collectionView.cellForItem(at: indexPath) as? CVCell,
+                  let componentView = cell.componentView as? CVComponentMessage.CVComponentViewMessage
+            else {
+                owsFailDebug("Could not find CVComponentViewMessage")
+                return
+            }
+            componentView.focusAccessibility()
+        } else {
+            owsFailDebug("Unable to find message to highlight [\(messageId)]")
+        }
+    }
 
     var indexPathOfUnreadMessagesIndicator: IndexPath? {
         loadCoordinator.indexPathOfUnreadIndicator
@@ -69,11 +84,12 @@ extension ConversationViewController {
 
     func performMessageHighlightAnimationIfNeeded() {
         if let messageId = viewState.highlightedMessageId {
+            focusAccessibilityOn(messageId: messageId)
             performHighlightAnimationSequenceFor(messageId: messageId)
             viewState.highlightedMessageId = nil
         }
     }
-
+    
     private func performHighlightAnimationSequenceFor(messageId: String) {
         if let indexPath = indexPath(forInteractionUniqueId: messageId) {
             guard let cell = collectionView.cellForItem(at: indexPath) as? CVCell,
@@ -82,7 +98,6 @@ extension ConversationViewController {
                 owsFailDebug("Could not find CVComponentViewMessage")
                 return
             }
-
             componentViewMessage.performMessageBubbleHighlightAnimation()
         } else {
             owsFailDebug("Unable to find a message to highlight. [\(messageId)]")

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -6545,7 +6545,7 @@
 "PUSH_REGISTER_SUCCESS" = "Successfully re-registered for push notifications.";
 
 /* Accessibility label stating the author of the message to which you are replying. Embeds: {{ the author of the message to which you are replying }}. */
-"QUOTED_REPLY_ACCESSIBILITY_LABEL_FORMAT" = "Replying to %@.";
+"QUOTED_REPLY_ACCESSIBILITY_LABEL_FORMAT" = "Replying to %@. Double Tap to go to original message.";
 
 /* Indicates the author of a quoted message. Embeds {{the author's name or phone number}}. */
 "QUOTED_REPLY_AUTHOR_INDICATOR_FORMAT" = "%@";


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 12, iOS 18.4.1

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe briefly how you tested that your fix works.
-->

This PR `fixes #6079` by adding additional text to the accessibility string for a quoted message view. This extra text informs the user that by double-tapping on the view, they will be taken to the original message.

https://github.com/user-attachments/assets/46604490-4bcd-4c95-b05c-e1a6be2585c3

(Edit)
Since my change involves touching some of the locale files, what is the process for updating all locale files to be accurate? Do a series of human translators do it, or is there a script for using an AI translator? Can you give me some insight, Sasha?