### PR TITLE
Add Russia to censoredCountryCodes

### DIFF
--- a/SignalServiceKit/Network/OWSCensorshipConfiguration.swift
+++ b/SignalServiceKit/Network/OWSCensorshipConfiguration.swift
@@ -170,6 +170,8 @@ struct OWSCensorshipConfiguration {
         "+998": "UZ",
         // Pakistan
         "+92": "PK",
+        // Russia
+        "+7": "RU",
     ]
 
     /// Returns nil if the phone number is not known to be censored


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [ ] I have not signed the [Contributor Licence Agreement](https://signal.org/cla/), but I agree to all terms listed there.

### Contributor checklist
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 8, iOS 16.7.11

- - - - - - - - - -

### Description
This PR enables censorship circumvention by default for accounts with a Russian (+7) phone number. At the time of writing, it's impossible to use Signal in Russia due to the local government's network restrictions. This small fix is required for Signal to work independently and without additional workarounds.

Additionally, I noticed that Signal doesn't call `updateHasCensoredPhoneNumberDuringProvisioning()` during the registration/login flow, so the user still has to use a VPN or proxy service to create an account or log in. This seems like an oversight, so I'll try to make an additional PR that fixes this in the near future (I have to come up with a clean way to do this first).