### PR TITLE
Fix typing error in class

### DIFF
--- a/Signal/src/ViewControllers/AppSettings/Account/DeleteAccountConfirmationViewController.swift
+++ b/Signal/src/ViewControllers/AppSettings/Account/DeleteAccountConfirmationViewController.swift
@@ -284,7 +284,7 @@ class DeleteAccountConfirmationViewController: OWSTableViewController2 {
                 comment: "Title for the action sheet confirmation title of the 'delete account confirmation' view controller.",
             ),
             message: OWSLocalizedString(
-                "DELETE_ACCOUNT_CONFIRMATION_ACTION_SHEEET_MESSAGE",
+                "DELETE_ACCOUNT_CONFIRMATION_ACTION_SHEET_MESSAGE",
                 comment: "Title for the action sheet message of the 'delete account confirmation' view controller.",
             ),
             proceedTitle: OWSLocalizedString(


### PR DESCRIPTION
This (for example) has to be fixed as well as a consequence of #6194 

But there are still several more issues with those typos inside classes, unforetunately, but I'll try to fix them as soon as possible