### PR TITLE
Increase number of pinned threads to 6

### DIFF
--- a/SignalServiceKit/PinnedThreadManager/PinnedThreadManager.swift
+++ b/SignalServiceKit/PinnedThreadManager/PinnedThreadManager.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 public enum PinnedThreads {
-    public static let maxPinnedThreads = 4
+    public static let maxPinnedThreads = 6
 }
 
 public protocol PinnedThreadManager {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 17 Pro (iOS 26)

- - - - - - - - - -

### Description

There has been discussion for many years about the [number of pinned convesations](https://community.signalusers.org/t/allow-for-more-than-4-pinned-chats/19869) that Signal allows. 

This change, which increases the number of pinned threads from 4 to 6, is inspired [by my own usage of Signal](https://bsky.app/profile/mbbischoff.com/post/3ls27bek2zh2x) to communicate with many [fellow queer and trans people](https://bsky.app/profile/rosemary.world/post/3luv6mll65c2s) and analysis of other messaging applications, which have begun increasing the number of allowed pins in recent years (iMessage, Telegram).

As phones have gotten larger, it no longer makes sense to limit the number of pins to 4. While it may make sense to remove the limit entirely, I’d like to start with a discussion just of raising the limit to a number that better reflects how much vertical space the most popular modern phones have to show pinned conversations "above the fold".

If this change is accepted, I’d also be more than happy to apply it to the other clients for parity.

## Screenshot

<img width="300" alt="image" src="https://github.com/user-attachments/assets/67ea5e39-16cb-467d-a979-6a994910eca5" />

## Research

| App                    | Pin Limit                                                                                    
| ---------------------- | ---------------------------------------------------------------------------------------------
| **iMessage**           | 9 conversations                                                                              
| **Telegram**           | Up to **5 chats** in main chat list + 5 secret chats; with Premium, up to **10** pinned chats
| **WhatsApp**, **Facebook**, **Instagram**           | 3 chats                                                                                      