### PR TITLE
**Commit message:**

### DIFF
--- a/Signal/ConversationView/ConversationInputToolbar.swift
+++ b/Signal/ConversationView/ConversationInputToolbar.swift
@@ -1440,6 +1440,11 @@ public class ConversationInputToolbar: UIView, LinkPreviewViewDraftDelegate, Quo
             ensureButtonVisibility(withAnimation: true, doLayout: true)
         }
     }
+    
+    var isVoiceInteractionActive: Bool {
+        return voiceMemoRecordingState != .idle && voiceMemoRecordingState != .draft
+    }
+    
     private var voiceMemoGestureStartLocation: CGPoint?
 
     private var isShowingVoiceMemoUI: Bool = false {

--- a/Signal/ConversationView/ConversationViewController.swift
+++ b/Signal/ConversationView/ConversationViewController.swift
@@ -523,6 +523,11 @@ public final class ConversationViewController: OWSViewController {
         if viewState.inProgressVoiceMessage?.isRecording == true {
             return false
         }
+        
+        // Don't allow orientation changes during voice memo interactions
+        if inputToolbar?.isVoiceInteractionActive == true {
+            return false
+        }
 
         return super.shouldAutorotate
     }


### PR DESCRIPTION
**Changes:**
1. Added `isVoiceInteractionActive` computed property to `ConversationInputToolbar` that checks if voice memo is in active state (not idle/draft)
2. Added orientation lock logic to `ConversationViewController.shouldAutorotate` that prevents rotation during voice interactions
3. Both changes work together to fix autorotation issues during voice memo usage

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 15 Pro Max
- - - - - - - - - -

### Description
Fixing #6021 #4359
