### PR TITLE
Fix accessibility of attachment keyboard buttons

### DIFF
--- a/Signal/src/ViewControllers/Attachment Keyboard/AttachmentFormatPickerView.swift
+++ b/Signal/src/ViewControllers/Attachment Keyboard/AttachmentFormatPickerView.swift
@@ -316,6 +316,9 @@ class AttachmentFormatPickerView: UIView {
             textLabel.autoPinEdges(toSuperviewEdgesExcludingEdge: .top)
 
             configure()
+
+            isAccessibilityElement = true
+            accessibilityTraits.insert(.button)
         }
 
         @available(*, unavailable, message: "Unimplemented")
@@ -354,6 +357,7 @@ class AttachmentFormatPickerView: UIView {
             textLabel.text = text
             button.configuration?.image = UIImage(imageLiteralResourceName: imageName)
             accessibilityIdentifier = UIView.accessibilityIdentifier(in: self, name: "format-\(attachmentType.rawValue)")
+            accessibilityLabel = text
         }
     }
 }


### PR DESCRIPTION
### Contributor checklist
- [X] My commits are rebased on the latest main branch
- [X] My commits are in nice logical chunks
- [X] My contribution is fully baked and is ready to be merged as is
- [X] I have tested my contribution on these devices:
 * iPhone 17 Pro Simulator, iOS 26.0 using Accessibility Inspector. I also verified my changes using Reveal App.

- - - - - - - - - -

### Description
This change fixes the accessibility of the buttons in the attachment keyboard by combining the icon and the label into a single accessibility element.

### Before
<img width="450" alt="Before" src="https://github.com/user-attachments/assets/79915525-edd9-41e5-b01e-2c804b6af0d4" />

### After
<img width="450" alt="After" src="https://github.com/user-attachments/assets/653c1f35-cbcd-4fab-aa15-4bd7badcb186" />