### PR TITLE
Fix accessibility issues in Get Started section

### DIFF
--- a/Signal/src/ViewControllers/GetStartedBannerViewController.swift
+++ b/Signal/src/ViewControllers/GetStartedBannerViewController.swift
@@ -149,6 +149,11 @@ private class GetStartedCardCellContentView: UIView, UIContentView {
 
     private static let cornerRadius: CGFloat = if #available(iOS 26, *) { 26 } else { 12 }
 
+    private static let closeAccessibilityLabel = OWSLocalizedString(
+        "GET_STARTED_CARD_CLOSE_A11YLABEL",
+        comment: "Accessibility label for the close button in each Get Started card.",
+    )
+
     init(configuration: GetStartedCardCellContentConfiguration) {
         self.configuration = configuration
 
@@ -212,6 +217,13 @@ private class GetStartedCardCellContentView: UIView, UIContentView {
                 label.font = .dynamicTypeFootnote.semibold()
             }
         }
+
+        isAccessibilityElement = true
+        accessibilityTraits.insert(.button)
+        accessibilityCustomActions = [UIAccessibilityCustomAction(name: Self.closeAccessibilityLabel, actionHandler: { [weak self] _ in
+            self?.closeButtonTapped()
+            return true
+        })]
     }
 
     required init?(coder: NSCoder) {
@@ -278,10 +290,13 @@ private class GetStartedCardCellContentView: UIView, UIContentView {
         } else {
             updateBackgroundColor(using: config.card)
         }
+
+        accessibilityLabel = config.card.title
     }
 
     private func closeButtonTapped() {
         closeAction?()
+        UIAccessibility.post(notification: .screenChanged, argument: nil)
     }
 }
 
@@ -298,6 +313,7 @@ class GetStartedBannerViewController: OWSViewController {
             "GET_STARTED_BANNER_TITLE",
             comment: "Title for the 'Get Started' banner",
         )
+        label.accessibilityTraits.insert(.header)
         return label
     }()
 

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -3655,6 +3655,9 @@
 /* 'Get Started' button directing users to create a group */
 "GET_STARTED_CARD_NEW_GROUP" = "New Group";
 
+/* Accessibility label for the close button in each Get Started card. */
+"GET_STARTED_CARD_CLOSE_A11YLABEL" = "Remove suggestion";
+
 /* Error displayed when there is a failure fetching a GIF from the remote service. */
 "GIF_PICKER_ERROR_FETCH_FAILURE" = "Failed to fetch the requested GIF. Please verify you are online.";
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] My commits are rebased on the latest main branch
- [X] My commits are in nice logical chunks
- [ ] My contribution is fully baked and is ready to be merged as is
- [X] I have tested my contribution on these devices:
 * iPhone 17 Pro Simulator, iOS 26.0 using Accessibility Inspector. I also verified my changes using Reveal App.

- - - - - - - - - -

### Description
This change makes some minor accessibility improvements to the "Get Started" section of the home screen when a user logs into Signal for the first time.
* It adds a `.header` trait to the "Get Started" label so that it's clear that it's a section.
* It consolidates each Get Started card into a single accessibility element and makes Close into a custom action.

#### Before
<img width="450" alt="Before" src="https://github.com/user-attachments/assets/22031214-b1c2-4537-9c2c-08153450ebff" />

#### After
<img width="450" alt="After" src="https://github.com/user-attachments/assets/6019a916-68bf-4d40-96ed-45ae52dca4b5" />

#### Screen recording
https://github.com/user-attachments/assets/2bb5bd2e-8db4-4e53-a9d8-bd4390c789eb