### PR TITLE
Fix share extension theme not updating on system appearance change

### DIFF
--- a/SignalUI/RecipientPickers/ConversationPicker.swift
+++ b/SignalUI/RecipientPickers/ConversationPicker.swift
@@ -246,6 +246,15 @@ open class ConversationPickerViewController: OWSTableViewController2 {
         updateTableContents(shouldReload: false)
     }
 
+    open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        let userInterfaceStyleDidChange = previousTraitCollection?.userInterfaceStyle != traitCollection.userInterfaceStyle
+        if !CurrentAppContext().isMainApp, userInterfaceStyleDidChange {
+            Theme.shareExtensionThemeOverride = traitCollection.userInterfaceStyle
+        }
+    }
+
     // MARK: - ConversationCollection
 
     private func restoreSelection() {


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
  * iPhone 15 Pro, iOS 17

- - - - - - - - - -

### Description

When the share extension is open and the user changes the system appearance (dark/light mode) via Control Center or Settings, the share extension UI does not update to reflect the new theme.

**Root cause:** The `Theme.shareExtensionThemeOverride` property was only being set once during `viewDidLoad`, but there was no mechanism to detect and respond to system appearance changes while the share extension was already visible.

**Fix:** Added `traitCollectionDidChange` override in `ConversationPickerViewController` to detect when `userInterfaceStyle` changes and update `Theme.shareExtensionThemeOverride` accordingly, which triggers the theme notification and updates the UI.

**Testing:** Opened share extension from Photos app, toggled dark/light mode via Control Center while share sheet was visible, verified UI updates correctly.

---

<img width="200" alt="Group" src="https://github.com/user-attachments/assets/d95c4b4e-15aa-421f-803a-dd17ae07bc93" />
