### PR TITLE
Fix Screen Lock authentication while device is locked

### DIFF
--- a/Signal/util/ScreenLockUI.swift
+++ b/Signal/util/ScreenLockUI.swift
@@ -161,6 +161,12 @@ class ScreenLockUI {
         )
         NotificationCenter.default.addObserver(
             self,
+            selector: #selector(protectedDataDidBecomeAvailable),
+            name: UIApplication.protectedDataDidBecomeAvailableNotification,
+            object: nil,
+        )
+        NotificationCenter.default.addObserver(
+            self,
             selector: #selector(screenLockDidChange),
             name: ScreenLock.ScreenLockDidChange,
             object: nil,
@@ -292,6 +298,11 @@ class ScreenLockUI {
 
         guard !appIsInactiveOrBackground else {
             // Never show the auth UI unless active.
+            return
+        }
+
+        guard UIApplication.shared.isProtectedDataAvailable else {
+            // Never show the auth UI while the device is locked.
             return
         }
 
@@ -445,6 +456,11 @@ class ScreenLockUI {
     @objc
     private func applicationDidEnterBackground(_ notification: Notification) {
         appIsInBackground = true
+    }
+
+    @objc
+    private func protectedDataDidBecomeAvailable(_ notification: Notification) {
+        ensureUI()
     }
 }
 


### PR DESCRIPTION
## Contributor checklist

Administrative:

- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md).
- [x] I have read the [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) document and understand the caveats in the Pull Requests section.
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/).

Commits and testing:

- [x] My commits are rebased on the latest main branch.
- [x] My commits are well-structured for review.
- [x] My change has been thoroughly tested, and I am not aware of any regressions to existing features or behaviors.
- [x] I have tested my contribution on these devices:
 * iPhone 15 Pro, iOS 27.0 (Public Beta 3)

---

## Description

When Signal is open on an iPhone with Always-On Display enabled, locking the phone causes Signal's Face ID prompt to appear on the Lock Screen. After unlocking the phone, Signal asks for Face ID again.

This change prevents Signal from starting Screen Lock authentication while the device is locked. Once the device is unlocked, Signal checks the Screen Lock state again and presents authentication normally.

## Testing

- Tested with Screen Lock set to immediately and Always-On Display enabled. The Signal prompt no longer appeared while the phone was locked, and appeared once after unlocking.
- Repeated the test with Low Power Mode enabled.
- Verified that backgrounding and reopening Signal still requires authentication.
- Built the Signal scheme with code signing disabled.
- Ran SwiftFormat on the changed file.