### PR TITLE
[#6315] Fix missing accessibility label for buttons of attachement view

### DIFF
--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -490,6 +490,21 @@
 /* Message shown in a toast after user successfully saves attachments to Photos. 'Photos' is the name of the default Photos app on iOS, and should be localized as that app's name. */
 "ATTACHMENT_SAVING_SUCCESS_MESSAGE" = "Saved to Photos";
 
+/* Accessibility label for the 'add media' dialog. */
+"ATTACHMENT_TOOL_BUTTON_ADD_MEDIA_ACCESSIBILITY_LABEL" = "Add media";
+
+/* Accessibility label for the 'crop/scale image' dialog. */
+"ATTACHMENT_TOOL_BUTTON_CROP_SCALE_ACCESSIBILITY_LABEL" = "Crop or scale image";
+
+/* Accessibility label for the 'high/standard quality' dialog. */
+"ATTACHMENT_TOOL_BUTTON_MEDIA_QUALITY_ACCESSIBILITY_LABEL" = "Media quality";
+
+/* Accessibility label for the 'pen' dialog. */
+"ATTACHMENT_TOOL_BUTTON_PEN_ACCESSIBILITY_LABEL" = "Draw or annotate media";
+
+/* Accessibility label for the 'view one' dialog. */
+"ATTACHMENT_TOOL_BUTTON_VIEW_ONE_ACCESSIBILITY_LABEL" = "View once";
+
 /* Short text label for an animated attachment, used for thread preview and on the lock screen */
 "ATTACHMENT_TYPE_ANIMATED" = "Animated";
 

--- a/Signal/translations/fr.lproj/Localizable.strings
+++ b/Signal/translations/fr.lproj/Localizable.strings
@@ -490,6 +490,21 @@
 /* Message shown in a toast after user successfully saves attachments to Photos. 'Photos' is the name of the default Photos app on iOS, and should be localized as that app's name. */
 "ATTACHMENT_SAVING_SUCCESS_MESSAGE" = "Enregistré dans Photos";
 
+/* Accessibility label for the 'add media' dialog. */
+"ATTACHMENT_TOOL_BUTTON_ADD_MEDIA_ACCESSIBILITY_LABEL" = "Ajouter un média";
+
+/* Accessibility label for the 'crop/scale image' dialog. */
+"ATTACHMENT_TOOL_BUTTON_CROP_SCALE_ACCESSIBILITY_LABEL" = "Rogner ou redimensionner une image";
+
+/* Accessibility label for the 'high/standard quality' dialog. */
+"ATTACHMENT_TOOL_BUTTON_MEDIA_QUALITY_ACCESSIBILITY_LABEL" = "Qualité du média";
+
+/* Accessibility label for the 'pen' dialog. */
+"ATTACHMENT_TOOL_BUTTON_PEN_ACCESSIBILITY_LABEL" = "Dessiner ou annoter le média";
+
+/* Accessibility label for the 'view one' dialog. */
+"ATTACHMENT_TOOL_BUTTON_VIEW_ONE_ACCESSIBILITY_LABEL" = "Visible une seule fois";
+
 /* Short text label for an animated attachment, used for thread preview and on the lock screen */
 "ATTACHMENT_TYPE_ANIMATED" = "Pièce jointe animée";
 

--- a/SignalUI/AttachmentApproval/AttachmentApprovalToolbar.swift
+++ b/SignalUI/AttachmentApproval/AttachmentApprovalToolbar.swift
@@ -339,19 +339,39 @@ class AttachmentApprovalToolbar: UIView, MediaCaptionToolbarDelegate {
     }
 
     var buttonViewOnce: UIButton {
-        mediaCaptionToolbar.viewOnceButton
+        let viewOnceButton = mediaCaptionToolbar.viewOnceButton
+        viewOnceButton.accessibilityLabel = OWSLocalizedString(
+            "ATTACHMENT_TOOL_BUTTON_VIEW_ONE_ACCESSIBILITY_LABEL",
+            comment: "Accessibility label for the 'view one' dialog.",
+        )
+        return viewOnceButton
     }
 
     var buttonPenTool: UIButton {
-        mediaToolbar.penToolButton
+        let penToolButton = mediaToolbar.penToolButton
+        penToolButton.accessibilityLabel = OWSLocalizedString(
+            "ATTACHMENT_TOOL_BUTTON_PEN_ACCESSIBILITY_LABEL",
+            comment: "Accessibility label for the 'pen' dialog.",
+        )
+        return penToolButton
     }
 
     var buttonCropTool: UIButton {
-        mediaToolbar.cropToolButton
+        let cropButton = mediaToolbar.cropToolButton
+        cropButton.accessibilityLabel = OWSLocalizedString(
+            "ATTACHMENT_TOOL_BUTTON_CROP_SCALE_ACCESSIBILITY_LABEL",
+            comment: "Accessibility label for the 'crop/scale image' dialog.",
+        )
+        return cropButton
     }
 
     var buttonMediaQuality: UIButton {
-        mediaToolbar.mediaQualityButton
+        let mediaQualityButton = mediaToolbar.mediaQualityButton
+        mediaQualityButton.accessibilityLabel = OWSLocalizedString(
+            "ATTACHMENT_TOOL_BUTTON_MEDIA_QUALITY_ACCESSIBILITY_LABEL",
+            comment: "Accessibility label for the 'high/standard quality' dialog.",
+        )
+        return mediaQualityButton
     }
 
     var buttonSaveMedia: UIButton {
@@ -359,7 +379,12 @@ class AttachmentApprovalToolbar: UIView, MediaCaptionToolbarDelegate {
     }
 
     var buttonAddMedia: UIButton {
-        mediaToolbar.addMediaButton
+        let mediaQualityButton = mediaToolbar.addMediaButton
+        mediaQualityButton.accessibilityLabel = OWSLocalizedString(
+            "ATTACHMENT_TOOL_BUTTON_ADD_MEDIA_ACCESSIBILITY_LABEL",
+            comment: "Accessibility label for the 'add media' dialog.",
+        )
+        return mediaQualityButton
     }
 }
 


### PR DESCRIPTION
Closes #6315 

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 17 Pro, iOS 26.5

- - - - - - - - - -

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->
For buttons in `AttachmentApprovalToolbar`, add an accessibility label.
Use the internal script to extract wording keys, and update english and french translations.

<img height="400" alt="Accessibility Inspector after fix" src="https://github.com/user-attachments/assets/b5115b5f-f9a9-4151-bdd5-e50a0fa3b432" />

