### PR TITLE
Add reorder in StickerManager

### DIFF
--- a/SignalUI/Stickers/StickerPickerView.swift
+++ b/SignalUI/Stickers/StickerPickerView.swift
@@ -462,9 +462,7 @@ private class StickerPickerPageView: UIView {
         let oldStickerPacks = stickerPacks
 
         SSKEnvironment.shared.databaseStorageRef.read { transaction in
-            self.stickerPacks = StickerManager.installedStickerPacks(transaction: transaction).sorted {
-                $0.dateCreated > $1.dateCreated
-            }
+            self.stickerPacks = StickerManager.orderedInstalledStickerPacks(transaction: transaction)
         }
 
         // These go (via delegate) as source data to the toolbar.


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 13, iOS 26.3
 * iPhone 17 Pro simulator, iOS 26.2

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->
This PR adds manual reordering for installed sticker packs on iOS.

Installed packs were previously shown by dateCreated. This change introduces a persisted custom order that users can manage via drag and drop in Manage Stickers, and the same order is now used in Sticker Picker.

This feature has been requested by the community since 2021:
https://community.signalusers.org/t/ability-to-reorder-sticker-packs-desktop-ios/29124
and brings iOS in line with Android’s existing sticker-pack reordering behavior.

Scope note: this is a client-only iOS change with local persistence (KeyValueStore) and no protocol or backend changes.

### Behavior details:

- Reordered pack IDs are stored locally in KeyValueStore (installedStickerPackOrder).
- New installs are prepended to preserve current default behavior.
- Uninstalled packs are removed from saved order.
- If saved order is missing or incomplete, ordering falls back to dateCreated and appends missing packs by recency.

### Testing

- Verified users without saved order still see dateCreated ordering.
- Verified drag-and-drop reordering in Manage Stickers.
- Verified order persists after app restart.
- Verified Sticker Picker reflects the same reordered list.
- Verified new installs prepend and uninstall cleanup keeps remaining order valid.

### Demo
Attached demo showing drag-and-drop reorder and matching Sticker Picker order.
 

https://github.com/user-attachments/assets/fb98c287-ec17-4e46-a292-f38dbaf9a5e7

