### PR TITLE
Fix database write starvation and UI freezes (#6328)

### DIFF
--- a/SignalServiceKit/Storage/Database/GRDBDatabaseStorageAdapter.swift
+++ b/SignalServiceKit/Storage/Database/GRDBDatabaseStorageAdapter.swift
@@ -376,8 +376,6 @@ extension GRDBDatabaseStorageAdapter {
         var txCompletionBlocks: [DBWriteTransaction.CompletionBlock]!
 
         let counter = checkpointState.update {
-            $0.workItem?.cancel()
-            $0.workItem = nil
             $0.counter += 1
             return $0.counter
         }
@@ -401,11 +399,9 @@ extension GRDBDatabaseStorageAdapter {
         }
 
         checkpointState.update {
-            guard $0.counter == counter else {
-                return
+            if $0.workItem == nil {
+                $0.workItem = scheduleCheckpoint(counter: $0.counter)
             }
-            $0.workItem?.cancel()
-            $0.workItem = scheduleCheckpoint(counter: counter)
             if $0.backgroundTask == nil {
                 $0.backgroundTask = OWSBackgroundTask(label: "database checkpoint")
             }
@@ -540,21 +536,14 @@ extension GRDBDatabaseStorageAdapter {
             owsAssertDebug(GRDBStorage.checkpointTimeout == nil)
         }
 
+        let backgroundTaskToEnd = checkpointState.update { state -> OWSBackgroundTask? in
+            state.workItem = nil
+            return state.backgroundTask.take()
+        }
+
         pool.writeWithoutTransaction { database in
-            let (shouldCheckpoint, backgroundTask) = checkpointState.update {
-                let shouldCheckpoint = $0.counter == counter
-                var backgroundTask: OWSBackgroundTask?
-                if shouldCheckpoint {
-                    backgroundTask = $0.backgroundTask.take()
-                }
-                return (shouldCheckpoint, backgroundTask)
-            }
             defer {
-                backgroundTask?.end()
-            }
-            guard shouldCheckpoint else {
-                Logger.warn("skipping checkpoint that's been canceled")
-                return
+                backgroundTaskToEnd?.end()
             }
             guard database.sqliteConnection != nil else {
                 Logger.warn("skipping checkpoint for database that's already closed.")
@@ -617,7 +606,7 @@ private struct GRDBStorage {
     private let dbURL: URL
     private let poolConfiguration: Configuration
 
-    fileprivate static let maxBusyTimeoutMs = 50
+    fileprivate static let maxBusyTimeoutMs = 250
 
     init(dbURL: URL, keyFetcher: GRDBKeyFetcher) throws {
         self.dbURL = dbURL

--- a/SignalServiceKit/Storage/TimeGatedBatch.swift
+++ b/SignalServiceKit/Storage/TimeGatedBatch.swift
@@ -36,7 +36,7 @@ public enum TimeGatedBatch {
     public static func enumerateObjects<T, E>(
         _ objects: some Sequence<T>,
         db: any DB,
-        yieldTxAfter: TimeInterval = 1.0,
+        yieldTxAfter: TimeInterval = 0.05,
         file: String = #file,
         function: String = #function,
         line: Int = #line,
@@ -61,6 +61,9 @@ public enum TimeGatedBatch {
                     }
                     // Process another object with this transaction...
                 }
+            }
+            if !isDone {
+                await Task.yield()
             }
         }
     }
@@ -100,8 +103,8 @@ public enum TimeGatedBatch {
     /// processed in that transaction.
     public static func processAll<E: Error, TxContext, DoneResult>(
         db: DB,
-        yieldTxAfter maximumDuration: TimeInterval = 0.5,
-        delayTwixtTx: TimeInterval = 0,
+        yieldTxAfter maximumDuration: TimeInterval = 0.05,
+        delayTwixtTx: TimeInterval = 0.01,
         errorTxCompletion: GRDB.Database.TransactionCompletion = .commit,
         file: String = #file,
         function: String = #function,
@@ -129,8 +132,8 @@ public enum TimeGatedBatch {
     /// Like `processAll` but without "transaction contexts".
     public static func processAll<E: Error, DoneResult>(
         db: DB,
-        yieldTxAfter maximumDuration: TimeInterval = 0.5,
-        delayTwixtTx: TimeInterval = 0,
+        yieldTxAfter maximumDuration: TimeInterval = 0.05,
+        delayTwixtTx: TimeInterval = 0.01,
         errorTxCompletion: GRDB.Database.TransactionCompletion = .commit,
         file: String = #file,
         function: String = #function,


### PR DESCRIPTION
Resolve severe SQLite lock contention causing multi-second UI hangs and WAL file bloat during high-frequency syncs.

* TimeGatedBatch: Reduce transaction duration limit (yieldTxAfter) to 50ms and introduce cooperative yielding (delayTwixtTx = 10ms and Task.yield) to prevent main thread starvation.
* GRDBDatabaseStorageAdapter: Prevent pending WAL checkpoints from being continuously cancelled and starved by rapid writes.
* Increase maxBusyTimeoutMs to 250ms to allow checkpoints to succeed under minor read contention.

Fixes #6328

## Contributor checklist

Administrative:

* [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md).
* [x] I have read the [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) document and understand the caveats in the Pull Requests section.
* [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/).

Commits and testing:

* [x] My commits are rebased on the latest main branch.
* [x] My commits are well-structured for review.
* [x] My change has been thoroughly tested, and I am not aware of any regressions to existing features or behaviors.
* [x] I have tested my contribution on these devices:
* iPhone 12, iOS 17.5
* iPhone 15 Pro (Simulator), iOS 17.5



---

## Description

### Summary

This pull request mitigates database write starvation, WAL file bloating, and UI freezes during heavy incoming/outgoing message bursts (e.g., bulk syncs, rapid typing indicators, and read receipts).

### Root Cause

1. `TimeGatedBatch` previously held write transactions for up to 1.0s without yielding, locking out concurrent operations and blocking the main thread during high-frequency syncs.
2. In `GRDBDatabaseStorageAdapter`, frequent writes continuously rescheduled and postponed the pending 750ms WAL checkpoint timer. Under sustained write workloads, checkpoints were starved indefinitely, leading to an oversized WAL file and multi-second transaction execution times.
3. A 50ms busy timeout during checkpoints frequently triggered `SQLITE_BUSY` aborts under minor read contention between the main app and the Notification Service Extension (NSE).

### How This Was Tested

* **Simulated Heavy Load:** Simulated a heavy inbound message sync and rapid typing indicator exchanges to trigger continuous background database writes.
* **Performance Profiling:** Monitored `_processAll` durations via logs to ensure transaction times remain strictly bounded and no longer spike to the 15-30 second range.
* **UI Responsiveness:** Performed aggressive scrolling in the conversation view during message ingestion to confirm frame drops and `scrollingAnimationCompletionTimerDidFire` assertions are fully resolved.
* **Database Integrity:** Verified that GRDB checkpoints still fire accurately and that data persists cleanly after forced app terminations mid-batch.