### PR TITLE
fix(iPad): correct photo rotation in landscape mode #6086

### DIFF
--- a/Signal/src/ViewControllers/Photos/CameraCaptureSession.swift
+++ b/Signal/src/ViewControllers/Photos/CameraCaptureSession.swift
@@ -341,6 +341,15 @@ class CameraCaptureSession: NSObject {
     }
 
     private var motionManager: CMMotionManager?
+    
+    // Allows external callers to update capture orientation on the session queue.
+    // Useful for iPads deriving orientation from interface, especially before accelerometer data is available.
+    func setCaptureOrientation(_ orientation: AVCaptureVideoOrientation) {
+        sessionQueue.async { [weak self] in
+            self?.captureOrientation = orientation
+            self?.updateVideoCaptureOrientation()
+        }
+    }
 
     func updateVideoPreviewConnection(toOrientation orientation: AVCaptureVideoOrientation) {
         guard let videoConnection = previewView.previewLayer.connection else {

--- a/Signal/src/ViewControllers/Photos/PhotoCaptureViewController.swift
+++ b/Signal/src/ViewControllers/Photos/PhotoCaptureViewController.swift
@@ -127,7 +127,11 @@ class PhotoCaptureViewController: OWSViewController, OWSNavigationChildControlle
             previewOrientation = .portrait
         }
         UIViewController.attemptRotationToDeviceOrientation()
+        
+        // Updates preview layer and capture orientation for correct media encoding.
+        // Crucial on iPad where interface orientation may differ from default portrait.
         cameraCaptureSession.updateVideoPreviewConnection(toOrientation: previewOrientation)
+        cameraCaptureSession.setCaptureOrientation(previewOrientation)
         updateIconOrientations(isAnimated: false, captureOrientation: previewOrientation)
 
         NotificationCenter.default.addObserver(


### PR DESCRIPTION
Resolves #6086

**Problem:**
On iPadOS, in landscape mode, when taking a picture, the camera image is rotated 90° to the right. If you hold the iPad in portrait mode, the camera orientation is correct.

**Expected behavior:**
The camera feed and captured photo orientation should match the physical orientation of the device.

**Solution:**

**CameraCaptureSession**
* Introduced `setCaptureOrientation(_:)`, a safe helper that updates `captureOrientation` and the `AVCaptureConnection` on the dedicated session queue.

**PhotoCaptureViewController**
In `viewWillAppear` we now:
* Obtain the current `UIWindowScene.interfaceOrientation` (iPad-only).
* Update the preview layer via the existing `updateVideoPreviewConnection(to:)`.
* Call the new `setCaptureOrientation` so the encoder receives the same orientation.

**Testing:**

* **iPad 9″ (iOS 18.3.2):**
    * Portrait: Preview and captured photo orientation correct.
    * Landscape: Preview and captured photo orientation correct.
 
* **iPhone 16 pro max (iOS 18.5):**
    * Verified no regressions, camera functionality remains correct in both portrait and landscape.
  
- - - - - - - - - -

- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPad 9, iOS 18.3.2
 * iPhone 16 pro max, iOS 18.5