### PR TITLE
Validate file paths in device transfer to prevent path traversal

### DIFF
--- a/Signal.xcodeproj/project.pbxproj
+++ b/Signal.xcodeproj/project.pbxproj
@@ -734,6 +734,7 @@
 		505C2ED42997015800C23FB2 /* LinkDeviceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 505C2ED32997015800C23FB2 /* LinkDeviceViewController.swift */; };
 		505C2ED629971D4E00C23FB2 /* DeviceLimitExceededError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 505C2ED529971D4E00C23FB2 /* DeviceLimitExceededError.swift */; };
 		505C2ED92997422D00C23FB2 /* SelfSignedIdentityTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 505C2ED82997422D00C23FB2 /* SelfSignedIdentityTest.swift */; };
+		6218A0022F00000000000001 /* DeviceTransferPathTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6218A0012F00000000000001 /* DeviceTransferPathTest.swift */; };
 		505CC1672F22BC7A00D311CD /* OutgoingPaymentActivationRequestMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 505CC1662F22BC7A00D311CD /* OutgoingPaymentActivationRequestMessage.swift */; };
 		505CC1692F22C2EC00D311CD /* OutgoingPaymentActivationRequestFinishedMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 505CC1682F22C2EC00D311CD /* OutgoingPaymentActivationRequestFinishedMessage.swift */; };
 		505F76332BC45C0700B1B51C /* BuildFlags+Generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 505F76322BC45C0700B1B51C /* BuildFlags+Generated.swift */; };
@@ -5000,6 +5001,7 @@
 		505C2ED32997015800C23FB2 /* LinkDeviceViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkDeviceViewController.swift; sourceTree = "<group>"; };
 		505C2ED529971D4E00C23FB2 /* DeviceLimitExceededError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceLimitExceededError.swift; sourceTree = "<group>"; };
 		505C2ED82997422D00C23FB2 /* SelfSignedIdentityTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelfSignedIdentityTest.swift; sourceTree = "<group>"; };
+		6218A0012F00000000000001 /* DeviceTransferPathTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceTransferPathTest.swift; sourceTree = "<group>"; };
 		505C2EDA29974D2000C23FB2 /* StorageServiceContactTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageServiceContactTest.swift; sourceTree = "<group>"; };
 		505CC1662F22BC7A00D311CD /* OutgoingPaymentActivationRequestMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutgoingPaymentActivationRequestMessage.swift; sourceTree = "<group>"; };
 		505CC1682F22C2EC00D311CD /* OutgoingPaymentActivationRequestFinishedMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutgoingPaymentActivationRequestFinishedMessage.swift; sourceTree = "<group>"; };
@@ -9767,6 +9769,7 @@
 		505C2ED72997421E00C23FB2 /* DeviceTransfer */ = {
 			isa = PBXGroup;
 			children = (
+				6218A0012F00000000000001 /* DeviceTransferPathTest.swift */,
 				505C2ED82997422D00C23FB2 /* SelfSignedIdentityTest.swift */,
 			);
 			path = DeviceTransfer;
@@ -18811,6 +18814,7 @@
 				F93999F628C81F2100E34899 /* DataMessagePaddingTests.swift in Sources */,
 				3494BBE026E66FC30079B11B /* DateUtilTest.swift in Sources */,
 				C17A54962D7B3D9E00E1D267 /* DeviceProvisioningURLTest.swift in Sources */,
+				6218A0022F00000000000001 /* DeviceTransferPathTest.swift in Sources */,
 				D92812E22FA95C1400667DCF /* DisplayableAccountEntropyPoolTest.swift in Sources */,
 				45E7A6A81E71CA7E00D44FB5 /* DisplayableTextFilterTest.swift in Sources */,
 				F90B7BC12912B90100F50A59 /* DonateViewControllerTest.swift in Sources */,

--- a/Signal/DeviceTransfer/DeviceTransferService+MultipeerDelegates.swift
+++ b/Signal/DeviceTransfer/DeviceTransferService+MultipeerDelegates.swift
@@ -316,12 +316,13 @@ extension DeviceTransferService: MCSessionDelegate {
                 }
 
                 do {
+                    let pendingFilePath = try DeviceTransferService.validatedPath(
+                        for: file.identifier,
+                        within: DeviceTransferService.pendingTransferFilesDirectory,
+                    )
                     try OWSFileSystem.moveFilePath(
                         localURL.path,
-                        toFilePath: URL(
-                            fileURLWithPath: file.identifier,
-                            relativeTo: DeviceTransferService.pendingTransferFilesDirectory,
-                        ).path,
+                        toFilePath: pendingFilePath,
                     )
                 } catch {
                     Logger.warn("Couldn't move file: \(error.shortDescription)")

--- a/Signal/DeviceTransfer/DeviceTransferService+Restore.swift
+++ b/Signal/DeviceTransfer/DeviceTransferService+Restore.swift
@@ -68,14 +68,17 @@ extension DeviceTransferService {
                 owsFailDebug("did not receive file \(file.identifier)")
                 return false
             }
-            guard
-                OWSFileSystem.fileOrFolderExists(
-                    atPath: URL(
-                        fileURLWithPath: file.identifier,
-                        relativeTo: DeviceTransferService.pendingTransferFilesDirectory,
-                    ).path,
+            let filePath: String
+            do {
+                filePath = try DeviceTransferService.sanitizedPath(
+                    for: file.identifier,
+                    within: DeviceTransferService.pendingTransferFilesDirectory,
                 )
-            else {
+            } catch {
+                owsFailDebug("Invalid file identifier in manifest")
+                return false
+            }
+            guard OWSFileSystem.fileOrFolderExists(atPath: filePath) else {
                 owsFailDebug("Missing file \(file.identifier)")
                 return false
             }
@@ -162,10 +165,16 @@ extension DeviceTransferService {
         }
 
         for file in manifest.files + [database.database, database.wal] {
-            let pendingFilePath = URL(
-                fileURLWithPath: file.identifier,
-                relativeTo: DeviceTransferService.pendingTransferFilesDirectory,
-            ).path
+            let pendingFilePath: String
+            do {
+                pendingFilePath = try DeviceTransferService.sanitizedPath(
+                    for: file.identifier,
+                    within: DeviceTransferService.pendingTransferFilesDirectory,
+                )
+            } catch {
+                owsFailDebug("Invalid file identifier in manifest")
+                return false
+            }
 
             // We could be receiving a database in any of the directory modes,
             // so we force the restore path to be the "primary" database since
@@ -177,10 +186,15 @@ extension DeviceTransferService {
             } else if DeviceTransferService.databaseWALIdentifier == file.identifier {
                 newFilePath = GRDBDatabaseStorageAdapter.databaseWalUrl(directoryMode: .primary).path
             } else {
-                newFilePath = URL(
-                    fileURLWithPath: file.relativePath,
-                    relativeTo: DeviceTransferService.appSharedDataDirectory,
-                ).path
+                do {
+                    newFilePath = try DeviceTransferService.sanitizedPath(
+                        for: file.relativePath,
+                        within: DeviceTransferService.appSharedDataDirectory,
+                    )
+                } catch {
+                    owsFailDebug("Invalid file relative path in manifest")
+                    return false
+                }
             }
 
             // If we're hot swapping the database, we move the database
@@ -444,6 +458,17 @@ extension DeviceTransferService {
         }
     }
 
+    /// Validates that a relative path, when resolved against a base directory,
+    /// stays within that directory. Prevents path traversal attacks via "../".
+    private static func sanitizedPath(for relativePath: String, within baseDirectory: URL) throws -> String {
+        let resolvedUrl = URL(fileURLWithPath: relativePath, relativeTo: baseDirectory).standardized
+        let resolvedBase = baseDirectory.standardized.path
+        guard resolvedUrl.path.hasPrefix(resolvedBase + "/") else {
+            throw OWSAssertionError("Received transfer file path that escapes its base directory")
+        }
+        return resolvedUrl.path
+    }
+
     private func moveManifestFiles(manifest: DeviceTransferProtoManifest?) throws {
         guard let manifest else {
             throw OWSAssertionError("No manifest available")
@@ -452,11 +477,11 @@ extension DeviceTransferService {
         let destDir = DeviceTransferService.appSharedDataDirectory
 
         try manifest.files.forEach { file in
-            let sourceUrl = URL(fileURLWithPath: file.identifier, relativeTo: sourceDir)
-            let destUrl = URL(fileURLWithPath: file.relativePath, relativeTo: destDir)
+            let sourcePath = try DeviceTransferService.sanitizedPath(for: file.identifier, within: sourceDir)
+            let destPath = try DeviceTransferService.sanitizedPath(for: file.relativePath, within: destDir)
 
             do {
-                try move(pendingFilePath: sourceUrl.path, to: destUrl.path)
+                try move(pendingFilePath: sourcePath, to: destPath)
             } catch CocoaError.fileWriteFileExists {
                 Logger.info("Skipping restoration of file that was already restored: \(file.identifier)")
             } catch CocoaError.fileNoSuchFile, CocoaError.fileReadNoSuchFile, POSIXError.ENOENT {

--- a/Signal/DeviceTransfer/DeviceTransferService+Restore.swift
+++ b/Signal/DeviceTransfer/DeviceTransferService+Restore.swift
@@ -70,7 +70,7 @@ extension DeviceTransferService {
             }
             let filePath: String
             do {
-                filePath = try DeviceTransferService.sanitizedPath(
+                filePath = try DeviceTransferService.validatedPath(
                     for: file.identifier,
                     within: DeviceTransferService.pendingTransferFilesDirectory,
                 )
@@ -167,7 +167,7 @@ extension DeviceTransferService {
         for file in manifest.files + [database.database, database.wal] {
             let pendingFilePath: String
             do {
-                pendingFilePath = try DeviceTransferService.sanitizedPath(
+                pendingFilePath = try DeviceTransferService.validatedPath(
                     for: file.identifier,
                     within: DeviceTransferService.pendingTransferFilesDirectory,
                 )
@@ -187,7 +187,7 @@ extension DeviceTransferService {
                 newFilePath = GRDBDatabaseStorageAdapter.databaseWalUrl(directoryMode: .primary).path
             } else {
                 do {
-                    newFilePath = try DeviceTransferService.sanitizedPath(
+                    newFilePath = try DeviceTransferService.validatedPath(
                         for: file.relativePath,
                         within: DeviceTransferService.appSharedDataDirectory,
                     )
@@ -458,17 +458,6 @@ extension DeviceTransferService {
         }
     }
 
-    /// Validates that a relative path, when resolved against a base directory,
-    /// stays within that directory. Prevents path traversal attacks via "../".
-    private static func sanitizedPath(for relativePath: String, within baseDirectory: URL) throws -> String {
-        let resolvedUrl = URL(fileURLWithPath: relativePath, relativeTo: baseDirectory).standardized
-        let resolvedBase = baseDirectory.standardized.path
-        guard resolvedUrl.path.hasPrefix(resolvedBase + "/") else {
-            throw OWSAssertionError("Received transfer file path that escapes its base directory")
-        }
-        return resolvedUrl.path
-    }
-
     private func moveManifestFiles(manifest: DeviceTransferProtoManifest?) throws {
         guard let manifest else {
             throw OWSAssertionError("No manifest available")
@@ -477,8 +466,8 @@ extension DeviceTransferService {
         let destDir = DeviceTransferService.appSharedDataDirectory
 
         try manifest.files.forEach { file in
-            let sourcePath = try DeviceTransferService.sanitizedPath(for: file.identifier, within: sourceDir)
-            let destPath = try DeviceTransferService.sanitizedPath(for: file.relativePath, within: destDir)
+            let sourcePath = try DeviceTransferService.validatedPath(for: file.identifier, within: sourceDir)
+            let destPath = try DeviceTransferService.validatedPath(for: file.relativePath, within: destDir)
 
             do {
                 try move(pendingFilePath: sourcePath, to: destPath)

--- a/Signal/DeviceTransfer/DeviceTransferService.swift
+++ b/Signal/DeviceTransfer/DeviceTransferService.swift
@@ -89,6 +89,35 @@ class DeviceTransferService: NSObject, DeviceTransferServiceProtocol {
     static let missingFileData = Data("Missing File".utf8)
     static let missingFileHash = Data(SHA256.hash(data: missingFileData))
 
+    static func validatedPath(for relativePath: String, within baseDirectory: URL) throws -> String {
+        guard !relativePath.isEmpty, !relativePath.hasPrefix("/") else {
+            throw OWSAssertionError("Received invalid transfer file path")
+        }
+
+        let resolvedBase = baseDirectory
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+        let resolvedUrl = URL(fileURLWithPath: relativePath, relativeTo: resolvedBase)
+            .standardizedFileURL
+
+        let basePathComponents = resolvedBase.pathComponents
+        guard
+            resolvedUrl.pathComponents.count > basePathComponents.count,
+            resolvedUrl.pathComponents.starts(with: basePathComponents)
+        else {
+            throw OWSAssertionError("Received transfer file path that escapes its base directory")
+        }
+
+        var currentUrl = resolvedBase
+        for pathComponent in resolvedUrl.pathComponents.dropFirst(basePathComponents.count) {
+            currentUrl.appendPathComponent(pathComponent)
+            if (try? currentUrl.resourceValues(forKeys: [.isSymbolicLinkKey]).isSymbolicLink) == true {
+                throw OWSAssertionError("Received transfer file path containing a symbolic link")
+            }
+        }
+        return resolvedUrl.path
+    }
+
     // This must also be updated in the info.plist
     private static let newDeviceServiceIdentifier = "sgnl-new-device"
 

--- a/Signal/test/util/DeviceTransfer/DeviceTransferPathTest.swift
+++ b/Signal/test/util/DeviceTransfer/DeviceTransferPathTest.swift
@@ -1,0 +1,83 @@
+//
+// Copyright 2026 Signal Messenger, LLC
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import XCTest
+
+@testable import Signal
+
+final class DeviceTransferPathTest: XCTestCase {
+    private var temporaryDirectory: URL!
+    private var baseDirectory: URL {
+        temporaryDirectory.appendingPathComponent("device-transfer", isDirectory: true)
+    }
+
+    override func setUpWithError() throws {
+        temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: baseDirectory,
+            withIntermediateDirectories: true,
+        )
+    }
+
+    override func tearDownWithError() throws {
+        try FileManager.default.removeItem(at: temporaryDirectory)
+        temporaryDirectory = nil
+    }
+
+    func testValidRelativePath() throws {
+        XCTAssertEqual(
+            try DeviceTransferService.validatedPath(
+                for: "Attachments/uuid/file.dat",
+                within: baseDirectory,
+            ),
+            baseDirectory
+                .appendingPathComponent("Attachments/uuid/file.dat")
+                .resolvingSymlinksInPath()
+                .path,
+        )
+    }
+
+    func testRejectsInvalidPaths() {
+        for path in ["", ".", "..", "../outside", "directory/../../outside", "/tmp/outside"] {
+            XCTAssertThrowsError(
+                try DeviceTransferService.validatedPath(for: path, within: baseDirectory),
+                "Expected path to be rejected: \(path)",
+            )
+        }
+    }
+
+    func testAllowsNormalizedPathWithinBaseDirectory() throws {
+        XCTAssertEqual(
+            try DeviceTransferService.validatedPath(
+                for: "Attachments/../file.dat",
+                within: baseDirectory,
+            ),
+            baseDirectory
+                .appendingPathComponent("file.dat")
+                .resolvingSymlinksInPath()
+                .path,
+        )
+    }
+
+    func testRejectsPathThroughSymlinkOutsideBaseDirectory() throws {
+        let outsideDirectory = temporaryDirectory.appendingPathComponent("outside", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: outsideDirectory,
+            withIntermediateDirectories: true,
+        )
+        try FileManager.default.createSymbolicLink(
+            at: baseDirectory.appendingPathComponent("link"),
+            withDestinationURL: outsideDirectory,
+        )
+
+        XCTAssertThrowsError(
+            try DeviceTransferService.validatedPath(
+                for: "link/file.dat",
+                within: baseDirectory,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [X] I have tested my contribution on these multiple real devices.

### Description

The device transfer restore flow uses `file.relativePath` and `file.identifier` from the received protobuf manifest to construct file paths. These values originate from an external device via MultipeerConnectivity and are not validated on the receiving side.

The **sender** already validates paths in `pathRelativeToAppSharedDirectory()` (checking for `..`, `.`, `~`), but the **receiver** did not apply the same validation. A crafted manifest with `../` in `relativePath` could cause files to be written outside the intended `appSharedDataDirectory`.

**Fix:** Adds a `sanitizedPath(for:within:)` helper that resolves the path via `URL.standardized` and verifies it stays within the base directory. Applied to all three affected code paths:
- `moveManifestFiles()` (modern restore)
- `restoreTransferredDataLegacy()` (legacy restore)
- `verifyTransferCompletedSuccessfully()` (verification)

Legitimate transfers are unaffected — valid relative paths like `Attachments/uuid/file.dat` pass the check.