### PR TITLE
[#6255] Voice Over does not vocalize correctly the hours

### DIFF
--- a/Signal/src/ViewControllers/AppSettings/Payments/ArchivedPaymentHistoryItem.swift
+++ b/Signal/src/ViewControllers/AppSettings/Payments/ArchivedPaymentHistoryItem.swift
@@ -135,6 +135,10 @@ struct ArchivedPaymentHistoryItem: PaymentsHistoryItem {
         return archivedPayment.statusDescription(isOutgoing: isOutgoing)
     }
 
+    func statusDescriptionForAccessibility(isLongForm: Bool) -> String? {
+        return statusDescription(isLongForm: isLongForm)
+    }
+
     /// Read status is only tracked on TSPaymentModels, so there's not really anything to do here.
     func markAsRead(tx: SignalServiceKit.DBWriteTransaction) { }
 

--- a/Signal/src/ViewControllers/AppSettings/Payments/PaymentHistoryItem.swift
+++ b/Signal/src/ViewControllers/AppSettings/Payments/PaymentHistoryItem.swift
@@ -44,6 +44,8 @@ public protocol PaymentsHistoryItem {
 
     func statusDescription(isLongForm: Bool) -> String?
 
+    func statusDescriptionForAccessibility(isLongForm: Bool) -> String?
+
     func markAsRead(tx: DBWriteTransaction)
 
     func reload(tx: DBReadTransaction) -> Self?

--- a/Signal/src/ViewControllers/AppSettings/Payments/PaymentsDetailViewController.swift
+++ b/Signal/src/ViewControllers/AppSettings/Payments/PaymentsDetailViewController.swift
@@ -289,6 +289,7 @@ class PaymentsDetailViewController: OWSTableViewController2, DatabaseChangeDeleg
                     comment: "Label for the transaction status in the payment details view in the app settings.",
                 ),
                 bottomText: statusMessage,
+                bottomAccessibilityText: paymentItem.statusDescriptionForAccessibility(isLongForm: true),
                 useFailedColor: paymentItem.isFailed,
             ))
         }
@@ -374,6 +375,7 @@ class PaymentsDetailViewController: OWSTableViewController2, DatabaseChangeDeleg
     private func buildStatusItem(
         topText: String,
         bottomText: String,
+        bottomAccessibilityText: String? = nil,
         useFailedColor: Bool = false,
     ) -> OWSTableItem {
         OWSTableItem(
@@ -387,6 +389,7 @@ class PaymentsDetailViewController: OWSTableViewController2, DatabaseChangeDeleg
 
                 let bottomLabel = UILabel()
                 bottomLabel.text = bottomText
+                bottomLabel.accessibilityLabel = bottomAccessibilityText
                 bottomLabel.textColor = .Signal.secondaryLabel
                 bottomLabel.font = UIFont.dynamicTypeFootnoteClamped
                 bottomLabel.numberOfLines = 0

--- a/Signal/src/ViewControllers/AppSettings/Payments/PaymentsSettingsViewController.swift
+++ b/Signal/src/ViewControllers/AppSettings/Payments/PaymentsSettingsViewController.swift
@@ -500,7 +500,8 @@ class PaymentsSettingsViewController: OWSTableViewController2, PaymentsHistoryDa
             )
 
             if let balanceConversionText = Self.buildBalanceConversionText(paymentBalance: paymentBalance) {
-                conversionLabel.text = balanceConversionText
+                conversionLabel.text = balanceConversionText.display
+                conversionLabel.accessibilityLabel = balanceConversionText.accessibility
             } else {
                 conversionStack.alpha = 0
             }
@@ -598,7 +599,7 @@ class PaymentsSettingsViewController: OWSTableViewController2, PaymentsHistoryDa
         return button
     }
 
-    private static func buildBalanceConversionText(paymentBalance: PaymentBalance) -> String? {
+    private static func buildBalanceConversionText(paymentBalance: PaymentBalance) -> (display: String, accessibility: String)? {
         let localCurrencyCode = SSKEnvironment.shared.paymentsCurrenciesRef.currentCurrencyCode
         guard let currencyConversionInfo = SSKEnvironment.shared.paymentsCurrenciesRef.conversionInfo(forCurrencyCode: localCurrencyCode) else {
             return nil
@@ -619,11 +620,14 @@ class PaymentsSettingsViewController: OWSTableViewController2, PaymentsHistoryDa
         //
         // It is sufficient to format as a time, currency conversions go stale in less than a day.
         let conversionFreshnessString = DateUtil.formatDateAsTime(currencyConversionInfo.conversionDate)
+        let conversionFreshnessAccessibilityString = DateUtil.formatDateAsTimeForAccessibility(currencyConversionInfo.conversionDate)
         let formatString = OWSLocalizedString(
             "SETTINGS_PAYMENTS_BALANCE_CONVERSION_FORMAT",
             comment: "Format string for the 'local balance converted into local currency' indicator. Embeds: {{ %1$@ the local balance in the local currency, %2$@ the local currency code, %3$@ the date the currency conversion rate was obtained. }}..",
         )
-        return String.nonPluralLocalizedStringWithFormat(formatString, fiatAmountString, localCurrencyCode, conversionFreshnessString)
+        let display = String.nonPluralLocalizedStringWithFormat(formatString, fiatAmountString, localCurrencyCode, conversionFreshnessString)
+        let accessibility = String.nonPluralLocalizedStringWithFormat(formatString, fiatAmountString, localCurrencyCode, conversionFreshnessAccessibilityString)
+        return (display: display, accessibility: accessibility)
     }
 
     private func configureHistorySection(

--- a/Signal/src/ViewControllers/AppSettings/Payments/PaymentsViewUtils.swift
+++ b/Signal/src/ViewControllers/AppSettings/Payments/PaymentsViewUtils.swift
@@ -357,9 +357,29 @@ extension TSPaymentModel {
         return result
     }
 
+    func statusDescriptionForAccessibility(isLongForm: Bool) -> String {
+        var result = statusDescription(isLongForm: isLongForm)
+        // Replace the appended date with the accessibility-friendly version.
+        result = String(result.dropLast(Self.formatDate(sortDate, isLongForm: isLongForm).count + 1))
+        result.append(" ")
+        result.append(Self.formatDateForAccessibility(sortDate, isLongForm: isLongForm))
+        return result
+    }
+
     static func formatDate(_ date: Date, isLongForm: Bool) -> String {
         if isLongForm {
             return statusDateTimeLongFormatter.string(from: date)
+        } else {
+            return statusDateShortFormatter.string(from: date)
+        }
+    }
+
+    static func formatDateForAccessibility(_ date: Date, isLongForm: Bool) -> String {
+        if isLongForm {
+            // Replace only the time portion with the spoken form; keep the date portion visual.
+            let datePart = DateFormatter.localizedString(from: date, dateStyle: .medium, timeStyle: .none)
+            let timePart = DateUtil.formatDateAsTimeForAccessibility(date)
+            return "\(datePart) \(timePart)"
         } else {
             return statusDateShortFormatter.string(from: date)
         }

--- a/Signal/src/ViewControllers/AppSettings/Payments/TSPaymentModelHistoryItem.swift
+++ b/Signal/src/ViewControllers/AppSettings/Payments/TSPaymentModelHistoryItem.swift
@@ -123,6 +123,10 @@ public struct PaymentsHistoryModelItem: PaymentsHistoryItem {
         paymentModel.statusDescription(isLongForm: isLongForm)
     }
 
+    public func statusDescriptionForAccessibility(isLongForm: Bool) -> String? {
+        paymentModel.statusDescriptionForAccessibility(isLongForm: isLongForm)
+    }
+
     public func markAsRead(tx: DBWriteTransaction) {
         PaymentUtils.markPaymentAsRead(paymentModel, transaction: tx)
     }

--- a/SignalServiceKit/Util/DateUtil.swift
+++ b/SignalServiceKit/Util/DateUtil.swift
@@ -177,6 +177,11 @@ public class DateUtil {
         return timeFormatter.string(from: date)
     }
 
+    public static func formatDateAsTimeForAccessibility(_ date: Date) -> String {
+        let components = Calendar.current.dateComponents([.hour, .minute], from: date)
+        return accessibilityTimeFormatter.string(from: components) ?? timeFormatter.string(from: date)
+    }
+
     // MARK: Formatting for UI
 
     // We might receive a message "from the future" due to a bug or

--- a/SignalServiceKit/Util/DateUtil.swift
+++ b/SignalServiceKit/Util/DateUtil.swift
@@ -25,6 +25,13 @@ public class DateUtil {
         return formatter
     }()
 
+    private static let accessibilityTimeFormatter: DateComponentsFormatter = {
+        let formatter = DateComponentsFormatter()
+        formatter.unitsStyle = .spellOut
+        formatter.allowedUnits = [.hour, .minute]
+        return formatter
+    }()
+
     public static let weekdayFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.setLocalizedDateFormatFromTemplate("EEEE")
@@ -206,6 +213,10 @@ public class DateUtil {
             let format = shouldUseLongFormat ? longFormat : shortFormat
             return String.localizedStringWithFormat(format, minutesDiff)
         } else {
+            if shouldUseLongFormat {
+                let components = Calendar.current.dateComponents([.hour, .minute], from: date)
+                return accessibilityTimeFormatter.string(from: components) ?? timeFormatter.string(from: date)
+            }
             return timeFormatter.string(from: date)
         }
     }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 14 Pro, iOS 26.4

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

#### Time vocalization of messages for Voice Over has been fixed.

Commit ecca307b731a8f33c8e22aea44444529cf0a9c4d

Hours were not vocalized properly with Voice Over.
For example, a message sent at 11:41, display in the GUI like "11:41",
was vocalized "11 41", and not for example in english "11 hours 41 minutes".

Defines a dedicated date components formatter with a spelled out unit style
 to expose only hours and minutes for vocalization.

<img  height="500" alt="after - hours vocalized" src="https://github.com/user-attachments/assets/17c0b7c4-20e1-4bf8-b89f-940e6541596d" />

#### Vocalization of hours in paiements pages 

Commit 1e004e35f21849f42a92462bd69abc91ede65bb0

The hours displayed in the paiements pages were not well vocalized.
Indeed an time displayed in the GUI "14:06" was vocalzied "14 06" and not
in the local hour expression.

Thus refactored a bit the things to handle more separatly the displayed value
and the accessible value for Voice Over.

<img width="877" height="1048" alt="after - vocalization of hours in paiements" src="https://github.com/user-attachments/assets/83adf36d-62ff-4a61-83ae-85d9dc93f880" />

#### Related issue

Closes #6255
