### PR TITLE
[#6263] Fix vocalized label of QrCode in security number page

### DIFF
--- a/SignalUI/SafetyNumbers/FingerprintViewController.swift
+++ b/SignalUI/SafetyNumbers/FingerprintViewController.swift
@@ -367,6 +367,10 @@ public class FingerprintViewController: OWSViewController, OWSNavigationChildCon
                 tintColor: .white,
             )
             button.addTarget(self, action: #selector(didTapShare), for: .touchUpInside)
+            button.accessibilityLabel = OWSLocalizedString(
+                "BUTTON_SHARE",
+                comment: "Accessibility label for the share button on the fingerprint view.",
+            )
             return button
         }()
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 14 Pro, iOS 26.4

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

The security number page displays a QrCode with a share button. However the share button is not well vocalized: Voice Over vocalizes the icon name (i.e. "share"), and nothing else.

Now it uses the suitable localizable.

<img height="500" alt="after - has label" src="https://github.com/user-attachments/assets/bcdaf423-387a-4520-8782-de207fdbec56" />

### Related issue

Closes signalapp/Signal-iOS#6263