### PR TITLE
Migrate the code of AppIconSettingsTableViewController.swift from a UIKit-based implementation to a SwiftUI-based one

### DIFF
--- a/Signal/src/ViewControllers/AppSettings/Appearance/AppIconSettingsTableViewController.swift
+++ b/Signal/src/ViewControllers/AppSettings/Appearance/AppIconSettingsTableViewController.swift
@@ -137,7 +137,6 @@ struct AppIconSettingsView: View {
     @State private var isAnimating = false
     @State private var iconSize = CGFloat(60)
 
-示
     private let customIcons: [[AppIcon]] = [
         [.default, .white, .color, .night],
         [.nightVariant, .chat, .bubbles, .yellow],


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [ ] I have tested my contribution on these devices:

- - - - - - - - - -

### Description
<!--

-->Most of the code in AppIconSettingsTableViewController.swift has been migrated from UIKit to SwiftUI. In this implementation, it was not a complete migration from UIKit; instead, SwiftUI is used for the majority of the code, while some parts still use UIKit, and the development also emphasizes compatibility with UIKit.

Regarding stability and compile errors, the implementation has been thoroughly reviewed using two AI models: Gemini 3.1 Pro Thinking and Claude 4.6 Sonnet Thinking (this does not mean that “vibe coding” was done; the AI was only asked to review, and the AI did not directly edit the files).

By migrating from UIKit to SwiftUI, it becomes possible to use features such as Xcode’s live preview, reduce bugs due to a smaller amount of code, and optimize memory management. In addition, since Apple’s latest frameworks increasingly prioritize SwiftUI, I believe that a gradual migration to SwiftUI is necessary.

I intend to fully support the migration of Signal’s code and would like to migrate more code to SwiftUI in the future. If there are any differences in perspective with the team, please let me know. I will stop immediately.

This text was translated from Japanese into English by ChatGPT.
