### PR TITLE
[#6265] Missing `.isLink` trait for FAQ reference in support page

### DIFF
--- a/Signal/src/ViewControllers/AppSettings/Donations/DonationSettingsViewController.swift
+++ b/Signal/src/ViewControllers/AppSettings/Donations/DonationSettingsViewController.swift
@@ -384,12 +384,19 @@ class DonationSettingsViewController: OWSTableViewController2 {
             ))
         }
 
-        section.add(.disclosureItem(
-            icon: .settingsHelp,
-            withText: OWSLocalizedString(
-                "DONATION_VIEW_DONOR_FAQ",
-                comment: "Title for the 'Donor FAQ' button on the donation screen",
-            ),
+        section.add(OWSTableItem(
+            customCellBlock: {
+                let cell = OWSTableItem.buildCell(
+                    icon: .settingsHelp,
+                    itemName: OWSLocalizedString(
+                        "DONATION_VIEW_DONOR_FAQ",
+                        comment: "Title for the 'Donor FAQ' button on the donation screen",
+                    ),
+                    accessoryType: .disclosureIndicator,
+                )
+                cell.accessibilityTraits = .link
+                return cell
+            },
             actionBlock: { [weak self] in
                 let vc = SFSafariViewController(url: URL.Support.Donations.donorFAQ)
                 self?.present(vc, animated: true, completion: nil)


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 14 Pro, iOS 26.4

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

The FAQ item in support page directs the user outside the app, but is vocalized as a button which is not relevant because buttons are more for things scopped to the app, not outside.

Add thus a link trait for Voice Over. Because the view relies on UITableView, the button trait remains still.

<img height="500" alt="after - link trait" src="https://github.com/user-attachments/assets/00254e3d-bd1f-4969-9b54-675ceca06151" />


### Related issue

Closes signalapp/Signal-iOS#6265