### PR TITLE
Fix audio/mpeg file extension mapping

### DIFF
--- a/SignalServiceKit/Util/MimeTypeUtil.swift
+++ b/SignalServiceKit/Util/MimeTypeUtil.swift
@@ -947,7 +947,7 @@ public enum MimeTypeUtil {
         "audio/midi": "midi",
         "audio/mod": "mod",
         "audio/mp4": "m4a",
-        "audio/mpeg": "mpg",
+        "audio/mpeg": "mp3",
         "audio/mpeg3": "mp3",
         "audio/ogg": "oga",
         "audio/s3m": "s3m",


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 13 Pro, iOS 26.2
 
- - - - - - - - - -

### Description

This PR fixes an incorrect file-extension mapping for the MIME type `audio/mpeg`, which currently resolves to `.mpg` and causes audio messages to be exported and shared as **video files** on iOS.

The mapping is updated from:

`"audio/mpeg": "mpg"` => `"audio/mpeg": "mp3"`

#### Context

`.mpg` / `.mpeg` refer to **MPEG Program Stream** container formats, which are designed to multiplex **video and audio** and are therefore treated as **video containers** by operating systems and media frameworks:

> “Program stream (PS or MPEG-PS) is a container format for multiplexing digital audio, video and more.”  
> https://en.wikipedia.org/wiki/MPEG_program_stream

As a result, using `.mpg` for `audio/mpeg` causes exported audio files to be misclassified as video.

By contrast, the official IANA registration for `audio/mpeg` (RFC 3003) lists the valid file extensions as:

> File extension(s): .mp1, .mp2, .mp3  
> https://www.iana.org/assignments/media-types/audio/mpeg

Mapping `audio/mpeg` to `.mp3` aligns with the MIME specification and OS media classification behavior.

#### Result

- Audio messages with MIME type `audio/mpeg` are exported with the `.mp3` extension
- iOS correctly recognizes them as audio files
- Sharing to Files, Notes, and other apps behaves as expected

#### Testing

- Sent an MP3 file to the iOS Signal app and confirmed it renders as an audio message
- Long-pressed the message and pressed Share 
- Verified that file in share sheet uses the `.mp3` extension and displays audio type and not `.mpg` extension and video type
- Confirmed no regression in in-app audio playback

Fixes https://github.com/signalapp/Signal-iOS/issues/6140
