### PR TITLE
Fix flicker when opening media by adjusting transition view alpha

### DIFF
--- a/Signal/src/ViewControllers/MediaGallery/Transitions/MediaZoomAnimationController.swift
+++ b/Signal/src/ViewControllers/MediaGallery/Transitions/MediaZoomAnimationController.swift
@@ -80,6 +80,7 @@ extension MediaZoomAnimationController: UIViewControllerAnimatedTransitioning {
             return
         }
         containerView.addSubview(toView)
+        toView.alpha = 0.0
         toView.autoPinEdgesToSuperviewEdges()
         toView.layoutIfNeeded()
 
@@ -140,7 +141,6 @@ extension MediaZoomAnimationController: UIViewControllerAnimatedTransitioning {
         // Because toggling `isHidden` causes UIStack view layouts to change, we instead toggle `alpha`
         fromTransitionalOverlayView?.alpha = 1.0
         fromMediaContext.mediaView.alpha = 0.0
-        toView.alpha = 0.0
         toTransitionalOverlayView?.alpha = 0.0
         toMediaContext.mediaView.alpha = 0.0
 
@@ -170,12 +170,14 @@ extension MediaZoomAnimationController: UIViewControllerAnimatedTransitioning {
             fromContextProvider.mediaDidPresent(fromContext: fromMediaContext)
             toContextProvider.mediaDidPresent(toContext: toMediaContext)
 
+            // Show the actual media views first to prevent flash during transition cleanup
+            toMediaContext.mediaView.alpha = 1.0
+            fromMediaContext.mediaView.alpha = 1.0
+
+            // Then remove transition views after media is visible
             clippingView.removeFromSuperview()
             fromTransitionalOverlayView?.removeFromSuperview()
             toTransitionalOverlayView?.removeFromSuperview()
-
-            toMediaContext.mediaView.alpha = 1.0
-            fromMediaContext.mediaView.alpha = 1.0
 
             transitionContext.completeTransition(!transitionContext.transitionWasCancelled)
         }


### PR DESCRIPTION
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 13 Pro, iOS 26.0.1

- - - - - - - - - -

### Description
This PR addresses a brief flicker that occurs when opening images or videos in the chat view.
Fixes #6132 

Sets the initial `toView.alpha` to `0.0` before the transition begins to avoid premature rendering. Ensures media views are fully visible before removing transition overlays, preventing a black or white flash during animation. Verified no regressions in standard media opening transitions