### PR TITLE
Fix dimming animation flicker

### DIFF
--- a/Signal/ConversationView/CellViews/CVColorOrGradientView.swift
+++ b/Signal/ConversationView/CellViews/CVColorOrGradientView.swift
@@ -337,25 +337,13 @@ public class CVColorOrGradientView: ManualLayoutViewWithLayer {
 
         dimmerLayer.removeAllAnimations()
 
-        // Animate fade-in.
-        let fadeIn = CABasicAnimation(keyPath: #keyPath(CALayer.opacity))
-        fadeIn.fromValue = 0
-        fadeIn.toValue = 1
-        fadeIn.duration = stepDuration
-        fadeIn.fillMode = .forwards
-        fadeIn.isRemovedOnCompletion = false
-        dimmerLayer.add(fadeIn, forKey: "fadeIn")
-
-        // Schedule fade-out after delay.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2 * stepDuration) {
-            let fadeOut = CABasicAnimation(keyPath: #keyPath(CALayer.opacity))
-            fadeOut.fromValue = 1
-            fadeOut.toValue = 0
-            fadeOut.duration = stepDuration
-            fadeOut.fillMode = .forwards
-            fadeOut.isRemovedOnCompletion = false
-            dimmerLayer.add(fadeOut, forKey: "fadeOut")
-        }
+        let animation = CAKeyframeAnimation(keyPath: #keyPath(CALayer.opacity))
+        animation.values = [0, 1, 1, 0]
+        animation.keyTimes = [0, 1.0 / 3.0, 2.0 / 3.0, 1].map { NSNumber(value: $0) }
+        animation.duration = stepDuration * 3
+        animation.fillMode = .forwards
+        animation.isRemovedOnCompletion = false
+        dimmerLayer.add(animation, forKey: "dimming")
     }
 }
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] My commits are rebased on the latest main branch
- [X] My commits are in nice logical chunks
- [X] My contribution is fully baked and is ready to be merged as is
- [X] I have tested my contribution on these devices:
 * iPhone 16, iOS 26.2 (xcode simulator)

https://github.com/user-attachments/assets/1bb90889-e7bf-4e0f-9ef5-8b1d894a5894

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

Fixes #6179, see it for context on the issue.

This bug is due to the fact that the parent message dimming animation is composed of a `fadeIn` and separate async `fadeOut`. When we tap in quick succession we call `dimmerLayer.removeAllAnimations()` to remove any old animation, but this doesn't include the `fadeOut` if the async hasn't fired yet. This means we end up with multiple old async `fadeOut`s causing the parent message to flicker once the tapping stops.

The fix is to make this into one sync animation that contains the fade in and fade out. This way when the link is tapped again we clear the entire old animation including the fade out. This seems simpler and cleaner than tracking the async queue and clearing from there, and more logically correct to treat the animation as atomic.
