### PR TITLE
[#6257] Hide from Voice Over decorative image in backup onboarding view

### DIFF
--- a/Signal/Backups/Onboarding/BackupOnboardingIntroViewController.swift
+++ b/Signal/Backups/Onboarding/BackupOnboardingIntroViewController.swift
@@ -71,6 +71,7 @@ struct BackupOnboardingIntroView: View {
 
                 Image(.backupsLogo)
                     .frame(width: 80, height: 80)
+                    .accessibilityHidden(true)
 
                 Spacer().frame(height: 16)
                 HStack {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- x ] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [X] I have tested my contribution on these devices:
 * iPhone 14 Pro, iOS 26.4

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

The onboarding view for backups has a top image, but this is a decorative one. Voice Over vocalized it, but the image does not bring details interesting for the user.

Now the image is hidden.

Closes signalapp/Signal-iOS#6257


