### PR TITLE
Show most recent messages in 3D Touch conversation preview

### DIFF
--- a/Signal/ConversationView/ConversationViewController.swift
+++ b/Signal/ConversationView/ConversationViewController.swift
@@ -67,6 +67,7 @@ public final class ConversationViewController: OWSViewController {
         threadViewModel: ThreadViewModel,
         action: ConversationViewAction,
         focusMessageId: String?,
+        scrollToNewestMessages: Bool = false,
         tx: DBReadTransaction,
     ) -> ConversationViewController {
         let thread = threadViewModel.threadRecord
@@ -82,6 +83,12 @@ public final class ConversationViewController: OWSViewController {
         if let focusMessageId {
             loadAroundMessageId = focusMessageId
             scrollToMessageId = focusMessageId
+        } else if scrollToNewestMessages {
+            // When scrollToNewestMessages is true, load and scroll to the most recent
+            // messages instead of the first unread message. This is useful for 3D Touch
+            // previews where users want to see the current conversation state.
+            loadAroundMessageId = nil
+            scrollToMessageId = nil
         } else if let oldestUnreadMessage {
             loadAroundMessageId = oldestUnreadMessage.uniqueId
             // Set this to `nil` so that we scroll to the unread divider.

--- a/Signal/src/ViewControllers/HomeView/Chat List/ChatListViewController+Helpers.swift
+++ b/Signal/src/ViewControllers/HomeView/Chat List/ChatListViewController+Helpers.swift
@@ -195,6 +195,7 @@ extension ChatListViewController {
                 threadViewModel: threadViewModel,
                 action: .none,
                 focusMessageId: nil,
+                scrollToNewestMessages: true,
                 tx: tx,
             )
         }


### PR DESCRIPTION
Previously, when using 3D Touch to preview a conversation from the chat list, the preview would scroll to the first unread message. This made it difficult to quickly check the current state of a conversation without opening it.

This change adds a `scrollToNewestMessages` parameter to `ConversationViewController.load()` and uses it for 3D Touch previews, so users can now see the most recent messages when previewing a chat.

### First time contributor checklist
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * Build verified on iOS Simulator (iPhone 17 Pro Max)
 * Note: Server-connected testing requires official signing certificates (per CONTRIBUTING.md known limitations)

- - - - - - - - - -

### Description

**Problem:**
When using 3D Touch (or long-press on newer devices) to preview a conversation from the chat list, the preview scrolls to the first unread message instead of showing the most recent messages. This prevents users from quickly glancing at the current state of a conversation.

**Solution:**
Added a `scrollToNewestMessages` parameter to `ConversationViewController.load()` with a default value of `false` to maintain backward compatibility. For 3D Touch previews, this is set to `true` so the preview displays the most recent messages.

**Changes:**
- `ConversationViewController.swift`: Added `scrollToNewestMessages: Bool = false` parameter
- `ChatListViewController+Helpers.swift`: Pass `scrollToNewestMessages: true` when creating preview

**Testing:**
- Build compiles and runs successfully on iOS Simulator
- Code logic verified through review
- Default parameter value ensures no impact on existing callers