### PR TITLE
Add Picture-in-Picture support for video calls

### DIFF
--- a/Signal.xcodeproj/project.pbxproj
+++ b/Signal.xcodeproj/project.pbxproj
@@ -1733,6 +1733,7 @@
 		A163E8AB16F3F6AA0094D68B /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A163E8AA16F3F6A90094D68B /* Security.framework */; };
 		A1A018521805C5E800A052A6 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A11CD70C17FA230600A2D1B1 /* QuartzCore.framework */; };
 		A1A018531805C60D00A052A6 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D221A091169C9E5E00537ABF /* CoreGraphics.framework */; };
+		A2F1E0D9C8B7A6F5E4D3C2B1 /* CallPictureInPictureControllerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3E4F5A6B7C8D9E0F1A2 /* CallPictureInPictureControllerTest.swift */; };
 		A5E7C675248C5443007C949A /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = A5E7C673248C5442007C949A /* InfoPlist.strings */; };
 		B60EDE041A05A01700D73516 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B60EDE031A05A01700D73516 /* AudioToolbox.framework */; };
 		B66DBF4A19D5BBC8006EA940 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B66DBF4919D5BBC8006EA940 /* Images.xcassets */; };
@@ -3496,6 +3497,7 @@
 		F0B872B8269D079B00D26481 /* ContextMenuConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0B872B7269D079B00D26481 /* ContextMenuConfiguration.swift */; };
 		F0EE4DB626A7AC18001DE4ED /* ContextMenuReactionBarAccessory.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0EE4DB526A7AC18001DE4ED /* ContextMenuReactionBarAccessory.swift */; };
 		F0FB6B20269E625A00AC2A41 /* ContextMenuController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0FB6B1F269E625A00AC2A41 /* ContextMenuController.swift */; };
+		F2E1D0C9B8A7F6E5D4C3B2A1 /* CallPictureInPictureController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6A7B8C9D0E1F2 /* CallPictureInPictureController.swift */; };
 		F5C80FA22BE3F29F0028F76D /* RTCIceServerFetcherTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5C80FA12BE3F29F0028F76D /* RTCIceServerFetcherTest.swift */; };
 		F900F2DD27F25AB400431E09 /* DonationReceiptViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F900F2DC27F25AB300431E09 /* DonationReceiptViewController.swift */; };
 		F903C29B28EC7AE60035B42B /* RegistrationIdGeneratorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F903C29A28EC7AE60035B42B /* RegistrationIdGeneratorTest.swift */; };
@@ -5975,12 +5977,14 @@
 		954AEE681DF33D32002E5410 /* ContactsPickerTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContactsPickerTest.swift; sourceTree = "<group>"; };
 		A11CD70C17FA230600A2D1B1 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		A163E8AA16F3F6A90094D68B /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
+		A1B2C3D4E5F6A7B8C9D0E1F2 /* CallPictureInPictureController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallPictureInPictureController.swift; sourceTree = "<group>"; };
 		A1C32D4D17A0652C000A904E /* AddressBook.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AddressBook.framework; path = System/Library/Frameworks/AddressBook.framework; sourceTree = SDKROOT; };
 		A1C32D4F17A06537000A904E /* AddressBookUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AddressBookUI.framework; path = System/Library/Frameworks/AddressBookUI.framework; sourceTree = SDKROOT; };
 		A1FDCBEE16DAA6C300868894 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
 		A33E43CA8A572CA70089C4CC /* Pods-SignalServiceKit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SignalServiceKit.debug.xcconfig"; path = "Target Support Files/Pods-SignalServiceKit/Pods-SignalServiceKit.debug.xcconfig"; sourceTree = "<group>"; };
 		A566C0C0B69138202C0367E6 /* Pods-Signal.app store release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Signal.app store release.xcconfig"; path = "Target Support Files/Pods-Signal/Pods-Signal.app store release.xcconfig"; sourceTree = "<group>"; };
 		A5E7C674248C5442007C949A /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = translations/en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		B1C2D3E4F5A6B7C8D9E0F1A2 /* CallPictureInPictureControllerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallPictureInPictureControllerTest.swift; sourceTree = "<group>"; };
 		B3F39202F831935AAE1C5F54 /* Pods_SignalUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SignalUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B60EDE031A05A01700D73516 /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
 		B634CBB31AB10D2300C49B99 /* hr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hr; path = translations/hr.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -8414,6 +8418,7 @@
 				D202868416DBE108009068E9 /* AVFoundation.framework in Frameworks */,
 				D202868116DBE0E7009068E9 /* CFNetwork.framework in Frameworks */,
 				A1A018531805C60D00A052A6 /* CoreGraphics.framework in Frameworks */,
+		A2F1E0D9C8B7A6F5E4D3C2B1 /* CallPictureInPictureControllerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3E4F5A6B7C8D9E0F1A2 /* CallPictureInPictureControllerTest.swift */; };
 				D202868316DBE0FC009068E9 /* CoreTelephony.framework in Frameworks */,
 				D221A0AE169C9E5F00537ABF /* Foundation.framework in Frameworks */,
 				A10FDF79184FB4BB007FF963 /* MediaPlayer.framework in Frameworks */,
@@ -9728,6 +9733,7 @@
 			children = (
 				E1D827D82BDC1F6B0022C1AF /* ReactionBurstManagerTests.swift */,
 				E16B440D2BBF242C00D2583E /* ReactionsModelTest.swift */,
+				B1C2D3E4F5A6B7C8D9E0F1A2 /* CallPictureInPictureControllerTest.swift */,
 				F5C80FA12BE3F29F0028F76D /* RTCIceServerFetcherTest.swift */,
 			);
 			path = Calls;
@@ -14052,6 +14058,7 @@
 				D9E43BBD2CC194140001536E /* ReactionsSink.swift */,
 				55B7535F2D97303A00CCC91C /* RemoteMuteToast.swift */,
 				D9E43BBE2CC194140001536E /* RemoteVideoView.swift */,
+				A1B2C3D4E5F6A7B8C9D0E1F2 /* CallPictureInPictureController.swift */,
 				D9E43BBF2CC194140001536E /* ReturnToCallViewController.swift */,
 				D9E43BC02CC194140001536E /* SimulatorCallUIAdaptee.swift */,
 				D9E43BC12CC194140001536E /* SupplementalCallControlsForFullscreenLocalMember.swift */,
@@ -18213,6 +18220,7 @@
 				D994C7D92C486E54009ECEDA /* ContextMenuButton.swift in Sources */,
 				F0B872B8269D079B00D26481 /* ContextMenuConfiguration.swift in Sources */,
 				F0FB6B20269E625A00AC2A41 /* ContextMenuController.swift in Sources */,
+		F2E1D0C9B8A7F6E5D4C3B2A1 /* CallPictureInPictureController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6A7B8C9D0E1F2 /* CallPictureInPictureController.swift */; };
 				F0B872B6269CF6D900D26481 /* ContextMenuInteraction.swift in Sources */,
 				F0EE4DB626A7AC18001DE4ED /* ContextMenuReactionBarAccessory.swift in Sources */,
 				B94E922D2E381478007BA81B /* ContextualActionBuilder.swift in Sources */,
@@ -18683,6 +18691,7 @@
 				348433DF243CA94600C7F64A /* ReplaceAdminViewController.swift in Sources */,
 				F952C0A629C8DA5E00D93766 /* RequestAccountDataReportViewController.swift in Sources */,
 				50BD86AF2A3CFF89005B6AC1 /* ResendMessagePromptBuilder.swift in Sources */,
+				F2E1D0C9B8A7F6E5D4C3B2A1 /* CallPictureInPictureController.swift in Sources */,
 				D9E43C0E2CC194140001536E /* ReturnToCallViewController.swift in Sources */,
 				348EE28F25B897BF00814FC2 /* ReusableMediaView.swift in Sources */,
 				66A22C0928A18D49007CD4F5 /* RingerSwitch.swift in Sources */,
@@ -18859,6 +18868,7 @@
 				E16B440E2BBF242C00D2583E /* ReactionsModelTest.swift in Sources */,
 				661278082996BA8900A1D5A1 /* RegistrationCoordinatorTest.swift in Sources */,
 				6612780D2996BD0300A1D5A1 /* RegistrationCoordinatorTestShims.swift in Sources */,
+				A2F1E0D9C8B7A6F5E4D3C2B1 /* CallPictureInPictureControllerTest.swift in Sources */,
 				F5C80FA22BE3F29F0028F76D /* RTCIceServerFetcherTest.swift in Sources */,
 				F963164B291AE06C00218FB7 /* ScrubbingLogFormatterTest.swift in Sources */,
 				505C2ED92997422D00C23FB2 /* SelfSignedIdentityTest.swift in Sources */,

--- a/Signal/Calls/CallService.swift
+++ b/Signal/Calls/CallService.swift
@@ -500,6 +500,11 @@ final class CallService: CallServiceStateObserver, CallServiceStateDelegate {
 
     // MARK: - Video
 
+    /// Whether system Picture-in-Picture is currently active for the call.
+    /// When true, the local video capture continues running even while the
+    /// app is backgrounded so the remote party still sees our video.
+    var isPictureInPictureActive: Bool = false
+
     var shouldHaveLocalVideoTrack: Bool {
         guard let call = self.callServiceState.currentCall else {
             return false
@@ -509,7 +514,12 @@ final class CallService: CallServiceStateObserver, CallServiceStateDelegate {
         // support or emulation (http://goo.gl/rHAnC1) so don't bother
         // trying to open a local stream.
         guard !Platform.isSimulator else { return false }
-        guard UIApplication.shared.applicationState != .background else { return false }
+
+        // When PiP is active, keep the local video track alive even in
+        // the background so the remote party continues to receive our video.
+        if !isPictureInPictureActive {
+            guard UIApplication.shared.applicationState != .background else { return false }
+        }
 
         switch call.mode {
         case .individual(let individualCall):

--- a/Signal/Calls/UserInterface/CallPictureInPictureController.swift
+++ b/Signal/Calls/UserInterface/CallPictureInPictureController.swift
@@ -1,0 +1,504 @@
+//
+// Copyright 2024 Signal Messenger, LLC
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import AVKit
+@preconcurrency import AVFoundation
+import CoreMotion
+import SignalServiceKit
+import UIKit
+import WebRTC
+
+@preconcurrency @MainActor
+class CallPictureInPictureController: NSObject {
+
+    private var pipController: AVPictureInPictureController?
+    private var pipVideoCallViewController: AVPictureInPictureVideoCallViewController?
+
+    private var sampleBufferView: SampleBufferDisplayView?
+    private var frameRenderer: PiPFrameRenderer?
+    private weak var currentRemoteVideoTrack: RTCVideoTrack?
+
+    private var localSampleBufferView: SampleBufferDisplayView?
+    private var localCaptureOutput: AVCaptureVideoDataOutput?
+    private var localCaptureDelegate: LocalCaptureOutputDelegate?
+    private weak var attachedCaptureSession: AVCaptureSession?
+    private var motionManager: CMMotionManager?
+
+    private(set) var isPictureInPictureActive: Bool = false
+    var onRestoreUserInterface: (() -> Void)?
+    var onPictureInPictureDidStop: (() -> Void)?
+    private weak var sourceView: UIView?
+
+    // MARK: - Configuration
+
+    func configure(sourceView: UIView) {
+        guard AVPictureInPictureController.isPictureInPictureSupported() else {
+            Logger.warn("PiP is not supported on this device.")
+            return
+        }
+
+        pipController = nil
+        pipVideoCallViewController = nil
+        self.sourceView = sourceView
+
+        let callVC = AVPictureInPictureVideoCallViewController()
+        callVC.preferredContentSize = CGSize(width: 1080, height: 1920)
+
+        // Using layerClass = AVSampleBufferDisplayLayer makes the layer the
+        // view's backing layer. A standalone layer added via addSublayer does
+        // NOT render in the out-of-process PiP window.
+        let sbView = SampleBufferDisplayView()
+        sbView.sampleBufferLayer.videoGravity = .resizeAspect
+        callVC.view.addSubview(sbView)
+        sbView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            sbView.leadingAnchor.constraint(equalTo: callVC.view.leadingAnchor),
+            sbView.trailingAnchor.constraint(equalTo: callVC.view.trailingAnchor),
+            sbView.topAnchor.constraint(equalTo: callVC.view.topAnchor),
+            sbView.bottomAnchor.constraint(equalTo: callVC.view.bottomAnchor),
+        ])
+        self.sampleBufferView = sbView
+
+        let localView = SampleBufferDisplayView()
+        localView.sampleBufferLayer.videoGravity = .resizeAspectFill
+        localView.layer.cornerRadius = 6
+        localView.clipsToBounds = true
+        localView.layer.borderWidth = 1
+        localView.layer.borderColor = UIColor.white.withAlphaComponent(0.5).cgColor
+        callVC.view.addSubview(localView)
+        localView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            localView.widthAnchor.constraint(equalTo: callVC.view.widthAnchor, multiplier: 0.28),
+            localView.heightAnchor.constraint(equalTo: localView.widthAnchor, multiplier: 16.0 / 9.0),
+            localView.trailingAnchor.constraint(equalTo: callVC.view.trailingAnchor, constant: -6),
+            localView.bottomAnchor.constraint(equalTo: callVC.view.bottomAnchor, constant: -6),
+        ])
+        self.localSampleBufferView = localView
+        self.pipVideoCallViewController = callVC
+
+        let pipContentSource = AVPictureInPictureController.ContentSource(
+            activeVideoCallSourceView: sourceView,
+            contentViewController: callVC
+        )
+
+        let controller = AVPictureInPictureController(contentSource: pipContentSource)
+        controller.delegate = self
+        controller.canStartPictureInPictureAutomaticallyFromInline = true
+        self.pipController = controller
+
+        let renderer = PiPFrameRenderer(sampleBufferLayer: sbView.sampleBufferLayer)
+        renderer.onVideoSizeChanged = { [weak callVC] size in
+            callVC?.preferredContentSize = size
+        }
+        frameRenderer = renderer
+    }
+
+    // MARK: - Local Video
+
+    func attachLocalCaptureSession(_ session: AVCaptureSession) {
+        detachLocalCaptureSession()
+        guard let localLayer = localSampleBufferView?.sampleBufferLayer else { return }
+
+        let output = AVCaptureVideoDataOutput()
+        output.alwaysDiscardsLateVideoFrames = true
+        output.videoSettings = [
+            kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA
+        ]
+        let delegate = LocalCaptureOutputDelegate(sampleBufferLayer: localLayer)
+        output.setSampleBufferDelegate(delegate, queue: DispatchQueue(label: "org.signal.pip.localvideo"))
+
+        session.beginConfiguration()
+        if session.canAddOutput(output) {
+            session.addOutput(output)
+            self.localCaptureOutput = output
+            self.localCaptureDelegate = delegate
+            self.attachedCaptureSession = session
+        }
+        session.commitConfiguration()
+
+        // CMMotionManager tracks orientation via accelerometer — works on
+        // background queues and while the app is backgrounded during PiP.
+        // Same threshold-based approach used in CameraCaptureSession.swift.
+        let manager = CMMotionManager()
+        manager.accelerometerUpdateInterval = 0.2
+        manager.startAccelerometerUpdates(to: OperationQueue()) { [weak delegate] data, _ in
+            guard let accel = data?.acceleration, let delegate else { return }
+            let orientation: CGImagePropertyOrientation
+            if accel.x >= 0.75 {
+                orientation = .upMirrored
+            } else if accel.x <= -0.75 {
+                orientation = .downMirrored
+            } else if accel.y <= -0.75 {
+                orientation = .leftMirrored
+            } else if accel.y >= 0.75 {
+                orientation = .rightMirrored
+            } else {
+                return
+            }
+            delegate.currentOrientation = orientation
+        }
+        self.motionManager = manager
+    }
+
+    private func detachLocalCaptureSession() {
+        if let output = localCaptureOutput, let session = attachedCaptureSession {
+            session.beginConfiguration()
+            session.removeOutput(output)
+            session.commitConfiguration()
+        }
+        motionManager?.stopAccelerometerUpdates()
+        motionManager = nil
+        localCaptureOutput = nil
+        localCaptureDelegate = nil
+        attachedCaptureSession = nil
+    }
+
+    // MARK: - Camera Multitasking
+
+    func enableMultitaskingCameraAccess(for captureSession: AVCaptureSession) {
+        if #available(iOS 16.0, *) {
+            if captureSession.isMultitaskingCameraAccessSupported {
+                captureSession.isMultitaskingCameraAccessEnabled = true
+            }
+        }
+    }
+
+    // MARK: - Video Track Management
+
+    func attachRemoteVideoTrack(_ track: RTCVideoTrack?) {
+        if let oldTrack = currentRemoteVideoTrack, let renderer = frameRenderer {
+            oldTrack.remove(renderer)
+        }
+        currentRemoteVideoTrack = track
+
+        if let track = track, let renderer = frameRenderer {
+            track.add(renderer)
+        }
+    }
+
+    // MARK: - PiP Lifecycle
+
+    func startPictureInPicture() {
+        guard let pipController = pipController else { return }
+        guard !pipController.isPictureInPictureActive else { return }
+        pipController.startPictureInPicture()
+    }
+
+    func stopPictureInPicture() {
+        pipController?.stopPictureInPicture()
+    }
+
+    func tearDown() {
+        stopPictureInPicture()
+        attachRemoteVideoTrack(nil)
+        detachLocalCaptureSession()
+        frameRenderer = nil
+        sampleBufferView = nil
+        localSampleBufferView = nil
+        pipController = nil
+        pipVideoCallViewController = nil
+    }
+}
+
+// MARK: - AVPictureInPictureControllerDelegate
+
+extension CallPictureInPictureController: AVPictureInPictureControllerDelegate {
+
+    nonisolated func pictureInPictureControllerWillStartPictureInPicture(
+        _ pictureInPictureController: AVPictureInPictureController
+    ) {
+        MainActor.assumeIsolated {
+            self.isPictureInPictureActive = true
+            AppEnvironment.shared.callService?.isPictureInPictureActive = true
+            AppEnvironment.shared.callService?.updateIsVideoEnabled()
+            UIDevice.current.beginGeneratingDeviceOrientationNotifications()
+        }
+    }
+
+    nonisolated func pictureInPictureControllerDidStartPictureInPicture(
+        _ pictureInPictureController: AVPictureInPictureController
+    ) {
+        MainActor.assumeIsolated {
+            Logger.info("PiP did start")
+        }
+    }
+
+    nonisolated func pictureInPictureControllerWillStopPictureInPicture(
+        _ pictureInPictureController: AVPictureInPictureController
+    ) {}
+
+    nonisolated func pictureInPictureControllerDidStopPictureInPicture(
+        _ pictureInPictureController: AVPictureInPictureController
+    ) {
+        MainActor.assumeIsolated {
+            self.isPictureInPictureActive = false
+            UIDevice.current.endGeneratingDeviceOrientationNotifications()
+            self.onPictureInPictureDidStop?()
+        }
+    }
+
+    nonisolated func pictureInPictureController(
+        _ pictureInPictureController: AVPictureInPictureController,
+        restoreUserInterfaceForPictureInPictureStopWithCompletionHandler completionHandler: @escaping (Bool) -> Void
+    ) {
+        MainActor.assumeIsolated {
+            self.onRestoreUserInterface?()
+            completionHandler(true)
+        }
+    }
+
+    nonisolated func pictureInPictureController(
+        _ pictureInPictureController: AVPictureInPictureController,
+        failedToStartPictureInPictureWithError error: Error
+    ) {
+        MainActor.assumeIsolated {
+            Logger.error("PiP failed to start: \(error)")
+            self.isPictureInPictureActive = false
+            AppEnvironment.shared.callService?.isPictureInPictureActive = false
+            AppEnvironment.shared.callService?.updateIsVideoEnabled()
+        }
+    }
+}
+
+// MARK: - SampleBufferDisplayView
+
+/// A UIView whose backing layer IS an AVSampleBufferDisplayLayer.
+/// Using `layerClass` is required for the layer to render in the
+/// out-of-process PiP window.
+private class SampleBufferDisplayView: UIView {
+    override class var layerClass: AnyClass { AVSampleBufferDisplayLayer.self }
+
+    var sampleBufferLayer: AVSampleBufferDisplayLayer {
+        layer as! AVSampleBufferDisplayLayer
+    }
+}
+
+// MARK: - PiPFrameRenderer
+
+private class PiPFrameRenderer: NSObject, RTCVideoRenderer {
+
+    private let sampleBufferLayer: AVSampleBufferDisplayLayer
+    private var frameCounter: Int = 0
+    private let ciContext = CIContext(options: [.useSoftwareRenderer: false])
+
+    var onVideoSizeChanged: ((CGSize) -> Void)?
+    private var lastOutputSize: CGSize = .zero
+
+    init(sampleBufferLayer: AVSampleBufferDisplayLayer) {
+        self.sampleBufferLayer = sampleBufferLayer
+        super.init()
+    }
+
+    // Intentionally empty — PiP window size is managed via preferredContentSize.
+    func setSize(_ size: CGSize) {}
+
+    func renderFrame(_ frame: RTCVideoFrame?) {
+        guard let frame = frame else { return }
+        guard var pixelBuffer = extractPixelBuffer(from: frame) else { return }
+
+        let orientation = Self.ciImageOrientation(for: frame.rotation)
+        if orientation != .up {
+            if let rotated = rotatePixelBuffer(pixelBuffer, orientation: orientation) {
+                pixelBuffer = rotated
+            }
+        }
+
+        frameCounter += 1
+
+        guard let sampleBuffer = Self.createImmediateDisplaySampleBuffer(
+            from: pixelBuffer,
+            presentationTime: CMTime(value: Int64(frameCounter), timescale: 30)
+        ) else {
+            return
+        }
+
+        let outputSize = CGSize(width: CVPixelBufferGetWidth(pixelBuffer),
+                                height: CVPixelBufferGetHeight(pixelBuffer))
+        let sizeChanged = outputSize != lastOutputSize && outputSize.width > 0 && outputSize.height > 0
+        if sizeChanged { lastOutputSize = outputSize }
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            if sizeChanged { self.onVideoSizeChanged?(outputSize) }
+            Self.safeEnqueue(sampleBuffer, on: self.sampleBufferLayer)
+        }
+    }
+
+    // MARK: - Rotation
+
+    private static func ciImageOrientation(for rotation: RTCVideoRotation) -> CGImagePropertyOrientation {
+        switch rotation {
+        case ._0:   return .up
+        case ._90:  return .right
+        case ._180: return .down
+        case ._270: return .left
+        @unknown default: return .up
+        }
+    }
+
+    private func rotatePixelBuffer(_ source: CVPixelBuffer, orientation: CGImagePropertyOrientation) -> CVPixelBuffer? {
+        let ciImage = CIImage(cvPixelBuffer: source).oriented(orientation)
+        let width = Int(ciImage.extent.width)
+        let height = Int(ciImage.extent.height)
+        guard let output = Self.createIOSurfacePixelBuffer(width: width, height: height, format: kCVPixelFormatType_32BGRA) else { return nil }
+        ciContext.render(ciImage, to: output)
+        return output
+    }
+
+    // MARK: - Pixel Buffer Extraction
+
+    private func extractPixelBuffer(from frame: RTCVideoFrame) -> CVPixelBuffer? {
+        if let cvPixelBufferWrapper = frame.buffer as? RTCCVPixelBuffer {
+            return ensureIOSurfaceBacked(cvPixelBufferWrapper.pixelBuffer)
+        }
+        return convertI420ToNV12(frame.buffer.toI420())
+    }
+
+    /// AVSampleBufferDisplayLayer silently drops non-IOSurface-backed buffers.
+    private func ensureIOSurfaceBacked(_ pixelBuffer: CVPixelBuffer) -> CVPixelBuffer {
+        if CVPixelBufferGetIOSurface(pixelBuffer) != nil { return pixelBuffer }
+
+        let width = CVPixelBufferGetWidth(pixelBuffer)
+        let height = CVPixelBufferGetHeight(pixelBuffer)
+        let format = CVPixelBufferGetPixelFormatType(pixelBuffer)
+        guard let dest = Self.createIOSurfacePixelBuffer(width: width, height: height, format: format) else { return pixelBuffer }
+
+        CVPixelBufferLockBaseAddress(pixelBuffer, .readOnly)
+        CVPixelBufferLockBaseAddress(dest, [])
+        let planeCount = CVPixelBufferGetPlaneCount(pixelBuffer)
+        if planeCount > 0 {
+            for plane in 0..<planeCount {
+                if let src = CVPixelBufferGetBaseAddressOfPlane(pixelBuffer, plane),
+                   let dst = CVPixelBufferGetBaseAddressOfPlane(dest, plane) {
+                    let srcStride = CVPixelBufferGetBytesPerRowOfPlane(pixelBuffer, plane)
+                    let dstStride = CVPixelBufferGetBytesPerRowOfPlane(dest, plane)
+                    let h = CVPixelBufferGetHeightOfPlane(pixelBuffer, plane)
+                    for row in 0..<h {
+                        memcpy(dst.advanced(by: row * dstStride), src.advanced(by: row * srcStride), min(srcStride, dstStride))
+                    }
+                }
+            }
+        } else if let src = CVPixelBufferGetBaseAddress(pixelBuffer),
+                  let dst = CVPixelBufferGetBaseAddress(dest) {
+            let srcStride = CVPixelBufferGetBytesPerRow(pixelBuffer)
+            let dstStride = CVPixelBufferGetBytesPerRow(dest)
+            for row in 0..<height {
+                memcpy(dst.advanced(by: row * dstStride), src.advanced(by: row * srcStride), min(srcStride, dstStride))
+            }
+        }
+        CVPixelBufferUnlockBaseAddress(dest, [])
+        CVPixelBufferUnlockBaseAddress(pixelBuffer, .readOnly)
+        return dest
+    }
+
+    private func convertI420ToNV12(_ i420Buffer: any RTCI420BufferProtocol) -> CVPixelBuffer? {
+        let width = Int(i420Buffer.width)
+        let height = Int(i420Buffer.height)
+        guard let outputBuffer = Self.createIOSurfacePixelBuffer(width: width, height: height, format: kCVPixelFormatType_420YpCbCr8BiPlanarFullRange) else { return nil }
+
+        CVPixelBufferLockBaseAddress(outputBuffer, [])
+        defer { CVPixelBufferUnlockBaseAddress(outputBuffer, []) }
+
+        if let yDest = CVPixelBufferGetBaseAddressOfPlane(outputBuffer, 0) {
+            let yDestStride = CVPixelBufferGetBytesPerRowOfPlane(outputBuffer, 0)
+            let ySrcStride = Int(i420Buffer.strideY)
+            for row in 0..<height {
+                memcpy(yDest.advanced(by: row * yDestStride), i420Buffer.dataY.advanced(by: row * ySrcStride), min(yDestStride, ySrcStride))
+            }
+        }
+
+        if let uvDest = CVPixelBufferGetBaseAddressOfPlane(outputBuffer, 1) {
+            let uvDestStride = CVPixelBufferGetBytesPerRowOfPlane(outputBuffer, 1)
+            let chromaHeight = height / 2
+            let chromaWidth = width / 2
+            for row in 0..<chromaHeight {
+                let uvDestRow = uvDest.advanced(by: row * uvDestStride)
+                let uSrcRow = i420Buffer.dataU.advanced(by: row * Int(i420Buffer.strideU))
+                let vSrcRow = i420Buffer.dataV.advanced(by: row * Int(i420Buffer.strideV))
+                for col in 0..<chromaWidth {
+                    uvDestRow.storeBytes(of: uSrcRow[col], toByteOffset: col * 2, as: UInt8.self)
+                    uvDestRow.storeBytes(of: vSrcRow[col], toByteOffset: col * 2 + 1, as: UInt8.self)
+                }
+            }
+        }
+        return outputBuffer
+    }
+
+    // MARK: - Shared Helpers
+
+    static func createIOSurfacePixelBuffer(width: Int, height: Int, format: OSType) -> CVPixelBuffer? {
+        var pixelBuffer: CVPixelBuffer?
+        let attrs: [String: Any] = [kCVPixelBufferIOSurfacePropertiesKey as String: [:] as [String: Any]]
+        let status = CVPixelBufferCreate(kCFAllocatorDefault, width, height, format, attrs as CFDictionary, &pixelBuffer)
+        return status == kCVReturnSuccess ? pixelBuffer : nil
+    }
+
+    static func createImmediateDisplaySampleBuffer(from pixelBuffer: CVPixelBuffer, presentationTime: CMTime) -> CMSampleBuffer? {
+        var formatDescription: CMVideoFormatDescription?
+        guard CMVideoFormatDescriptionCreateForImageBuffer(allocator: kCFAllocatorDefault, imageBuffer: pixelBuffer, formatDescriptionOut: &formatDescription) == noErr,
+              let formatDesc = formatDescription else { return nil }
+
+        var timingInfo = CMSampleTimingInfo(duration: CMTime(value: 1, timescale: 30), presentationTimeStamp: presentationTime, decodeTimeStamp: .invalid)
+        var sampleBuffer: CMSampleBuffer?
+        guard CMSampleBufferCreateReadyWithImageBuffer(allocator: kCFAllocatorDefault, imageBuffer: pixelBuffer, formatDescription: formatDesc, sampleTiming: &timingInfo, sampleBufferOut: &sampleBuffer) == noErr,
+              let sampleBuffer else { return nil }
+
+        if let attachments = CMSampleBufferGetSampleAttachmentsArray(sampleBuffer, createIfNecessary: true) as? [NSMutableDictionary],
+           let dict = attachments.first {
+            dict[kCMSampleAttachmentKey_DisplayImmediately] = true
+        }
+        return sampleBuffer
+    }
+
+    static func safeEnqueue(_ buffer: CMSampleBuffer, on layer: AVSampleBufferDisplayLayer) {
+        if layer.status == .failed { layer.flush() }
+        layer.enqueue(buffer)
+    }
+}
+
+// MARK: - LocalCaptureOutputDelegate
+
+/// Rotates local camera frames based on device orientation (set by CMMotionManager)
+/// and enqueues them into the local camera inset's AVSampleBufferDisplayLayer.
+private class LocalCaptureOutputDelegate: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate {
+
+    private let sampleBufferLayer: AVSampleBufferDisplayLayer
+    private var frameCount: Int64 = 0
+    private let ciContext = CIContext(options: [.useSoftwareRenderer: false])
+
+    // Written from CMMotionManager's OperationQueue, read from capture queue.
+    // Benign race on ARM64 — CGImagePropertyOrientation is a single-word enum.
+    var currentOrientation: CGImagePropertyOrientation = .leftMirrored
+
+    init(sampleBufferLayer: AVSampleBufferDisplayLayer) {
+        self.sampleBufferLayer = sampleBufferLayer
+        super.init()
+    }
+
+    func captureOutput(
+        _ output: AVCaptureOutput,
+        didOutput sampleBuffer: CMSampleBuffer,
+        from connection: AVCaptureConnection
+    ) {
+        guard let sourceBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
+
+        let ciImage = CIImage(cvPixelBuffer: sourceBuffer).oriented(currentOrientation)
+        let w = Int(ciImage.extent.width)
+        let h = Int(ciImage.extent.height)
+        guard let pixelBuffer = PiPFrameRenderer.createIOSurfacePixelBuffer(width: w, height: h, format: kCVPixelFormatType_32BGRA) else { return }
+        ciContext.render(ciImage, to: pixelBuffer)
+
+        frameCount += 1
+        guard let newSampleBuffer = PiPFrameRenderer.createImmediateDisplaySampleBuffer(
+            from: pixelBuffer,
+            presentationTime: CMTime(value: frameCount, timescale: 30)
+        ) else { return }
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            PiPFrameRenderer.safeEnqueue(newSampleBuffer, on: self.sampleBufferLayer)
+        }
+    }
+}

--- a/Signal/Calls/UserInterface/GroupCallViewController.swift
+++ b/Signal/Calls/UserInterface/GroupCallViewController.swift
@@ -587,6 +587,63 @@ final class GroupCallViewController: UIViewController {
             name: UserProfileNotifications.otherUsersProfileDidChange,
             object: nil,
         )
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(groupCallAppWillResignActive),
+            name: .OWSApplicationWillResignActive,
+            object: nil,
+        )
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(groupCallAppDidBecomeActive),
+            name: .OWSApplicationDidBecomeActive,
+            object: nil,
+        )
+
+        // Configure system PiP with our view as the source (must be in the
+        // window hierarchy for PiP to activate).
+        if let pipController = AppEnvironment.shared.windowManagerRef.callPiPController {
+            let captureSession = groupCall.videoCaptureController.captureSession
+            pipController.configure(sourceView: self.view)
+            pipController.enableMultitaskingCameraAccess(for: captureSession)
+            pipController.attachLocalCaptureSession(captureSession)
+        }
+    }
+
+    // MARK: - System PiP (Group Calls)
+
+    @objc
+    private func groupCallAppWillResignActive() {
+        // Start PiP while the scene is still foregroundActive.
+        guard ringRtcCall.localDeviceState.joinState == .joined,
+              !ringRtcCall.isOutgoingVideoMuted || !ringRtcCall.remoteDeviceStates.isEmpty else {
+            return
+        }
+        startGroupSystemPiP()
+    }
+
+    @objc
+    private func groupCallAppDidBecomeActive() {
+        stopGroupSystemPiP()
+    }
+
+    private func startGroupSystemPiP() {
+        guard let pipController = AppEnvironment.shared.windowManagerRef.callPiPController else { return }
+
+        // Attach the speaker (first remote) video track for PiP rendering.
+        if let firstRemote = ringRtcCall.remoteDeviceStates.sortedByAddedTime.first {
+            pipController.attachRemoteVideoTrack(firstRemote.videoTrack)
+        }
+
+        // isPictureInPictureActive is set eagerly in the PiP delegate's
+        // willStart callback so the camera stays alive.
+        pipController.startPictureInPicture()
+    }
+
+    private func stopGroupSystemPiP() {
+        AppEnvironment.shared.windowManagerRef.callPiPController?.stopPictureInPicture()
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
@@ -1768,6 +1825,9 @@ extension GroupCallViewController: GroupCallObserver {
     func groupCallEnded(_ call: GroupCall, reason: CallEndReason) {
         AssertIsOnMainThread()
         owsPrecondition(self.groupCall === call)
+
+        // Stop system PiP when the call ends.
+        stopGroupSystemPiP()
 
         let title: String
         let message: String?

--- a/Signal/Calls/UserInterface/IndividualCallViewController.swift
+++ b/Signal/Calls/UserInterface/IndividualCallViewController.swift
@@ -210,6 +210,48 @@ class IndividualCallViewController: OWSViewController, IndividualCallObserver {
         }
     }
 
+    // MARK: - System PiP
+
+    override func appWillResignActive() {
+        super.appWillResignActive()
+        // Start PiP while the scene is still foregroundActive — starting
+        // later (in appDidEnterBackground) fails because the scene has
+        // already transitioned away from foregroundActive.
+        guard individualCall.state == .connected,
+              individualCall.hasLocalVideo || individualCall.isRemoteVideoEnabled else {
+            return
+        }
+        startSystemPiP()
+    }
+
+    override func appDidBecomeActive() {
+        super.appDidBecomeActive()
+        stopSystemPiP()
+    }
+
+    private func startSystemPiP() {
+        guard let pipController = AppEnvironment.shared.windowManagerRef.callPiPController else { return }
+        // isPictureInPictureActive is set eagerly in the PiP delegate's
+        // willStart callback so the camera stays alive even if PiP starts
+        // automatically before this method runs.
+        pipController.startPictureInPicture()
+    }
+
+    private func stopSystemPiP() {
+        // isPictureInPictureActive cleanup is handled by the
+        // onPictureInPictureDidStop callback in WindowManager.
+        AppEnvironment.shared.windowManagerRef.callPiPController?.stopPictureInPicture()
+    }
+
+    /// Keep the PiP controller's remote video track in sync with the call.
+    private func updatePiPVideoTracks() {
+        guard let pipController = AppEnvironment.shared.windowManagerRef.callPiPController else { return }
+        // Always attach the remote track (even if video is currently disabled)
+        // so frames are ready to render when PiP starts. The track will produce
+        // frames once the remote party enables video.
+        pipController.attachRemoteVideoTrack(individualCall.remoteVideoTrack)
+    }
+
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
         coordinator.animate(alongsideTransition: { [weak self] _ in
@@ -279,6 +321,19 @@ class IndividualCallViewController: OWSViewController, IndividualCallObserver {
             name: .OWSApplicationDidBecomeActive,
             object: nil,
         )
+
+        // Configure system PiP with our view as the source (must be in the
+        // window hierarchy for PiP to activate).
+        if let pipController = AppEnvironment.shared.windowManagerRef.callPiPController {
+            let captureSession = individualCall.videoCaptureController.captureSession
+            pipController.configure(sourceView: self.view)
+            pipController.enableMultitaskingCameraAccess(for: captureSession)
+            pipController.attachLocalCaptureSession(captureSession)
+        }
+
+        // Attach remote video track to the PiP controller so frames are
+        // available when system PiP starts.
+        updatePiPVideoTracks()
     }
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
@@ -1096,6 +1151,12 @@ class IndividualCallViewController: OWSViewController, IndividualCallObserver {
         Logger.info("new call status: \(state)")
 
         self.updateCallUI()
+        updatePiPVideoTracks()
+
+        // If the call has ended, stop PiP.
+        if call.hasTerminated {
+            stopSystemPiP()
+        }
     }
 
     func individualCallLocalVideoMuteDidChange(_ call: IndividualCall, isVideoMuted: Bool) {
@@ -1116,6 +1177,7 @@ class IndividualCallViewController: OWSViewController, IndividualCallObserver {
     func individualCallRemoteVideoMuteDidChange(_ call: IndividualCall, isVideoMuted: Bool) {
         AssertIsOnMainThread()
         updateRemoteVideoTrack(remoteVideoTrack: isVideoMuted ? nil : call.remoteVideoTrack)
+        updatePiPVideoTracks()
         showCallControlsIfTheyMustBeVisible()
         scheduleBottomSheetTimeoutIfNecessary()
     }

--- a/Signal/Signal-Info.plist
+++ b/Signal/Signal-Info.plist
@@ -97,6 +97,8 @@
 	<string>Signal will save photos to your library.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Signal will let you choose which photos from your library to send.</string>
+	<key>NSPictureInPictureUsageDescription</key>
+	<string>Signal uses Picture-in-Picture to continue showing your video call while using other apps.</string>
 	<key>NSUserActivityTypes</key>
 	<array>
 		<string>INSendMessageIntent</string>

--- a/Signal/src/WindowManager.swift
+++ b/Signal/src/WindowManager.swift
@@ -255,6 +255,17 @@ class WindowManager {
         screenBlockingWindow.windowLevel = ._background
     }
 
+    // MARK: - System PiP
+
+    /// The system Picture-in-Picture controller for video calls.
+    /// Created when a call starts, torn down when it ends.
+    private(set) var callPiPController: CallPictureInPictureController?
+
+    /// Whether system-level PiP (not the in-app PiP) is currently active.
+    var isSystemPiPActive: Bool {
+        return callPiPController?.isPictureInPictureActive ?? false
+    }
+
     // MARK: Calls
 
     var shouldShowCallView: Bool = false
@@ -279,6 +290,19 @@ class WindowManager {
 
         shouldShowCallView = true
 
+        // Set up system PiP controller for video calls.
+        let pipController = CallPictureInPictureController()
+        pipController.onRestoreUserInterface = { [weak self] in
+            self?.returnToCallView()
+        }
+        pipController.onPictureInPictureDidStop = {
+            MainActor.assumeIsolated {
+                AppEnvironment.shared.callService?.isPictureInPictureActive = false
+                AppEnvironment.shared.callService?.updateIsVideoEnabled()
+            }
+        }
+        self.callPiPController = pipController
+
         // CallViewController only supports portrait for iPhones, but if we're _already_ landscape it won't
         // automatically switch.
         if !UIDevice.current.isIPad {
@@ -295,6 +319,10 @@ class WindowManager {
             Logger.warn("Ignoring end call request from obsolete call view controller.")
             return
         }
+
+        // Tear down system PiP.
+        callPiPController?.tearDown()
+        callPiPController = nil
 
         callViewWindow.rootViewController = nil
         callViewController = nil

--- a/Signal/test/Calls/CallPictureInPictureControllerTest.swift
+++ b/Signal/test/Calls/CallPictureInPictureControllerTest.swift
@@ -1,0 +1,77 @@
+//
+// Copyright 2024 Signal Messenger, LLC
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import AVKit
+import AVFoundation
+import XCTest
+
+@testable import Signal
+
+final class CallPictureInPictureControllerTest: XCTestCase {
+
+    @MainActor
+    func testPiPControllerInitialization() {
+        let controller = CallPictureInPictureController()
+        XCTAssertFalse(controller.isPictureInPictureActive)
+    }
+
+    @MainActor
+    func testAttachAndDetachRemoteVideoTrack() {
+        let controller = CallPictureInPictureController()
+        controller.attachRemoteVideoTrack(nil)
+        XCTAssertFalse(controller.isPictureInPictureActive)
+        controller.attachRemoteVideoTrack(nil)
+    }
+
+    @MainActor
+    func testTearDown() {
+        let controller = CallPictureInPictureController()
+        controller.tearDown()
+        XCTAssertFalse(controller.isPictureInPictureActive)
+    }
+
+    @MainActor
+    func testCallbacksAreSet() {
+        let controller = CallPictureInPictureController()
+        var restoreCalled = false
+        var stopCalled = false
+        controller.onRestoreUserInterface = { restoreCalled = true }
+        controller.onPictureInPictureDidStop = { stopCalled = true }
+        controller.onRestoreUserInterface?()
+        controller.onPictureInPictureDidStop?()
+        XCTAssertTrue(restoreCalled)
+        XCTAssertTrue(stopCalled)
+    }
+
+    @MainActor
+    func testMultipleTearDownsAreSafe() {
+        let controller = CallPictureInPictureController()
+        controller.tearDown()
+        controller.tearDown()
+    }
+
+    /// AVSampleBufferDisplayLayer requires IOSurface-backed pixel buffers.
+    /// Non-IOSurface buffers are silently dropped (grey output).
+    func testIOSurfaceBackedBufferIsRequired() {
+        // Non-IOSurface buffer
+        var nonIOBuffer: CVPixelBuffer?
+        CVPixelBufferCreate(kCFAllocatorDefault, 320, 180,
+                            kCVPixelFormatType_420YpCbCr8BiPlanarFullRange,
+                            nil, &nonIOBuffer)
+        XCTAssertNotNil(nonIOBuffer)
+        XCTAssertNil(CVPixelBufferGetIOSurface(nonIOBuffer!))
+
+        // IOSurface-backed buffer
+        let attrs: [String: Any] = [
+            kCVPixelBufferIOSurfacePropertiesKey as String: [:] as [String: Any]
+        ]
+        var ioBuffer: CVPixelBuffer?
+        CVPixelBufferCreate(kCFAllocatorDefault, 320, 180,
+                            kCVPixelFormatType_420YpCbCr8BiPlanarFullRange,
+                            attrs as CFDictionary, &ioBuffer)
+        XCTAssertNotNil(ioBuffer)
+        XCTAssertNotNil(CVPixelBufferGetIOSurface(ioBuffer!))
+    }
+}


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [ ] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 16 Pro Max, iOS 26.3.1

- - - - - - - - - -

### Description

Enables system PiP during video calls so users can continue two-way video while using other apps. Remote video renders in the PiP window via AVSampleBufferDisplayLayer (using layerClass + IOSurface-backed buffers), and a local camera preview is shown as a small inset via AVCaptureVideoPreviewLayer. Multitasking camera access keeps the local camera alive during PiP so the remote caller continues receiving video.

These changes were tested on a local build in a two-way call over 20 minutes, there are some performance issues and it does not re-sync the frame buffer as fast as I'd like when it started to fall behind.

If the team is open to this contribution I will spend more time profiling and tracking down possible improvements, if this feature is not wanted that's ok too, it was fun to build just for myself, I will continue to envy android users.
