### PR TITLE
Improve photo quality with enhanced AVCapturePhotoOutput settings

### DIFF
--- a/Signal/src/ViewControllers/Photos/CameraCaptureSession.swift
+++ b/Signal/src/ViewControllers/Photos/CameraCaptureSession.swift
@@ -1486,12 +1486,15 @@ private class PhotoCapture {
     let avCaptureOutput = AVCapturePhotoOutput()
 
     var flashMode: AVCaptureDevice.FlashMode = .off
-
-    init() {
+init() {
         avCaptureOutput.isLivePhotoCaptureEnabled = false
         avCaptureOutput.isHighResolutionCaptureEnabled = true
-    }
+        
+        if #available(iOS 13.0, *) {
 
+            avCaptureOutput.maxPhotoQualityPrioritization = .quality
+        }
+    }
     private var photoProcessors: [Int64: PhotoProcessor] = [:]
 
     func takePhoto(delegate: PhotoCaptureDelegate, captureOrientation: AVCaptureVideoOrientation, captureRect: CGRect) {
@@ -1502,9 +1505,18 @@ private class PhotoCapture {
 
         avCaptureConnection.videoOrientation = captureOrientation
 
-        let photoSettings = AVCapturePhotoSettings()
+    let photoSettings = AVCapturePhotoSettings()
         photoSettings.flashMode = flashMode
         photoSettings.isHighResolutionPhotoEnabled = true
+
+        if #available(iOS 13.0, *) {
+
+            photoSettings.photoQualityPrioritization = .quality
+        }
+
+        if avCaptureOutput.isAutoRedEyeReductionSupported {
+            photoSettings.isAutoRedEyeReductionEnabled = true
+        }
 
         let photoProcessor = PhotoProcessor(delegate: delegate, captureRect: captureRect) { [weak self] in
             self?.photoProcessors[photoSettings.uniqueID] = nil


### PR DESCRIPTION
## Summary
This PR improves photo quality in Signal's custom camera by leveraging iOS computational photography APIs available through AVFoundation.

## Changes
- Set `maxPhotoQualityPrioritization` to `.quality` on AVCapturePhotoOutput initialization
- Set `photoQualityPrioritization` to `.quality` for each photo capture
- Enable automatic red-eye reduction when supported by the device

## Motivation
Addresses #6098 - Users reported that photos taken with Signal's custom camera are significantly lower quality compared to the native iOS Camera app. While the custom camera cannot access all features like Night Mode, Portrait Mode, or Cinematic Mode (which require UIImagePickerController), these improvements maximize photo quality using the available AVFoundation APIs.

## Technical Details
- Uses `@available(iOS 13.0, *)` checks for quality prioritization APIs
- `photoQualityPrioritization = .quality` enables better image processing including:
  - Improved noise reduction
  - Better color accuracy
  - Enhanced dynamic range
  - Optimized sharpness
- High-resolution capture remains enabled
- Compatible with existing flash and orientation settings

## Testing
- Tested on various iOS devices (recommended: test in low-light conditions)
- Verified no performance regression in capture speed
- Confirmed backward compatibility with iOS 13+

## Limitations
This approach improves quality within the custom camera architecture but doesn't provide access to advanced modes like Night Mode or Portrait Mode, which would require adopting UIImagePickerController (a larger architectural change as noted in #6098).

Fixes #6098