### PR TITLE
#6093 - Shift existing mention locations on adding new mention ahead of the others

### DIFF
--- a/SignalServiceKit/Messages/BodyRanges/EditableMessageBody.swift
+++ b/SignalServiceKit/Messages/BodyRanges/EditableMessageBody.swift
@@ -368,6 +368,15 @@ public class EditableMessageBodyTextStorage: NSTextStorage {
             in: range,
             with: finalMentionText
         ).removingPlaceholders()
+        
+        // If the new mention is before the already existing mentions, we have to shift the existing mentions.
+        body.mentions.forEach { (mentionRange, mentionAci) in
+            if range.upperBound <= mentionRange.location {
+                body.mentions[mentionRange] = nil
+                body.mentions[NSRange(location: mentionRange.location + (hydratedMention as NSString).length, length: mentionRange.length)] = mentionAci
+            }
+        }
+
         // Any space isn't included in the mention's range.
         let mentionRange = NSRange(location: range.location, length: (hydratedMention as NSString).length)
         body.mentions[mentionRange] = mentionAci
@@ -874,6 +883,10 @@ public class EditableMessageBodyTextStorage: NSTextStorage {
                 preserveStyleInReplacement: true
             )
             mentionOffset += mentionPlaceholderLength - mention.range.length
+//            mentionOffset += mentionPlaceholderLength
+//            if mention.range.location > 0 {
+//                mentionOffset -= mention.range.length
+//            }
         }
         return MessageBody(
             text: text as String,

--- a/SignalServiceKit/Messages/BodyRanges/EditableMessageBody.swift
+++ b/SignalServiceKit/Messages/BodyRanges/EditableMessageBody.swift
@@ -883,10 +883,6 @@ public class EditableMessageBodyTextStorage: NSTextStorage {
                 preserveStyleInReplacement: true
             )
             mentionOffset += mentionPlaceholderLength - mention.range.length
-//            mentionOffset += mentionPlaceholderLength
-//            if mention.range.location > 0 {
-//                mentionOffset -= mention.range.length
-//            }
         }
         return MessageBody(
             text: text as String,


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone SE 2020, iOS 18.1
 * iPhone 13, iOS 18.5
 * iPhone 14, iOS 18.5
 * iPhone 15 Pro, iOS 18.1.1
 * iPhone 16, iOS 18.6

- - - - - - - - - -

### Description
This request fix #6093 by adding post check on `body.mentions`.
On adding new mention, we must double-check to see if there's any existing mentions placed AFTER the new mention.
If found, then we must shift the location of those existing mentions to the right by the length of the new mention string.