### PR TITLE
Add DNG as a valid photo filetype

### DIFF
--- a/SignalServiceKit/Util/ImageMetadata/ImageMetadata.swift
+++ b/SignalServiceKit/Util/ImageMetadata/ImageMetadata.swift
@@ -11,6 +11,7 @@ public enum ImageFormat: CustomStringConvertible {
     case tiff
     case jpeg
     case bmp
+    case dng
     case webp
     case heic
     case heif
@@ -27,6 +28,8 @@ public enum ImageFormat: CustomStringConvertible {
             "ImageFormat_Jpeg"
         case .bmp:
             "ImageFormat_Bmp"
+        case .dng:
+            "ImageFormat_Dng"
         case .webp:
             "ImageFormat_Webp"
         case .heic:
@@ -42,14 +45,24 @@ public enum ImageFormat: CustomStringConvertible {
 
     private var mimeTypes: (preferredMimeType: MimeType, alternativeMimeTypes: [MimeType]) {
         switch self {
-        case .png: (.imagePng, [.imageApng, .imageVndMozillaApng])
-        case .gif: (.imageGif, [])
-        case .tiff: (.imageTiff, [.imageXTiff])
-        case .jpeg: (.imageJpeg, [])
-        case .bmp: (.imageBmp, [.imageXWindowsBmp])
-        case .webp: (.imageWebp, [])
-        case .heic: (.imageHeic, [])
-        case .heif: (.imageHeif, [])
+        case .png:
+            (.imagePng, [.imageApng, .imageVndMozillaApng])
+        case .gif:
+            (.imageGif, [])
+        case .tiff:
+            (.imageTiff, [.imageXTiff])
+        case .jpeg:
+            (.imageJpeg, [])
+        case .bmp:
+            (.imageBmp, [.imageXWindowsBmp])
+        case .dng:
+            (.imageDng, [])
+        case .webp:
+            (.imageWebp, [])
+        case .heic:
+            (.imageHeic, [])
+        case .heif:
+            (.imageHeif, [])
         }
     }
 

--- a/SignalServiceKit/Util/MimeTypeUtil.swift
+++ b/SignalServiceKit/Util/MimeTypeUtil.swift
@@ -15,6 +15,7 @@ public enum MimeType: String {
     case applicationZip = "application/zip"
     case imageApng = "image/apng"
     case imageBmp = "image/bmp"
+    case imageDng = "image/x-adobe-dng"
     case imageGif = "image/gif"
     case imageHeic = "image/heic"
     case imageHeif = "image/heif"
@@ -74,7 +75,7 @@ public enum MimeTypeUtil {
     public static let supportedAudioUtiTypes: Set<String> = Set(utiTypesForMimeTypes(supportedAudioMimeTypesToExtensionTypes.keys))
     public static let supportedInputImageUtiTypes: Set<String> = Set(utiTypesForMimeTypes(supportedImageMimeTypesToExtensionTypes.keys))
     public static let supportedOutputImageUtiTypes: Set<String> = Set(utiTypesForMimeTypes(supportedImageMimeTypesToExtensionTypes.keys,
-                                                                                           excluding: [MimeType.imageWebp.rawValue, MimeType.imageHeic.rawValue, MimeType.imageHeif.rawValue]))
+                                                                                           excluding: [MimeType.imageWebp.rawValue, MimeType.imageHeic.rawValue, MimeType.imageHeif.rawValue, MimeType.imageDng.rawValue]))
     public static let supportedAnimatedImageUtiTypes: Set<String> = Set(utiTypesForMimeTypes(supportedMaybeAnimatedMimeTypesToExtensionTypes.keys))
     private static func utiTypesForMimeTypes<S: Sequence<String>>(_ mimeTypes: S, excluding excludedMimeTypes: Set<String>? = nil) -> Set<String> {
         var result = Set<String>()
@@ -188,6 +189,7 @@ public enum MimeTypeUtil {
         MimeType.imageXTiff.rawValue: "tif",
         MimeType.imageBmp.rawValue: "bmp",
         MimeType.imageXWindowsBmp.rawValue: "bmp",
+        MimeType.imageDng.rawValue: "dng",
         MimeType.imageHeic.rawValue: "heic",
         MimeType.imageHeif.rawValue: "heif",
         MimeType.imageWebp.rawValue: "webp",


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist

<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->

- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist

<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->

- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [ x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:

* iPhone 16 Pro Max, iOS 26 beta 9
* iPad Mini 2024, iPadOS 26 beta 9

---

### Description

Adds support for DNG as a valid image format. Resolves #4298 and #5337

Tested on two physical devices with RAW images captured on the iPhone and on a different DNG-generating camera.
