### PR TITLE
Remove exclamation point from GENERIC_INCOMING_MESSAGE_NOTIFICATION, …

### DIFF
--- a/Signal/translations/ar.lproj/Localizable.strings
+++ b/Signal/translations/ar.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "ملف مُرفَق";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "رسالة جديدة!";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "رسالة جديدة";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "ابدأ";

--- a/Signal/translations/be.lproj/Localizable.strings
+++ b/Signal/translations/be.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "Далучэнне";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Новае паведамленне!";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Новае паведамленне";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "Пачаць";

--- a/Signal/translations/bg.lproj/Localizable.strings
+++ b/Signal/translations/bg.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "Прикачен файл";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Ново съобщение!";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Ново съобщение";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "Да започваме";

--- a/Signal/translations/bn.lproj/Localizable.strings
+++ b/Signal/translations/bn.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "সংযুক্তি";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "নতুন বার্তা!";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "নতুন বার্তা";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "শুরু করা যাক";

--- a/Signal/translations/ca.lproj/Localizable.strings
+++ b/Signal/translations/ca.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "Fitxer adjunt";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Missatge nou!";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Missatge nou";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "Començar";

--- a/Signal/translations/cs.lproj/Localizable.strings
+++ b/Signal/translations/cs.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "Příloha";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Nová zpráva!";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Nová zpráva";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "Začněte";

--- a/Signal/translations/da.lproj/Localizable.strings
+++ b/Signal/translations/da.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "Vedhæftning";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Ny besked!";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Ny besked";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "Kom i gang";

--- a/Signal/translations/de.lproj/Localizable.strings
+++ b/Signal/translations/de.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "Anhang";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Neue Nachricht!";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Neue Nachricht";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "Leg los";

--- a/Signal/translations/el.lproj/Localizable.strings
+++ b/Signal/translations/el.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "Συνημμένο";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Νέο μήνυμα!";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Νέο μήνυμα";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "Ξεκίνα";

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "Attachment";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "New Message!";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "New message";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "Get Started";

--- a/Signal/translations/fa.lproj/Localizable.strings
+++ b/Signal/translations/fa.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "پیوست";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "پیام جدید!";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "پیام جدید";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "شروع";

--- a/Signal/translations/fi.lproj/Localizable.strings
+++ b/Signal/translations/fi.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "Liitetiedosto";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Uusi viesti!";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Uusi viesti";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "Aloita";

--- a/Signal/translations/ga.lproj/Localizable.strings
+++ b/Signal/translations/ga.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "Ceangaltán";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Teachtaireacht Nua!";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Teachtaireacht Nua";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "Tosaigh air";

--- a/Signal/translations/gu.lproj/Localizable.strings
+++ b/Signal/translations/gu.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "જોડાણ";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "નવો મેસેજ!";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "નવો મેસેજ";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "શરૂઆત કરો";

--- a/Signal/translations/he.lproj/Localizable.strings
+++ b/Signal/translations/he.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "צרופה";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "הודעה חדשה!";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "הודעה חדשה";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "להתחיל";

--- a/Signal/translations/hi.lproj/Localizable.strings
+++ b/Signal/translations/hi.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "अटैचमेंट";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "नया मैसेज!";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "नया मैसेज";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "शुरू करें";

--- a/Signal/translations/hr.lproj/Localizable.strings
+++ b/Signal/translations/hr.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "Privitak";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Nova poruka!";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Nova poruka";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "Krenimo";

--- a/Signal/translations/hu.lproj/Localizable.strings
+++ b/Signal/translations/hu.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "Csatolmány";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Új üzenet!";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Új üzenet";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "Kezdés";

--- a/Signal/translations/id.lproj/Localizable.strings
+++ b/Signal/translations/id.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "Lampiran";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Pesan Baru!";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Pesan Baru";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "Mulai";

--- a/Signal/translations/it.lproj/Localizable.strings
+++ b/Signal/translations/it.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "Allegato";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Nuovo messaggio!";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Nuovo messaggio";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "Iniziamo";

--- a/Signal/translations/ja.lproj/Localizable.strings
+++ b/Signal/translations/ja.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "添付ファイル";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "新着メッセージ！";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "新着メッセージ";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "始めましょう";

--- a/Signal/translations/lt.lproj/Localizable.strings
+++ b/Signal/translations/lt.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "Priedas";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Nauja žinutė!";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Nauja žinutė";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "Pradėti";

--- a/Signal/translations/mr.lproj/Localizable.strings
+++ b/Signal/translations/mr.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "संलग्न";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "नवीन संदेश!";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "नवीन संदेश";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "सुरू करा";

--- a/Signal/translations/ms.lproj/Localizable.strings
+++ b/Signal/translations/ms.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "Lampiran";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Mesej Baru!";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Mesej Baru";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "Mulakan";

--- a/Signal/translations/nb.lproj/Localizable.strings
+++ b/Signal/translations/nb.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "Vedlegg";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Ny melding!";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Ny melding";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "Kom i gang";

--- a/Signal/translations/nl.lproj/Localizable.strings
+++ b/Signal/translations/nl.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "Bijlage";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Nieuw bericht!";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Nieuw bericht";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "Aan de slag";

--- a/Signal/translations/pl.lproj/Localizable.strings
+++ b/Signal/translations/pl.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "Załącznik";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Nowa wiadomość!";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Nowa wiadomość";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "Na dobry początek";

--- a/Signal/translations/pt_BR.lproj/Localizable.strings
+++ b/Signal/translations/pt_BR.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "Anexo";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Nova mensagem!";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Nova mensagem";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "Começar";

--- a/Signal/translations/pt_PT.lproj/Localizable.strings
+++ b/Signal/translations/pt_PT.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "Anexo";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Nova mensagem!";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Nova mensagem";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "Começar";

--- a/Signal/translations/ro.lproj/Localizable.strings
+++ b/Signal/translations/ro.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "Atașament";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Mesaj nou!";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Mesaj nou";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "Începe";

--- a/Signal/translations/ru.lproj/Localizable.strings
+++ b/Signal/translations/ru.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "Вложение";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Новое сообщение!";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Новое сообщение";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "С чего начать";

--- a/Signal/translations/sk.lproj/Localizable.strings
+++ b/Signal/translations/sk.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "Príloha";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Nová správa!";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Nová správa";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "Poďme na to!";

--- a/Signal/translations/sr.lproj/Localizable.strings
+++ b/Signal/translations/sr.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "Прилог";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Нова порука!";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Нова порука";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "Започните";

--- a/Signal/translations/sv.lproj/Localizable.strings
+++ b/Signal/translations/sv.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "Bilaga";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Nytt meddelande!";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Nytt meddelande";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "Komma igång";

--- a/Signal/translations/th.lproj/Localizable.strings
+++ b/Signal/translations/th.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "แฟ้มแนบ";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "มีข้อความใหม่!";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "มีข้อความใหม่";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "เริ่มต้นใช้งาน";

--- a/Signal/translations/tr.lproj/Localizable.strings
+++ b/Signal/translations/tr.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "Eklenti";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Yeni İleti!";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Yeni İleti";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "Kullanmaya Başla";

--- a/Signal/translations/ug.lproj/Localizable.strings
+++ b/Signal/translations/ug.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "قوشۇمچە";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "يېڭى ئۇچۇر!";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "يېڭى ئۇچۇر";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "ئىشلىتىشكە باشلاش";

--- a/Signal/translations/ur.lproj/Localizable.strings
+++ b/Signal/translations/ur.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "منسلک مواد";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "نیا پیغام!";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "نیا پیغام";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "شروع کریں";

--- a/Signal/translations/vi.lproj/Localizable.strings
+++ b/Signal/translations/vi.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "Tập tin đính kèm";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Tin Nhắn Mới!";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "Tin Nhắn Mới";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "Bắt đầu";

--- a/Signal/translations/yue.lproj/Localizable.strings
+++ b/Signal/translations/yue.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "附件";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "有新訊息！";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "有新訊息";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "開始使用";

--- a/Signal/translations/zh_CN.lproj/Localizable.strings
+++ b/Signal/translations/zh_CN.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "附件";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "新消息！";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "新消息";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "开始";

--- a/Signal/translations/zh_HK.lproj/Localizable.strings
+++ b/Signal/translations/zh_HK.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "附件";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "新訊息！";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "新訊息";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "開始";

--- a/Signal/translations/zh_TW.lproj/Localizable.strings
+++ b/Signal/translations/zh_TW.lproj/Localizable.strings
@@ -3680,7 +3680,7 @@
 "GENERIC_ATTACHMENT_LABEL" = "附檔";
 
 /* notification title indicating the user generically has a new message */
-"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "新訊息！";
+"GENERIC_INCOMING_MESSAGE_NOTIFICATION" = "新訊息";
 
 /* Title for the 'Get Started' banner */
 "GET_STARTED_BANNER_TITLE" = "開始使用";


### PR DESCRIPTION
…lowercase "message" in English.

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x ] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [ ] I have tested my contribution on these devices:
! I don't have an Apple device, I am making this change on behalf of my iOS user friends who suggested it. Since the change is straightforward, I am hoping that either someone else would test it or that this step can be bypassed.

- - - - - - - - - -

### Description
The Android version of the Signal app displays "New message" for generic message notifications, whereas the iOS version displays "New Message!", which is less tone-neutral and incorrectly capitalized (an inconsistency with English vs other languages). In order to make the app more consistent across platforms, and at the suggestion of multiple iOS users I know who find the exclamation point "stressful" or "annoying", I have removed the exclamation point and fixed the capitalization. I have also removed the exclamation point from the message in other languages for consistency. I did not change the capitalization of any other languages (i.e German).