### PR TITLE
Do not clear delivered notifications on app activate

### DIFF
--- a/SignalServiceKit/Notifications/UserNotificationsPresenter.swift
+++ b/SignalServiceKit/Notifications/UserNotificationsPresenter.swift
@@ -327,7 +327,7 @@ public class UserNotificationPresenter {
     }
 
     public func clearNotificationsForAppActivate() {
-        Logger.info("Clearing notifications for app activate.")
+        Logger.info("Clearing pending notifications for app activate.")
 
         Task {
             let shouldRemoveNotificationRequestPredicate: (UNNotificationRequest) -> Bool = { request in
@@ -346,12 +346,12 @@ public class UserNotificationPresenter {
                 .filter { shouldRemoveNotificationRequestPredicate($0) }
                 .map(\.identifier)
 
-            let deliveredNotificationIDsToRemove = await Self.notificationCenter.deliveredNotifications()
-                .filter { shouldRemoveNotificationRequestPredicate($0.request) }
-                .map(\.request.identifier)
+            // Do not remove delivered notifications on app activate.
+            // Delivered notifications should remain visible in Notification Center
+            // until the related conversation is actually opened/read and canceled
+            // through the normal thread/message-specific cancellation paths.
 
             Self.notificationCenter.removePendingNotificationRequests(withIdentifiers: pendingNotificationIDsToRemove)
-            Self.notificationCenter.removeDeliveredNotifications(withIdentifiers: deliveredNotificationIDsToRemove)
         }
     }
 


### PR DESCRIPTION
Fixes signalapp/Signal-iOS#6320

### First time contributor checklist
- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md) and [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) documents
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist
- [x] My commits are rebased on the latest main branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have tested my contribution on these devices:
 * iPhone 15 Pro, iOS 26.6

- - - - - - - - - -

### Description
Signal iOS was clearing delivered notifications from Apple Notification Center when the app was opened.

This change stops removing delivered notifications in `clearNotificationsForAppActivate()` and only clears pending notifications there.

Delivered notifications should remain visible until the related conversation is actually opened/read and removed through the existing thread/message-specific cancellation paths.

### Testing
- Receive one or more Signal messages.
- Confirm notifications are visible in Notification Center.
- Open Signal without opening the related conversation.
- Verify notifications remain visible in Notification Center.
- Open the conversation.
- Verify the corresponding notifications are dismissed through existing cancellation logic.