### PR TITLE
[#6271] Text of number of members in group in common in settings view does not follow `DynamicTypeSize`

### DIFF
--- a/SignalUI/RecipientPickers/GroupTableViewCell.swift
+++ b/SignalUI/RecipientPickers/GroupTableViewCell.swift
@@ -21,7 +21,7 @@ public class GroupTableViewCell: UITableViewCell {
 
         // Font config
         nameLabel.font = .dynamicTypeBody
-        subtitleLabel.font = .regularFont(ofSize: 11)
+        subtitleLabel.font = .dynamicTypeCaption2
 
         // Layout
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 14 Pro, iOS 26.4

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

If user increase sizes of texts of the app, the text displaying the number of people in a group is not increased.
uses a dynamic type size, with default value with the same size as before.

<img height="500" alt="after - text increase" src="https://github.com/user-attachments/assets/ba8f171f-cfe2-49db-9b98-1129df8c1bc3" />

### Related issue

Closes signalapp/Signal-iOS#6271
