### PR TITLE
[#6311] Fix mute button accessibility label of Signal thread

### DIFF
--- a/Signal/ConversationView/ConversationViewController+UI.swift
+++ b/Signal/ConversationView/ConversationViewController+UI.swift
@@ -197,6 +197,10 @@ extension ConversationViewController {
                 actionExecuted: {},
             ),
         )
+        muteButton.accessibilityLabel = OWSLocalizedString(
+            "CONVERSATION_SETTINGS_MUTE_LABEL",
+            comment: "Accessibility label to mute the thread",
+        )
         navigationItem.rightBarButtonItem = muteButton
     }
 


### PR DESCRIPTION
Closes #6311

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 17 Pro, iOS 26.5

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->
Add missing accessibility label for mute button of Signal thread to let Voice over user be noticed of what should do the button instead of having the image name vocalized

<img height="400" alt="Accessibility Inspector with fix" src="https://github.com/user-attachments/assets/4b9babe0-b008-4d0f-9ed3-b2290720b734" />

