### PR TITLE
Fix attachment approval chat color

### DIFF
--- a/Signal/ConversationView/ConversationViewController+ConversationInputToolbarDelegate.swift
+++ b/Signal/ConversationView/ConversationViewController+ConversationInputToolbarDelegate.swift
@@ -987,6 +987,10 @@ extension ConversationViewController: SendMediaNavDataSource {
         return [displayName]
     }
 
+    var sendMediaNavSendButtonTintColor: UIColor? {
+        viewState.conversationStyle.bubbleChatColorOutgoing.asChatUIElementTintColor()
+    }
+
     func sendMediaNavMentionableAcis(tx: DBReadTransaction) -> [Aci] {
         supportsMentions ? thread.recipientAddresses(with: tx).compactMap(\.aci) : []
     }

--- a/Signal/ConversationView/ConversationViewController+Delegates.swift
+++ b/Signal/ConversationView/ConversationViewController+Delegates.swift
@@ -70,6 +70,10 @@ extension ConversationViewController: AttachmentApprovalViewControllerDataSource
         return [displayName]
     }
 
+    public var attachmentApprovalSendButtonTintColor: UIColor? {
+        viewState.conversationStyle.bubbleChatColorOutgoing.asChatUIElementTintColor()
+    }
+
     public func attachmentApprovalMentionableAcis(tx: DBReadTransaction) -> [Aci] {
         supportsMentions ? thread.recipientAddresses(with: tx).compactMap(\.aci) : []
     }

--- a/Signal/src/ViewControllers/Photos/SendMediaNavigationController.swift
+++ b/Signal/src/ViewControllers/Photos/SendMediaNavigationController.swift
@@ -34,9 +34,15 @@ protocol SendMediaNavDataSource: AnyObject {
 
     var sendMediaNavRecipientNames: [String] { get }
 
+    var sendMediaNavSendButtonTintColor: UIColor? { get }
+
     func sendMediaNavMentionableAcis(tx: DBReadTransaction) -> [Aci]
 
     func sendMediaNavMentionCacheInvalidationKey() -> String
+}
+
+extension SendMediaNavDataSource {
+    var sendMediaNavSendButtonTintColor: UIColor? { nil }
 }
 
 class CameraFirstCaptureNavigationController: SendMediaNavigationController {
@@ -648,6 +654,10 @@ extension SendMediaNavigationController: AttachmentApprovalViewControllerDataSou
 
     var attachmentApprovalRecipientNames: [String] {
         sendMediaNavDataSource?.sendMediaNavRecipientNames ?? []
+    }
+
+    var attachmentApprovalSendButtonTintColor: UIColor? {
+        sendMediaNavDataSource?.sendMediaNavSendButtonTintColor
     }
 
     func attachmentApprovalMentionableAcis(tx: DBReadTransaction) -> [Aci] {

--- a/SignalUI/AttachmentApproval/AttachmentApprovalToolbar.swift
+++ b/SignalUI/AttachmentApproval/AttachmentApprovalToolbar.swift
@@ -18,10 +18,23 @@ class AttachmentApprovalToolbar: UIView {
         var canChangeMediaQuality = true
         var canSaveMedia = false
         var doneButtonIcon: DoneButtonIcon = .send
+        var doneButtonTintColor: UIColor?
 
         enum DoneButtonIcon: String {
             case send = "send-blue-42-dark"
             case next = "chevron-right-colored-42"
+        }
+
+        static func == (lhs: Configuration, rhs: Configuration) -> Bool {
+            lhs.isAddMoreVisible == rhs.isAddMoreVisible &&
+                lhs.isMediaStripVisible == rhs.isMediaStripVisible &&
+                lhs.isMediaHighQualityEnabled == rhs.isMediaHighQualityEnabled &&
+                lhs.isViewOnceOn == rhs.isViewOnceOn &&
+                lhs.canToggleViewOnce == rhs.canToggleViewOnce &&
+                lhs.canChangeMediaQuality == rhs.canChangeMediaQuality &&
+                lhs.canSaveMedia == rhs.canSaveMedia &&
+                lhs.doneButtonIcon == rhs.doneButtonIcon &&
+                lhs.doneButtonTintColor?.isEqual(rhs.doneButtonTintColor) ?? (rhs.doneButtonTintColor == nil)
         }
     }
 
@@ -192,7 +205,10 @@ class AttachmentApprovalToolbar: UIView {
         // to get a nice animation.
         mediaToolbar.isHiddenInStackView = isEditingMediaMessage
 
-        mediaToolbar.sendButton.setImage(UIImage(imageLiteralResourceName: configuration.doneButtonIcon.rawValue), for: .normal)
+        mediaToolbar.updateDoneButton(
+            icon: configuration.doneButtonIcon,
+            tintColor: configuration.doneButtonTintColor,
+        )
         mediaToolbar.setIsMediaQualityHigh(enabled: configuration.isMediaHighQualityEnabled, animated: animated)
 
         let availableButtons: MediaToolbar.AvailableButtons = {
@@ -445,10 +461,6 @@ private class MediaToolbar: UIView {
     )
     let sendButton: UIButton = {
         let button = UIButton(type: .system)
-        button.setImage(
-            UIImage(imageLiteralResourceName: AttachmentApprovalToolbar.Configuration.DoneButtonIcon.send.rawValue),
-            for: .normal,
-        )
         button.ows_contentEdgeInsets = UIEdgeInsets(margin: UIDevice.current.isNarrowerThanIPhone6 ? 4 : 8)
         button.accessibilityLabel = MessageStrings.sendButton
         button.sizeToFit()
@@ -457,6 +469,30 @@ private class MediaToolbar: UIView {
 
     private static let imageMediaQualityHigh = UIImage(imageLiteralResourceName: "quality-high")
     private static let imageMediaQualityStandard = UIImage(imageLiteralResourceName: "quality-standard")
+
+    fileprivate func updateDoneButton(
+        icon: AttachmentApprovalToolbar.Configuration.DoneButtonIcon,
+        tintColor: UIColor?,
+    ) {
+        switch (icon, tintColor) {
+        case (.send, .some(let tintColor)):
+            sendButton.setImage(
+                UIImage(imageLiteralResourceName: icon.rawValue).withRenderingMode(.alwaysTemplate),
+                for: .normal,
+            )
+            sendButton.tintColor = tintColor
+        case (.send, .none):
+            sendButton.setImage(
+                UIImage(imageLiteralResourceName: icon.rawValue).withRenderingMode(.alwaysOriginal),
+                for: .normal,
+            )
+        case (.next, _):
+            sendButton.setImage(
+                UIImage(imageLiteralResourceName: icon.rawValue).withRenderingMode(.alwaysOriginal),
+                for: .normal,
+            )
+        }
+    }
 
     fileprivate func setIsMediaQualityHigh(enabled: Bool, animated: Bool) {
         let image = enabled ? MediaToolbar.imageMediaQualityHigh : MediaToolbar.imageMediaQualityStandard

--- a/SignalUI/AttachmentApproval/AttachmentApprovalViewController.swift
+++ b/SignalUI/AttachmentApproval/AttachmentApprovalViewController.swift
@@ -62,9 +62,15 @@ public protocol AttachmentApprovalViewControllerDataSource: AnyObject {
 
     var attachmentApprovalRecipientNames: [String] { get }
 
+    var attachmentApprovalSendButtonTintColor: UIColor? { get }
+
     func attachmentApprovalMentionableAcis(tx: DBReadTransaction) -> [Aci]
 
     func attachmentApprovalMentionCacheInvalidationKey() -> String
+}
+
+public extension AttachmentApprovalViewControllerDataSource {
+    var attachmentApprovalSendButtonTintColor: UIColor? { nil }
 }
 
 // MARK: -
@@ -459,6 +465,7 @@ public final class AttachmentApprovalViewController: UIPageViewController, UIPag
             canChangeMediaQuality: options.contains(.canChangeQualityLevel),
             canSaveMedia: currentPageViewController.canSaveMedia,
             doneButtonIcon: isScreenNotFinal ? .next : .send,
+            doneButtonTintColor: approvalDataSource?.attachmentApprovalSendButtonTintColor,
         )
         bottomToolView.update(
             currentAttachmentItem: currentPageViewController.attachmentApprovalItem,


### PR DESCRIPTION
## Summary
Apply the conversation chat color to the send button in attachment approval.