### PR TITLE
Warn user that deletion will affect multiple devices

### DIFF
--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -7532,7 +7532,7 @@
 "SETTINGS_DELETE_DATA_BUTTON" = "Delete All Data";
 
 /* Alert message before user confirms clearing history */
-"SETTINGS_DELETE_HISTORYLOG_CONFIRMATION" = "Are you sure you want to delete all history (messages, attachments, calls, etc.)? This action cannot be reverted.";
+"SETTINGS_DELETE_HISTORYLOG_CONFIRMATION" = "Are you sure you want to delete all history (messages, attachments, calls, etc.) across all of your devices? This action cannot be reverted.";
 
 /* Confirmation text for button which deletes all message, calling, attachments, etc. */
 "SETTINGS_DELETE_HISTORYLOG_CONFIRMATION_BUTTON" = "Delete Everything";


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have ~tested~ built my contribution on these ~devices~ simulators:
* iPhone 15 Pro, iOS 17.5
* iPad Air, iOS 17.4

- - - - - - - - - -

### Description
This PR adds a warning message to inform users that deleting messages will affect all of their linked devices, not just the current device.
I deleted over 10 years' worth of chat logs that I was archiving on my Signal Desktop (macOS) installation by pressing this button, even after reading the message that was presented to me.
This would have prevented that.

| <img width="500" alt="Simulator Screenshot - iPhone 15 Pro - 2025-08-05 at 22 29 29" src="https://github.com/user-attachments/assets/ae9274fc-3ca1-44ac-a9e1-25015a84b6d3" /> |
|---|
