### PR TITLE
[#6309] Fix missing accessibility trait `link` for ToS button in splash views

### DIFF
--- a/Signal/Provisioning/UserInterface/ProvisioningSplashViewController.swift
+++ b/Signal/Provisioning/UserInterface/ProvisioningSplashViewController.swift
@@ -80,6 +80,7 @@ class ProvisioningSplashViewController: ProvisioningBaseViewController {
             },
         )
         tosPPButton.configuration?.baseForegroundColor = .Signal.secondaryLabel
+        tosPPButton.accessibilityTraits.insert(.link)
         tosPPButton.enableMultilineLabel()
         tosPPButton.accessibilityIdentifier = "onboarding.splash.explanationLabel"
 

--- a/Signal/Registration/UserInterface/RegistrationSplashViewController.swift
+++ b/Signal/Registration/UserInterface/RegistrationSplashViewController.swift
@@ -106,6 +106,7 @@ public class RegistrationSplashViewController: OWSViewController, OWSNavigationC
             },
         )
         tosPPButton.configuration?.baseForegroundColor = .Signal.secondaryLabel
+        tosPPButton.accessibilityTraits.insert(.link)
         tosPPButton.enableMultilineLabel()
 
         // Large buttons enclosed in a container with some extra horizontal padding.


### PR DESCRIPTION
Closes #6309

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 17 Pro, iOS 26.5

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

Add missing accessibility traits for Voice Over user so as to make them know the ToS button in splash views is a link and will redirect them outside the app / in another context.

Closes #6309 