### PR TITLE
Change maxSendEdits from 10 to 100 for many reasons (e.g., maxReceiveEdits is also 100)

### DIFF
--- a/SignalServiceKit/Messages/Edit/EditManagerImpl.swift
+++ b/SignalServiceKit/Messages/Edit/EditManagerImpl.swift
@@ -25,8 +25,8 @@ public class EditManagerImpl: EditManager {
         // original message
         static let editSendWindowMilliseconds: UInt64 = UInt64.dayInMs
 
-        // Message can only be edited 10 times
-        static let maxSendEdits: UInt = UInt(10)
+        // Message can only be edited 100 times
+        static let maxSendEdits: UInt = UInt(100)
     }
 
     public struct Context {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [ ] I have tested my contribution on these devices:
 * iDevice A, iOS X.Y.Z
 * iDevice B, iOS Z.Y

- - - - - - - - - -

### Description
I'm doing a simple change to change maxSendEdits from 10 to 100 for the following reasons:
1. maxReceiveEdits is also 100, see [code](https://github.com/signalapp/Signal-iOS/blob/5770e6f5b657b1fdb29d84d62960a521c60a6052/SignalServiceKit/Messages/Edit/EditManagerImpl.swift#L20)
2. allowing more SendEdits makes Signal strictly more powerful and easier to use.
3. for certain situations, it's frustrating to only allow 10 edits and one may have to delete the message and re-send one, which leads to worse user experience.

Thus I'd love to propose such the edit and sincerely ask maintainers to consider accept it.
