### PR TITLE
[#6267] Remove decorative image from groups memberships label in conversation header and labels for `Voice Over`

### DIFF
--- a/Signal/ConversationView/Components/CVComponentState.swift
+++ b/Signal/ConversationView/Components/CVComponentState.swift
@@ -493,6 +493,8 @@ public struct CVComponentState: Equatable {
             let detailsText: NSAttributedString?
             /// For mutual groups, lack thereof and note-to-self description.
             let mutualGroupsText: NSAttributedString?
+            /// Plain text version of mutualGroupsText for VoiceOver (no image attachment).
+            let mutualGroupsAccessibilityText: String?
             let threadType: SafetyTipsType
             let shouldShowSafetyTipsButton: Bool
             let isOfficialChat: Bool

--- a/Signal/ConversationView/Components/CVComponentThreadDetails.swift
+++ b/Signal/ConversationView/Components/CVComponentThreadDetails.swift
@@ -249,6 +249,7 @@ public class CVComponentThreadDetails: CVComponentBase, CVRootComponent {
                 innerViews.append(UIView.spacer(withHeight: vSpacingSafetySectionDefault))
                 let mutualGroupsLabelConfig = mutualGroupsLabelConfig(attributedText: mutualGroupsText)
                 mutualGroupsLabelConfig.applyForRendering(label: mutualGroupsLabel)
+                mutualGroupsLabel.accessibilityLabel = safetySection.mutualGroupsAccessibilityText
                 innerViews.append(mutualGroupsLabel)
             }
 
@@ -906,6 +907,7 @@ extension CVComponentThreadDetails {
             shouldShowProfileNamesEducation: false,
             detailsText: NSAttributedString(string: OWSLocalizedString("RELEASE_NOTES_DETAILS", comment: "Details text for the thread details view of the release notes channel")),
             mutualGroupsText: nil,
+            mutualGroupsAccessibilityText: nil,
             threadType: .contact,
             shouldShowSafetyTipsButton: false,
             isOfficialChat: true,
@@ -1038,6 +1040,7 @@ extension CVComponentThreadDetails {
             shouldShowProfileNamesEducation: shouldShowUnknownThreadWarning,
             detailsText: membersAttributedText,
             mutualGroupsText: nil,
+            mutualGroupsAccessibilityText: nil,
             threadType: .group,
             shouldShowSafetyTipsButton: shouldShowUnknownThreadWarning && groupThread.hasPendingMessageRequest(transaction: tx),
             isOfficialChat: false,
@@ -1070,6 +1073,7 @@ extension CVComponentThreadDetails {
                     with: .font(.dynamicTypeSubheadline),
                     .color(UIColor.Signal.label),
                 ),
+                mutualGroupsAccessibilityText: nil,
                 threadType: .contact,
                 shouldShowSafetyTipsButton: false,
                 isOfficialChat: false,
@@ -1174,6 +1178,7 @@ extension CVComponentThreadDetails {
                 "  ",
                 formattedString,
             ]),
+            mutualGroupsAccessibilityText: formattedString,
             threadType: .contact,
             shouldShowSafetyTipsButton: isMessageRequest,
             isOfficialChat: false,

--- a/SignalUI/Views/ProfileDetailLabel.swift
+++ b/SignalUI/Views/ProfileDetailLabel.swift
@@ -55,6 +55,8 @@ public class ProfileDetailLabel: UIStackView {
         self.spacing = 12
         self.alignment = .top
         self.layoutMargins = .zero
+        self.isAccessibilityElement = true
+        self.accessibilityLabel = attributedTitle.string
 
         // Make the icon an attributed string attachment so that it
         //  1. scales with Dynamic Type.
@@ -72,6 +74,7 @@ public class ProfileDetailLabel: UIStackView {
         self.addArrangedSubview(imageLabel)
         imageLabel.attributedText = imageString
         imageLabel.setCompressionResistanceHigh()
+        imageLabel.accessibilityElementsHidden = true
 
         let textLabel = UILabel()
         self.addArrangedSubview(textLabel)


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x} I have tested my contribution on these devices:
 * iPhone 14 Pro, iOS 26.4

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

#### Remove decorative image from groups memberships label in conversation header

Commit fb41b29e8fd9e7a6c42fc201ccd3c75ade9f597a

In a conversation with one people, user can have a label saying there is not group in common between user and the people.
However the image, a decorative one, is vocalized, likle "attachment png".

Now this image is removed for Voice Over.

####  Vocalization of decorative imaged in about sheet of user in tchat view

Commit 3765b1e3812479003cf2461b2c2f5c072f31a92c

With attributed string, the image in labels of sheet with details of users I talk with
is vocalized like "attachment png". The image is decorative and should not be
vocalzied by Voice Over.

Now fixed.

### Related issue

Closes signalapp/Signal-iOS#6267
