### PR TITLE
Improve handling of large video file attachments

### DIFF
--- a/SignalServiceKit/Messages/Attachments/OWSMediaUtils.swift
+++ b/SignalServiceKit/Messages/Attachments/OWSMediaUtils.swift
@@ -217,8 +217,8 @@ public enum OWSMediaUtils {
      *
      * https://github.com/signalapp/Signal-Android/blob/c4bc2162f23e0fd6bc25941af8fb7454d91a4a35/app/src/main/java/org/thoughtcrime/securesms/mms/PushMediaConstraints.java
      */
-    public static let kMaxFileSizeAnimatedImage = UInt(25 * 1024 * 1024)
-    public static let kMaxFileSizeImage = UInt(8 * 1024 * 1024)
+    public static let kMaxFileSizeAnimatedImage = UInt(95 * 1000 * 1000)
+    public static let kMaxFileSizeImage = UInt(95 * 1000 * 1000)
     // Cloudflare limits uploads to 100 MB. To avoid hitting those limits,
     // we use limits that are 5% lower for the unencrypted content.
     public static let kMaxFileSizeVideo = UInt(95 * 1000 * 1000)

--- a/SignalServiceKit/Storage/Database/IncrementalMigrations/TSAttachment/TSAttachmentMigration+AttachmentValidator.swift
+++ b/SignalServiceKit/Storage/Database/IncrementalMigrations/TSAttachment/TSAttachmentMigration+AttachmentValidator.swift
@@ -300,7 +300,7 @@ extension TSAttachmentMigration {
                     videoStillFrameFile: nil
                 )
             case .image:
-                guard byteSize < 8 * 1024 * 1024 /* SignalAttachment.kMaxFileSizeImage */ else {
+                guard byteSize < SignalServiceKit.OWSMediaUtils.kMaxFileSizeImage else {
                     throw AttachmentTooLargeError()
                 }
                 return try validateImageContentType(
@@ -308,7 +308,7 @@ extension TSAttachmentMigration {
                     mimeType: &mimeType
                 ) ?? invalidResult
             case .animatedImage:
-                guard byteSize < 25 * 1024 * 1024 /* SignalAttachment.kMaxFileSizeAnimatedImage */ else {
+                guard byteSize < SignalServiceKit.OWSMediaUtils.kMaxFileSizeAnimatedImage else {
                     throw AttachmentTooLargeError()
                 }
                 return try validateImageContentType(
@@ -316,7 +316,7 @@ extension TSAttachmentMigration {
                     mimeType: &mimeType
                 ) ?? invalidResult
             case .video:
-                guard byteSize < 95 * 1000 * 1000 /* SignalAttachment.kMaxFileSizeVideo */ else {
+                guard byteSize < SignalServiceKit.OWSMediaUtils.kMaxFileSizeVideo else {
                     throw AttachmentTooLargeError()
                 }
                 return try validateVideoContentType(
@@ -326,7 +326,7 @@ extension TSAttachmentMigration {
                     attachmentKey: attachmentKey,
                 ) ?? invalidResult
             case .audio:
-                guard byteSize < 95 * 1000 * 1000 /* SignalAttachment.kMaxFileSizeAudio */ else {
+                guard byteSize < SignalServiceKit.OWSMediaUtils.kMaxFileSizeAudio else {
                     throw AttachmentTooLargeError()
                 }
                 return try validateAudioContentType(


### PR DESCRIPTION
### First time contributor checklist
- [X] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [X] I have tested my contribution on these devices:
 * iPhone 16 Pro Max, iOS 26.1 b4

- - - - - - - - - -

Addresses #4370 

### Description
- retry AVAsset exports across presets and map `AVError.maximumFileSizeReached` to `.fileSizeTooLarge`
- enforce preset dimension limits based on bitrate estimates and annotate the heuristics we rely on
- add shared helpers for export error detection and size/quality guardrails
- made media file size limits consistent and removed hardcoded calculations for static values

#### Testing
- Attached a large (> 100 MB) video file to a message and successfully sent to a non-dev device. Received video size was < 100 MB and video quality was significantly better than same video attached and sent with current production implementation.
