### PR TITLE
[#6259] Fix missing `isLink` trait on helper cards embeded hyperlinks

### DIFF
--- a/Signal/src/ViewControllers/AppSettings/Payments/PaymentsSettingsViewController.swift
+++ b/Signal/src/ViewControllers/AppSettings/Payments/PaymentsSettingsViewController.swift
@@ -948,6 +948,8 @@ class PaymentsSettingsViewController: OWSTableViewController2, PaymentsHistoryDa
                 buttonLabel.text = buttonText
                 buttonLabel.textColor = .Signal.accent
                 buttonLabel.font = UIFont.dynamicTypeSubheadlineClamped
+                buttonLabel.isAccessibilityElement = true
+                buttonLabel.accessibilityTraits = .link
 
                 let animationView = LottieAnimationView(name: iconName)
                 animationView.contentMode = .scaleAspectFit


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 14 Pro, iOS 26.4

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

The helper cards can contain hyperlinks redirecting the users outside the app. However they were not marked as "link" component, and should be. Thus Voice Over was unable the vocalized the trait for the component.

Now the user knows there is an embedded hyperlink supposed to redirect it outside the app.

Closes signalapp/Signal-iOS#6259


