### PR TITLE
Preserve file extensions for generic attachments #6232

### DIFF
--- a/SignalServiceKit/Messages/Attachments/V2/AttachmentStream.swift
+++ b/SignalServiceKit/Messages/Attachments/V2/AttachmentStream.swift
@@ -87,12 +87,19 @@ public class AttachmentStream {
     /// will instead be inferred from the file contents) and made url-safe AND user-friendly. If nil, a random file name is used.
     public func makeDecryptedCopy(filename: String?) throws -> URL {
         var pathExtension: String = {
-            if let pathExtension = MimeTypeUtil.fileExtensionForMimeType(mimeType) {
+            if
+                case .file = contentType,
+                // Generic file MIME types are often lossy (e.g. .srt -> text/plain -> .txt),
+                // so preserve the sender's filename extension when available.
+                let filename,
+                let pathExtension = (filename as NSString).pathExtension.nilIfEmpty
+            {
+                return pathExtension
+            } else if let pathExtension = MimeTypeUtil.fileExtensionForMimeType(mimeType) {
                 return pathExtension
             } else if
                 let filename,
-                let filenameUrl = URL(string: filename),
-                let pathExtension = filenameUrl.pathExtension.nilIfEmpty
+                let pathExtension = (filename as NSString).pathExtension.nilIfEmpty
             {
                 return pathExtension
             } else {


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
  * iPhone 12, iOS 26.3
- - - - - - - - - -

### Description

Fixes #6232

This fixes generic attachment exports losing their original filename extension when saved or shared.

Previously, `AttachmentStream.makeDecryptedCopy(filename:)` preferred the MIME-derived extension before the sender-provided filename extension. For generic file attachments this can be lossy, for example:

- `.srt` attachments may have `text/plain` MIME type and save as `.txt`
- `.ipa` attachments may have `application/octet-stream` MIME type and save as `.bin`

For attachments whose validated content type is `.file`, this change preserves the sender's filename extension when available. Media attachments still prefer MIME-derived extensions, preserving the existing behavior for images, videos, audio, and animated images.

I also replaced `URL(string:)` extension extraction with `NSString.pathExtension`, which is safer for normal filenames that contain spaces or non-URL-safe characters.

Testing:
- Confirmed `git diff --check` passes.
- Manually tested saving `.srt` and `.ipa` attachments to Files; both preserve their original file extensions.
