### PR TITLE
[#6269] Fix missing button trait for Voice Over for disclosing items in contact about sheet

### DIFF
--- a/SignalUI/Views/ProfileDetailLabel.swift
+++ b/SignalUI/Views/ProfileDetailLabel.swift
@@ -55,6 +55,11 @@ public class ProfileDetailLabel: UIStackView {
         self.spacing = 12
         self.alignment = .top
         self.layoutMargins = .zero
+        self.isAccessibilityElement = true
+        self.accessibilityLabel = attributedTitle.string
+        if showDetailDisclosure {
+            self.accessibilityTraits = .button
+        }
 
         // Make the icon an attributed string attachment so that it
         //  1. scales with Dynamic Type.


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 14 Pro, iOS 26.4

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

Some elements can be pressed by the user to display elements likes sheets or popovers. But these elements are not described as buttons by Voice Over.

Now Voice Over describes it.

## Related issue

Closes signalapp/Signal-iOS#6269
