### PR TITLE
Fix first-time pod install when RingRTC artifacts are absent

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -97,8 +97,8 @@ post_install do |installer|
   strip_valid_archs(installer)
   update_frameworks_script(installer)
   disable_non_development_pod_warnings(installer)
-  fix_ringrtc_project_symlink(installer)
   fetch_ringrtc
+  fix_ringrtc_project_symlink(installer)
   copy_acknowledgements
 end
 
@@ -238,6 +238,8 @@ end
 # Workaround for RingRTC's weird cached artifacts, hopefully temporary
 def fix_ringrtc_project_symlink(installer)
   ringrtc_header_ref = installer.pods_project.reference_for_path(installer.sandbox.pod_dir('SignalRingRTC') + 'out/release/libringrtc/ringrtc.h')
+  return unless ringrtc_header_ref
+
   if ringrtc_header_ref.path.start_with?('../') || ringrtc_header_ref.path.start_with?('/') then
     ringrtc_header_ref.path = 'out/release/libringrtc/ringrtc.h'
   end


### PR DESCRIPTION
## Summary

Fix a first-time `pod install` failure when RingRTC artifacts are not yet available.

`fix_ringrtc_project_symlink` attempts to resolve `ringrtc.h` before `fetch_ringrtc` creates it. Fetching the artifacts first and handling a missing project reference prevents the post-install hook from failing.

## Error

```text
No such file or directory @ rb_check_realpath_internal - Pods/SignalRingRTC/out/release/libringrtc/ringrtc.h
```

## Testing

- `bundle exec pod install`