### PR TITLE
Add Periphery unused code workflow

### DIFF
--- a/.github/workflows/periphery-comment.yml
+++ b/.github/workflows/periphery-comment.yml
@@ -1,0 +1,15 @@
+name: Unused code comment
+
+on:
+  workflow_run:
+    workflows: ["Unused code"]
+    types: [completed]
+
+permissions: {}
+
+jobs:
+  comment:
+    permissions:
+      actions: read
+      pull-requests: write
+    uses: periphery-pro/actions/.github/workflows/comment.yml@v1

--- a/.github/workflows/periphery.yml
+++ b/.github/workflows/periphery.yml
@@ -1,0 +1,19 @@
+name: Unused code
+
+on:
+  pull_request:
+  push:
+    branches: ["main"]
+
+jobs:
+  periphery:
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    with:
+      runner: macos-26
+      xcode_version: "26.6"
+      checkout_submodules: true
+      setup: make fetch-ringrtc
+    uses: periphery-pro/actions/.github/workflows/scan.yml@v1

--- a/.periphery.yml
+++ b/.periphery.yml
@@ -1,0 +1,3 @@
+project: "Signal.xcworkspace"
+schemes:
+  - "Signal"


### PR DESCRIPTION
## Contributor checklist

Administrative:

- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md).
- [x] I have read the [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) document and understand the caveats in the Pull Requests section.
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/).

Commits and testing:

- [x] My commits are rebased on the latest main branch.
- [x] My commits are well-structured for review.
- [x] My change has been thoroughly tested, and I am not aware of any regressions to existing features or behaviors.
- [ ] I have tested my contribution on these devices:
 * iDevice A, iOS X.Y.Z
 * iDevice B, iOS Z.Y

---

## Description

Any interest in detecting unused code in PRs?

This change integrates the [Periphery reusable workflow](https://github.com/periphery-pro/actions). On pushes to the `main` branch, it scans for unused code and records a baseline. On PRs, it pulls the baseline for the merge-base commit and then reports any code that’s newly identified as unused.

The results are reported as inline comments in the diff for newly introduced unused code, and also a PR comment which also includes any results that aren’t present in the diff (i.e the change removes the final references to some existing code).

There aren’t any results posted in this PR, because main doesn’t have a baseline yet, and the `run_without_baseline` option is disabled (there are too many results), so it’ll take some time before folks base their PRs on `main` and start affecting the code graph.

