### PR TITLE
Reset keyboard to ABC layout after send

### DIFF
--- a/Signal/ConversationView/ConversationInputToolbar.swift
+++ b/Signal/ConversationView/ConversationInputToolbar.swift
@@ -1583,6 +1583,22 @@ public class ConversationInputToolbar: UIView, QuotedReplyPreviewDelegate {
         editTarget = nil
         setMessageBody(nil, animated: animated)
         inputTextView.undoManager?.removeAllActions()
+        resetKeyboardLayout()
+    }
+
+    /// Resets the iOS keyboard from the symbols/numbers pane back to the
+    /// default alphabetic layout by toggling ``keyboardType``. Each
+    /// reload is required — the first forces the keyboard to tear down
+    /// its current layout, and the second rebuilds it in the default
+    /// alpha state. Does not affect the user's selected language.
+    private func resetKeyboardLayout() {
+        guard inputTextView.inputView == nil, inputTextView.isFirstResponder else { return }
+
+        let original = inputTextView.keyboardType
+        inputTextView.keyboardType = (original == .default) ? .emailAddress : .default
+        inputTextView.reloadInputViews()
+        inputTextView.keyboardType = original
+        inputTextView.reloadInputViews()
     }
 
     // MARK: Content Size Change Handling


### PR DESCRIPTION
### Contributor checklist
- [X] My commits are rebased on the latest main branch
- [X] My commits are in nice logical chunks
- [X] My contribution is fully baked and is ready to be merged as is
- [X] I have tested my contribution on these devices:
 * iPhone 17, iOS 26.3
 * iPhone 17 Pro Max, iOS 26.3

- - - - - - - - - -

### Description
It is standard behavior on iOS messaging apps (iMessage, WhatsApp, etc) that when you send a message, the current input pane is returned to the default "ABC" pane.

For example: in iMessage, if I write the message "Hello, World!", and tap send, my keyboard will be set back to "ABC" ready to start my next message. However, on Signal, when I write "Hello, World!", and tap send, the input pane remains on punctuation, and I have to tap the "ABC" button to start typing my next message.

This adds friction, and is counter to the natural flow of iOS. Further, Signal for Android does not exhibit this behavior: it works as iMessage does and resets to "ABC" after send.

I contributed a PR for this in 2023, but it was reverted, because that change reset the keyboard to `.alphabet` which caused non-latin languages to change to English unexpectedly. This PR uses `.default` to avoid that issue.