### PR TITLE
Fixed an issue where the message field was scrollable even when no text was entered

### DIFF
--- a/Signal/ConversationView/ConversationInputTextView.swift
+++ b/Signal/ConversationView/ConversationInputTextView.swift
@@ -25,6 +25,7 @@ class ConversationInputTextView: BodyRangesTextView {
 
     private lazy var placeholderView = UILabel()
     private var placeholderConstraints: [NSLayoutConstraint]?
+    private static let scrollThreshold: CGFloat = 1
 
     weak var inputTextViewDelegate: ConversationInputTextViewDelegate?
     weak var textViewToolbarDelegate: ConversationTextViewToolbarDelegate?
@@ -44,6 +45,7 @@ class ConversationInputTextView: BodyRangesTextView {
         scrollIndicatorInsets = UIEdgeInsets(top: 4, leading: 4, bottom: 4, trailing: 4)
 
         isScrollEnabled = true
+        alwaysBounceVertical = true
         scrollsToTop = false
         isUserInteractionEnabled = true
 
@@ -126,21 +128,57 @@ class ConversationInputTextView: BodyRangesTextView {
     }
 
     override var font: UIFont? {
-        didSet { placeholderView.font = font }
+        didSet {
+            placeholderView.font = font
+            updateVerticalScrollingState()
+        }
     }
 
     override var contentInset: UIEdgeInsets {
-        didSet { ensurePlaceholderConstraints() }
+        didSet {
+            ensurePlaceholderConstraints()
+            updateVerticalScrollingState()
+        }
     }
 
     override var textContainerInset: UIEdgeInsets {
-        didSet { ensurePlaceholderConstraints() }
+        didSet {
+            ensurePlaceholderConstraints()
+            updateVerticalScrollingState()
+        }
     }
 
     override func setMessageBody(_ messageBody: MessageBody?, txProvider: ((DBReadTransaction) -> Void) -> Void) {
         super.setMessageBody(messageBody, txProvider: txProvider)
         updatePlaceholderVisibility()
         updateTextContainerInset()
+        updateVerticalScrollingState()
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        updateVerticalScrollingState()
+    }
+
+    private func updateVerticalScrollingState() {
+       guard bounds.width > 0, bounds.height > 0 else { return }
+
+       let fittingSize = sizeThatFits(CGSize(width: bounds.width, height: .greatestFiniteMagnitude))
+       let needsVerticalScroll = fittingSize.height - bounds.height > Self.scrollThreshold
+
+       if isScrollEnabled != needsVerticalScroll {
+            isScrollEnabled = needsVerticalScroll
+            alwaysBounceVertical = needsVerticalScroll
+       }
+
+       normalizeContentOffsetIfNeeded()
+    }
+
+    private func normalizeContentOffsetIfNeeded() {
+        let targetOffset = CGPoint(x: -adjustedContentInset.left, y: -adjustedContentInset.top)
+        guard contentOffset != targetOffset else { return }
+        setContentOffset(targetOffset, animated: false)
     }
 
     var pasteboardHasPossibleAttachment: Bool {
@@ -217,6 +255,7 @@ class ConversationInputTextView: BodyRangesTextView {
 
         inputTextViewDelegate?.textViewDidChange(self)
         textViewToolbarDelegate?.textViewDidChange(self)
+        updateVerticalScrollingState()
     }
 
     override func textViewDidChangeSelection(_ textView: UITextView) {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [ x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ x] My commits are rebased on the latest main branch
- [x ] My commits are in nice logical chunks
- [ x] My contribution is fully baked and is ready to be merged as is
- [  ] I have tested my contribution on these devices:

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

**Based on GitHub Issue 6221 and real-device testing with Signal app version 8.3, we have fixed an issue where the message field was scrollable even when no text had been entered**. 
The issue is now fixed; please see Issue 6221 for details on the bug.

[https://github.com/signalapp/Signal-iOS/issues/6221](url)

Translated from Japanese to English by Google Translate
