### PR TITLE
[#6313] Fix vocalization without parasites for thread title

### DIFF
--- a/Signal/ConversationView/Components/CVComponentThreadDetails.swift
+++ b/Signal/ConversationView/Components/CVComponentThreadDetails.swift
@@ -156,6 +156,7 @@ public class CVComponentThreadDetails: CVComponentBase, CVRootComponent {
 
         let titleButton = componentView.titleButton
         titleLabelConfig.applyForRendering(button: titleButton)
+        titleButton.accessibilityLabel = titleText
         self.configureTitleAction(button: titleButton, delegate: componentDelegate)
         innerViews.append(titleButton)
 


### PR DESCRIPTION
Closes #6313 

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 17 Pro, iOS 26.5

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->
Just define an accessibility label for the title to override the default label which contained parasites for Voice Over