### PR TITLE
Improve Stale Issue and Stale PR processing by Stale Bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,20 +14,31 @@ jobs:
     steps:
     - uses: actions/stale@v9
       with:
-        stale-issue-message: >
-          This issue has been automatically marked as stale because it has not had
-          recent activity. It will be closed if no further activity occurs. Thank you
-          for your contributions.
+        only-issue-labels: answered,needs-info
+        stale-issue-message: |
+          This issue has been automatically marked as stale because an answer
+          was given 90 days ago or there is missing information about the issue
+          since 90 days.
+
+          Please close the issue, if you are satisfied with the answer, or add
+          the requested information.
+
+          The issue will be closed in two weeks, if no further activity occurs.  
+          Thank you for your contributions.
         close-issue-message: >
-          This issue has been closed due to inactivity.
-        stale-pr-message: >
-          This PR has been automatically marked as stale because it has not had
-          recent activity. It will be closed if no further activity occurs. Thank you
-          for your contributions.
+          This issue has been closed due to inactivity. See previous message.
+        only-pr-labels: needs-changes
+        stale-pr-message: |
+          This PR has been automatically marked as stale because changes were
+          requested 90 days ago but there was not change.
+
+          This PR will be closed in two weeks, if no further activity occurs.  
+          Thank you for your contributions.
         close-pr-message: >
-          This PR has been closed due to inactivity.
+          This PR has been closed due to inactivity. See previous message.
         days-before-stale: 90
-        days-before-close: 7
+        # this is long enough for someone to go on 2 week holiday + 1 weekend + 1 extra day
+        days-before-close: 17
         stale-issue-label: stale
         stale-pr-label: stale
         # These are comma-separated lists, if we ever want more than one.


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices: no, since this did not touch Signal code
- - - - - - - - - -

### Description
Currently, all issues and PRs will get closed after 90 days of inactivity. This means real issues get dismissed because nobody found the time to take a closer look at it. This can be stopped by commenting anything into the issue withing 7 days.

This leads duplicated issues and an issue tracker that is not representative of the actual state and unhappy users. In some cases the comment to keep the issue open cannot be done in time because 7 days is not a lot of time and can easily by missed by a week of absence due to holidays or sickness.

To fix this, this adjusts how the stale bot handles issues. First off, issues/PRs labeled `acknowledged` issues will still be ignored by stale bot and never closed.
Stale bot will only look at issues marked `answered` or `needs-info` and PRS marked `needs-changes`. This means when a maintainer sees the issue there are a few options:

- Mark the issue/PR as `acknowledged`, if it is an issue
- Answer the issue and mark the issue as `answered`, if the issue should be solved with the answer (e.g. support requests)
- Answer the issue or PR with request for more information or request changes and mark the issue as `needs-info` or the PR as `needs-changes`

This also improves the stale bot messages for marking stale with more information about what is happening and what will happen.

The time from marking stale to closing the issue/PR is increasing to fit two weeks, one weekend, and one extra day to allow people to live their lives and go on holiday without the need of checking their emails.

This fixes #5931.
