### PR TITLE
Don't hard-assert on AVAudioSession category-change failures during call teardown

### DIFF
--- a/Signal/Calls/CallAudioService.swift
+++ b/Signal/Calls/CallAudioService.swift
@@ -504,7 +504,7 @@ class CallAudioService: IndividualCallObserver, GroupCallObserver {
             Logger.info("AVAudioSession changed from [category: \(oldCategory.rawValue), mode: \(oldMode.rawValue), options: \(oldOptions)] to [category: \(category.rawValue), mode: \(mode.rawValue), options: \(options)]")
         } catch {
             let message = "AVAudioSession failed to change from [category: \(oldCategory.rawValue), mode: \(oldMode.rawValue), options: \(oldOptions)] to [category: \(category.rawValue), mode: \(mode.rawValue), options: \(options)] with error: \(error)"
-            owsFailDebug(message)
+            Logger.error(message)
         }
 
         self.delegate?.callAudioServiceDidChangeAudioSession(self)


### PR DESCRIPTION
### Contributor checklist
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone, iOS 18

- - - - - - - - - -

### Description

Fixes #6246.

`CallAudioService.setAudioSession(category:mode:options:)` wraps `AVAudioSession.setCategory` and, on failure, calls `owsFailDebug`. That's a hard assertion — it trips a debugger breakpoint or crashes outright on debug/internal builds.

One of the paths that calls into this is `ensureProperAudioSession`, which reverts the session to `.ambient` when a call ends — including Call Link calls. If the OS rejects the category change while the audio session is mid-teardown, that's an expected, transient condition, not a programmer error. Treating it as one crashes the app on exactly the kind of build (debug/internal) contributors and QA rely on to catch real bugs, which just trains people to ignore it or makes debug builds unusable around call teardown.

This PR downgrades that one failure path from `owsFailDebug` to `Logger.error`, keeping the exact same diagnostic message so nothing is lost from the logs — it just stops being fatal. Nothing else about the method changes; the delegate callback right after the catch block still fires as before.

Tested by placing and ending a Call Link call on a physical iPhone (iOS 18) and confirming no crash on teardown.