### PR TITLE
Fix data race in ProfileFetcherImpl.FetchState.waiterContinuations

### DIFF
--- a/SignalServiceKit/Profiles/ProfileFetcher.swift
+++ b/SignalServiceKit/Profiles/ProfileFetcher.swift
@@ -94,8 +94,31 @@ public actor ProfileFetcherImpl: ProfileFetcher {
 
     private nonisolated let inProgressFetches = AtomicValue<[ServiceId: [FetchState]]>([:], lock: .init())
 
+    /// Tracks the state of an in-progress profile fetch, including any tasks waiting for it to complete.
+    /// This class is thread-safe: all access to `waiterContinuations` is synchronized via an internal lock.
     private class FetchState {
-        var waiterContinuations = [CancellableContinuation<Void>]()
+        private let lock = UnfairLock()
+        private var _waiterContinuations = [CancellableContinuation<Void>]()
+
+        /// Appends a waiter continuation in a thread-safe manner.
+        func appendWaiter(_ continuation: CancellableContinuation<Void>) {
+            lock.withLock {
+                _waiterContinuations.append(continuation)
+            }
+        }
+
+        /// Drains all waiter continuations and resumes them.
+        /// This atomically removes all waiters before resuming to avoid data races.
+        func drainAndResumeWaiters() {
+            let waiters = lock.withLock {
+                let copy = _waiterContinuations
+                _waiterContinuations.removeAll()
+                return copy
+            }
+            for waiter in waiters {
+                waiter.resume(with: .success(()))
+            }
+        }
     }
 
     private var rateLimitExpirationDate: MonotonicDate?
@@ -155,9 +178,8 @@ public actor ProfileFetcherImpl: ProfileFetcher {
         self.inProgressFetches.update {
             $0[serviceId, default: []].removeAll(where: { $0 === fetchState })
         }
-        for waiter in fetchState.waiterContinuations {
-            waiter.resume(with: .success(()))
-        }
+        // Resume all waiters in a thread-safe manner
+        fetchState.drainAndResumeWaiters()
     }
 
     public nonisolated func fetchProfileSyncImpl(
@@ -356,7 +378,7 @@ public actor ProfileFetcherImpl: ProfileFetcher {
                 // we want to wait for whichever takes the longest.
                 return $0[serviceId, default: []].map { fetchState in
                     let result = CancellableContinuation<Void>()
-                    fetchState.waiterContinuations.append(result)
+                    fetchState.appendWaiter(result)
                     return result
                 }
             }


### PR DESCRIPTION
# Data race in ProfileFetcherImpl.FetchState.waiterContinuations array

## Summary

There's a thread-safety issue in `ProfileFetcherImpl` where the `waiterContinuations` array inside `FetchState` can be concurrently modified and iterated, leading to undefined behavior.

## Location

`SignalServiceKit/Profiles/ProfileFetcher.swift`

## Root Cause

The `FetchState` class (line 96-98) contains a mutable Swift array that is accessed from multiple threads without synchronization:

```swift
private class FetchState {
    var waiterContinuations = [CancellableContinuation<Void>]()
}
```

While `inProgressFetches` is protected by an `AtomicValue`, the `FetchState` objects inside it are not thread-safe.

## Race Condition

**Thread A** in `waitForPendingFetches(for:)` (lines 351-367):
```swift
let cancellableContinuations = self.inProgressFetches.update {
    return $0[serviceId, default: []].map { fetchState in
        let result = CancellableContinuation<Void>()
        fetchState.waiterContinuations.append(result)  // WRITE operation
        return result
    }
}
```

**Thread B** in `finalizeFetchState(serviceId:fetchState:)` (lines 151-160):
```swift
private nonisolated func finalizeFetchState(serviceId: ServiceId, fetchState: FetchState) {
    self.inProgressFetches.update {
        $0[serviceId, default: []].removeAll(where: { $0 === fetchState })
    }
    // AtomicValue lock is released here ⬆️
    
    for waiter in fetchState.waiterContinuations {  // READ operation (iteration)
        waiter.resume(with: .success(()))
    }
}
```

The problem: After `finalizeFetchState` releases the atomic lock but before it finishes iterating, another thread can call `waitForPendingFetches` and mutate the same array.

## Potential Impact

1. **Memory corruption** - Swift arrays are copy-on-write but not thread-safe for concurrent mutation + iteration
2. **EXC_BAD_ACCESS crashes** - Memory being freed while still in use
3. **Dropped continuations** - Some waiters may never be resumed, causing async hangs
4. **Unpredictable behavior** - Iterator invalidation during mutation

## Reproduction Scenario

This is most likely to occur during high-concurrency profile fetching scenarios:
- Joining a large group chat (many profiles fetched simultaneously)
- Opening conversation list with many threads needing profile updates  
- Background sync after app launch
- Multiple calls to `waitForPendingFetches` while profile fetches are completing

## Suggested Fix

Make `FetchState` thread-safe by synchronizing access to `waiterContinuations`:

```swift
private class FetchState {
    private let lock = UnfairLock()
    private var _waiterContinuations = [CancellableContinuation<Void>]()
    
    func appendWaiter(_ continuation: CancellableContinuation<Void>) {
        lock.withLock {
            _waiterContinuations.append(continuation)
        }
    }
    
    func drainAndResumeWaiters() {
        let waiters = lock.withLock {
            let copy = _waiterContinuations
            _waiterContinuations.removeAll()
            return copy
        }
        for waiter in waiters {
            waiter.resume(with: .success(()))
        }
    }
}
```

Then update the call sites:

```swift
// In waitForPendingFetches:
fetchState.appendWaiter(result)

// In finalizeFetchState:
fetchState.drainAndResumeWaiters()
```

## Verification

This issue should be detectable by running the app with Thread Sanitizer (TSan) enabled during profile-heavy operations.

## Environment

- iOS Signal app
- Affects both main app and any extensions using `ProfileFetcher`
