### PR TITLE
[#6253] Fix vocalization of badges for tab bar item

### DIFF
--- a/Signal/src/ViewControllers/HomeView/HomeTabBarController.swift
+++ b/Signal/src/ViewControllers/HomeView/HomeTabBarController.swift
@@ -303,10 +303,14 @@ extension HomeTabBarController: BadgeObserver {
 
         if #available(iOS 18, *), UIDevice.current.isIPad {
             uiTab(for: .chatList).badgeValue = stringify(badgeCount.unreadChatCount)
+            uiTab(for: .chatList).accessibilityValue = stringify(badgeCount.unreadChatCount)
             uiTab(for: .calls).badgeValue = stringify(badgeCount.unreadCallsCount)
+            uiTab(for: .calls).accessibilityValue = stringify(badgeCount.unreadCallsCount)
         } else {
             chatListTabBarItem.badgeValue = stringify(badgeCount.unreadChatCount)
+            chatListTabBarItem.accessibilityValue = stringify(badgeCount.unreadChatCount)
             callsListTabBarItem.badgeValue = stringify(badgeCount.unreadCallsCount)
+            callsListTabBarItem.accessibilityValue = stringify(badgeCount.unreadCallsCount)
         }
     }
 }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 14 Pro, iOS 26.4

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

Voice Over did not vocalize the badges on tab bar item. This if a user with Voice Over focused a given tab bar, like the chats one, and if this tab abr had a badge for unread chats, the user did not get the information. This is not isofunctional with a straight case without Voice Over.

Now if a tab bar has a badge, the badge is vocalized.

<img height="300" alt="after - accessibility inspector - added value for badges" src="https://github.com/user-attachments/assets/6e24263f-400b-4df6-ac53-1c512918b638" />

### Related issue

Closes signalapp/Signal-iOS#6253