### PR TITLE
Add App Intents shortcuts

### DIFF
--- a/Signal.xcodeproj/project.pbxproj
+++ b/Signal.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		BFA100052C8511E000000001 /* AppIntentsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA100042C8511E000000001 /* AppIntentsTest.swift */; };
+		BFA100022C8511E000000001 /* SignalAppIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA100012C8511E000000001 /* SignalAppIntents.swift */; };
 		040277FA303DCFA6009C1468 /* LocalFileBackupAttachmentRestoreProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 040277F9303DCF9B009C1468 /* LocalFileBackupAttachmentRestoreProgress.swift */; };
 		040277FE303DE4F2009C1468 /* ChatListViewController+LocalFileBackupRestoreProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 040277FD303DE4F2009C1468 /* ChatListViewController+LocalFileBackupRestoreProgressView.swift */; };
 		040506F82F7EEF3B0078B769 /* RemoteReleaseNotesFetchingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 040506F72F7EEF290078B769 /* RemoteReleaseNotesFetchingManager.swift */; };
@@ -4253,6 +4255,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		BFA100042C8511E000000001 /* AppIntentsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIntentsTest.swift; sourceTree = "<group>"; };
+		BFA100012C8511E000000001 /* SignalAppIntents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignalAppIntents.swift; sourceTree = "<group>"; };
 		040277F9303DCF9B009C1468 /* LocalFileBackupAttachmentRestoreProgress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalFileBackupAttachmentRestoreProgress.swift; sourceTree = "<group>"; };
 		040277FD303DE4F2009C1468 /* ChatListViewController+LocalFileBackupRestoreProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatListViewController+LocalFileBackupRestoreProgressView.swift"; sourceTree = "<group>"; };
 		040506F72F7EEF290078B769 /* RemoteReleaseNotesFetchingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteReleaseNotesFetchingManager.swift; sourceTree = "<group>"; };
@@ -8655,6 +8659,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		BFA100032C8511E000000001 /* AppIntents */ = {
+			isa = PBXGroup;
+			children = (
+				BFA100012C8511E000000001 /* SignalAppIntents.swift */,
+			);
+			path = AppIntents;
+			sourceTree = "<group>";
+		};
 		040507132F80639B0078B769 /* RemoteReleaseNotes */ = {
 			isa = PBXGroup;
 			children = (
@@ -11903,6 +11915,7 @@
 				34B3F8951E8DF1B90035BE1A /* ViewControllers */,
 				34BEDB0F21C41E71007B0EAE /* views */,
 				F9B93CDF28E246D900B3F8A0 /* AppDelegateTest.swift */,
+				BFA100042C8511E000000001 /* AppIntentsTest.swift */,
 				4C83AC4123C55D9C00D4F2E6 /* SignalBaseTest.swift */,
 			);
 			path = test;
@@ -12310,6 +12323,7 @@
 			children = (
 				F94D12FD28BD0DD900B2C478 /* Accessibility */,
 				B91751C52EC552B100FF7A9C /* AppIcons */,
+				BFA100032C8511E000000001 /* AppIntents */,
 				5045F44129E0DAA400058E5F /* AppLaunch */,
 				661AEE462C2088DF0046B1D8 /* Attachments */,
 				D9EB00702FE0730700F81AD0 /* Autofill */,
@@ -19135,6 +19149,7 @@
 				886BB3D325BA0CA400079781 /* SetWallpaperViewController.swift in Sources */,
 				F915A77029CB6D4C00EB6F68 /* ShareActivityUtil.swift in Sources */,
 				880D90302481E617003D2B14 /* SignalApp.swift in Sources */,
+				BFA100022C8511E000000001 /* SignalAppIntents.swift in Sources */,
 				50C861E62EC52CA90001A4FA /* SignalAttachmentCloner.swift in Sources */,
 				D9E43C2D2CC194140001536E /* SignalCall.swift in Sources */,
 				8822558D26B9D1D7001A33C4 /* SignalDotMePhoneNumberLink.swift in Sources */,
@@ -19240,6 +19255,7 @@
 			files = (
 				6675F65129261E0C007A311E /* APNSRotationStoreTest.swift in Sources */,
 				F9B93CE028E246D900B3F8A0 /* AppDelegateTest.swift in Sources */,
+				BFA100052C8511E000000001 /* AppIntentsTest.swift in Sources */,
 				F9B3A92F293554090071EB95 /* ASWebAuthenticationSessionUtilTest.swift in Sources */,
 				50B6BCB42AEC58250010FB3B /* AuthorMergeHelperBuilderTest.swift in Sources */,
 				D962FC432E149ECF004DB623 /* BackupAttachmentDownloadTrackerTest.swift in Sources */,

--- a/Signal/AppIntents/SignalAppIntents.swift
+++ b/Signal/AppIntents/SignalAppIntents.swift
@@ -1,0 +1,434 @@
+//
+// Copyright 2024 Signal Messenger, LLC
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import AppIntents
+import Foundation
+import UIKit
+
+import SignalServiceKit
+
+@available(iOS 16.0, *)
+enum SignalIntentError: Swift.Error, CustomLocalizedStringResourceConvertible {
+    case notRegistered
+    case appNotReady
+    case conversationNotFound
+    case conversationCannotReceiveMessages
+    case emptyMessage
+    case sendFailed
+    case sendTimedOut
+
+    var localizedStringResource: LocalizedStringResource {
+        switch self {
+        case .notRegistered:
+            return "Signal is not set up or signed in. Please open Signal and register your account first."
+        case .appNotReady:
+            return "Signal must be open and unlocked before you can use this shortcut."
+        case .conversationNotFound:
+            return "The selected Signal conversation could not be found."
+        case .conversationCannotReceiveMessages:
+            return "The selected Signal conversation cannot receive messages."
+        case .emptyMessage:
+            return "The message text cannot be empty."
+        case .sendFailed:
+            return "Signal could not send the message."
+        case .sendTimedOut:
+            return "Signal has not confirmed the message yet. It may still send; check the chat before trying again."
+        }
+    }
+}
+
+@available(iOS 16.0, *)
+private func waitForSignalEnvironment(timeoutSeconds: Double = 3.5) async -> Bool {
+    guard !Task.isCancelled else { return false }
+
+    if AppReadinessObjcBridge.isAppReady, SSKEnvironment.hasShared {
+        return true
+    }
+
+    let interval: UInt64 = 150_000_000
+    let iterations = Int((timeoutSeconds * 1_000_000_000) / Double(interval))
+    for _ in 0..<iterations {
+        try? await Task.sleep(nanoseconds: interval)
+        guard !Task.isCancelled else { return false }
+        if AppReadinessObjcBridge.isAppReady, SSKEnvironment.hasShared {
+            return true
+        }
+    }
+    return AppReadinessObjcBridge.isAppReady && SSKEnvironment.hasShared
+}
+
+@available(iOS 16.0, *)
+@MainActor
+private func ensureSignalReadyAndUnlocked() async throws {
+    guard await waitForSignalEnvironment() else {
+        throw SignalIntentError.appNotReady
+    }
+
+    guard DependenciesBridge.shared.tsAccountManager.registrationStateWithMaybeSneakyTransaction.isRegistered else {
+        throw SignalIntentError.notRegistered
+    }
+
+    if SignalApp.shared.conversationSplitViewController == nil {
+        for _ in 0..<15 {
+            try? await Task.sleep(nanoseconds: 100_000_000)
+            if SignalApp.shared.conversationSplitViewController != nil { break }
+        }
+    }
+
+    guard
+        CurrentAppContext().isMainAppAndActiveIsolated,
+        SignalApp.shared.conversationSplitViewController != nil
+    else {
+        throw SignalIntentError.appNotReady
+    }
+
+    try await AppEnvironment.shared.screenLockUI.waitForScreenUnlockThrowingPrevious()
+}
+
+@available(iOS 16.0, *)
+@MainActor
+private func prepareUIForIntentPresentation() async throws {
+    guard let window = CurrentAppContext().mainWindow, window.rootViewController != nil else {
+        throw SignalIntentError.appNotReady
+    }
+
+    AppEnvironment.shared.windowManagerRef.minimizeCallIfNeeded()
+
+    await withCheckedContinuation { continuation in
+        SignalApp.shared.dismissAllModals(animated: false) {
+            continuation.resume()
+        }
+    }
+}
+
+@available(iOS 16.0, *)
+private func canExposeConversationEntities() async -> Bool {
+    guard
+        await waitForSignalEnvironment(),
+        DependenciesBridge.shared.tsAccountManager.registrationStateWithMaybeSneakyTransaction.isRegistered
+    else {
+        return false
+    }
+
+    return await MainActor.run {
+        UIApplication.shared.isProtectedDataAvailable
+            && !AppEnvironment.shared.screenLockUI.isLockedForAppIntents
+    }
+}
+
+@available(iOS 16.0, *)
+private func canResolveSavedConversationEntity(timeoutSeconds: Double = 3.5) async -> Bool {
+    guard
+        await waitForSignalEnvironment(timeoutSeconds: timeoutSeconds),
+        DependenciesBridge.shared.tsAccountManager.registrationStateWithMaybeSneakyTransaction.isRegistered
+    else {
+        return false
+    }
+
+    return await MainActor.run {
+        UIApplication.shared.isProtectedDataAvailable
+    }
+}
+
+@available(iOS 16.0, *)
+struct SignalConversationEntity: AppEntity {
+    static var defaultQuery = SignalConversationQuery()
+    static var typeDisplayRepresentation: TypeDisplayRepresentation = "Signal Conversation"
+
+    var id: String
+    var name: String
+    var isGroup: Bool
+
+    var displayRepresentation: DisplayRepresentation {
+        DisplayRepresentation(
+            title: "\(name)",
+            subtitle: isGroup
+                ? LocalizedStringResource("Group Chat", comment: "Subtitle for group chat entity")
+                : LocalizedStringResource("Contact", comment: "Subtitle for contact entity"),
+            image: .init(systemName: isGroup ? "person.3.fill" : "person.crop.circle.fill"),
+        )
+    }
+}
+
+@available(iOS 16.0, *)
+struct SignalConversationQuery: EntityQuery, EntityStringQuery {
+    func entities(for identifiers: [String]) async throws -> [SignalConversationEntity] {
+        guard await canResolveSavedConversationEntity() else { return [] }
+
+        return SSKEnvironment.shared.databaseStorageRef.read { tx in
+            identifiers.compactMap { uniqueId in
+                guard let thread = DependenciesBridge.shared.threadStore.fetchThread(uniqueId: uniqueId, tx: tx) else {
+                    return nil
+                }
+                guard thread.shouldThreadBeVisible else { return nil }
+                let name = SSKEnvironment.shared.contactManagerRef.displayName(for: thread, tx: tx)?.resolvedValue() ?? "Signal Contact"
+                return SignalConversationEntity(id: uniqueId, name: name, isGroup: thread is TSGroupThread)
+            }
+        }
+    }
+
+    func suggestedEntities() async throws -> [SignalConversationEntity] {
+        guard await canExposeConversationEntities() else { return [] }
+
+        return SSKEnvironment.shared.databaseStorageRef.read { tx in
+            var list = [SignalConversationEntity]()
+            DependenciesBridge.shared.threadStore.enumerateNonStoryThreads(tx: tx) { thread in
+                guard thread.shouldThreadBeVisible else { return true }
+                let name = SSKEnvironment.shared.contactManagerRef.displayName(for: thread, tx: tx)?.resolvedValue() ?? "Signal Contact"
+                list.append(SignalConversationEntity(id: thread.uniqueId, name: name, isGroup: thread is TSGroupThread))
+                return list.count < 30
+            }
+            return list
+        }
+    }
+
+    func entities(matching string: String) async throws -> [SignalConversationEntity] {
+        guard await canExposeConversationEntities() else { return [] }
+
+        let query = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else {
+            return try await suggestedEntities()
+        }
+
+        return SSKEnvironment.shared.databaseStorageRef.read { tx in
+            var list = [SignalConversationEntity]()
+            DependenciesBridge.shared.threadStore.enumerateNonStoryThreads(tx: tx) { thread in
+                guard thread.shouldThreadBeVisible else { return true }
+                let name = SSKEnvironment.shared.contactManagerRef.displayName(for: thread, tx: tx)?.resolvedValue() ?? ""
+                guard name.localizedCaseInsensitiveContains(query) else { return true }
+                list.append(SignalConversationEntity(id: thread.uniqueId, name: name, isGroup: thread is TSGroupThread))
+                return list.count < 25
+            }
+            return list
+        }
+    }
+}
+
+@available(iOS 16.0, *)
+struct SendSignalMessageIntent: AppIntent {
+    static var title: LocalizedStringResource = "Send Signal Message"
+    static var description = IntentDescription("Sends a text message after device authentication.")
+    static var openAppWhenRun = false
+    static var authenticationPolicy: IntentAuthenticationPolicy = .requiresLocalDeviceAuthentication
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Send \(\.$message) to \(\.$recipient)")
+    }
+
+    @Parameter(title: "Recipient", requestValueDialog: IntentDialog("Who would you like to message on Signal?"))
+    var recipient: SignalConversationEntity
+
+    @Parameter(title: "Message", requestValueDialog: IntentDialog("What would you like to say?"))
+    var message: String
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let trimmedText = message.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedText.isEmpty else {
+            throw SignalIntentError.emptyMessage
+        }
+        guard await canResolveSavedConversationEntity(timeoutSeconds: 25) else {
+            throw SignalIntentError.appNotReady
+        }
+        try Task.checkCancellation()
+
+        let messageBody = try await DependenciesBridge.shared.attachmentContentValidator
+            .prepareOversizeTextIfNeeded(MessageBody(text: trimmedText, ranges: .empty))
+
+        let backgroundMessageFetcher = DependenciesBridge.shared.backgroundMessageFetcherFactory.buildFetcher()
+        await backgroundMessageFetcher.start()
+        defer {
+            Task {
+                await backgroundMessageFetcher.stopAndWaitBeforeSuspending()
+            }
+        }
+
+        let sendPromise: Promise<Void>
+        do {
+            sendPromise = try await SSKEnvironment.shared.databaseStorageRef.awaitableWrite { transaction in
+                guard let thread = DependenciesBridge.shared.threadStore.fetchThread(uniqueId: recipient.id, tx: transaction) else {
+                    throw SignalIntentError.conversationNotFound
+                }
+                guard thread.shouldThreadBeVisible, thread.canSendChatMessagesToThread() else {
+                    throw SignalIntentError.conversationCannotReceiveMessages
+                }
+
+                ThreadUtil.addThreadToProfileWhitelistIfEmptyOrPendingRequest(
+                    thread,
+                    setDefaultTimerIfNecessary: true,
+                    tx: transaction,
+                )
+
+                let builder: TSOutgoingMessageBuilder = .withDefaultValues(thread: thread)
+                builder.setMessageBody(messageBody)
+                let dmConfig = DependenciesBridge.shared.disappearingMessagesConfigurationStore
+                    .fetchOrBuildDefault(for: .thread(thread), tx: transaction)
+                builder.expiresInSeconds = dmConfig.durationSeconds
+                builder.expireTimerVersion = NSNumber(value: dmConfig.timerVersion)
+
+                let outgoingMessage = TSOutgoingMessage(
+                    outgoingMessageWith: builder,
+                    additionalRecipients: [],
+                    explicitRecipients: [],
+                    skippedRecipients: [],
+                    transaction: transaction,
+                )
+                let preparedMessage = try UnpreparedOutgoingMessage.forMessage(
+                    outgoingMessage,
+                    body: messageBody,
+                    quotedReplyDraft: nil,
+                ).prepare(tx: transaction)
+                return ThreadUtil.enqueueMessagePromise(
+                    message: preparedMessage,
+                    limitToCurrentProcessLifetime: false,
+                    isHighPriority: true,
+                    transaction: transaction,
+                )
+            }
+        } catch let error as SignalIntentError {
+            throw error
+        } catch {
+            throw SignalIntentError.sendFailed
+        }
+
+        do {
+            try await sendPromise
+                .timeout(
+                    seconds: 10,
+                    description: "Sending Signal message",
+                    timeoutErrorBlock: { SignalIntentError.sendTimedOut },
+                )
+                .awaitableWithUncooperativeCancellationHandling()
+        } catch let error as SignalIntentError {
+            throw error
+        } catch {
+            throw SignalIntentError.sendFailed
+        }
+
+        return .result(dialog: IntentDialog("Message sent."))
+    }
+}
+
+@available(iOS 16.0, *)
+struct OpenSignalConversationIntent: AppIntent {
+    static var title: LocalizedStringResource = "Open Chat"
+    static var description = IntentDescription("Open a specific conversation in Signal.")
+    static var openAppWhenRun = true
+    static var authenticationPolicy: IntentAuthenticationPolicy = .requiresLocalDeviceAuthentication
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Open chat with \(\.$conversation)")
+    }
+
+    @Parameter(title: "Chat", requestValueDialog: IntentDialog("Which chat would you like to open?"))
+    var conversation: SignalConversationEntity
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        try await ensureSignalReadyAndUnlocked()
+
+        let threadExists = SSKEnvironment.shared.databaseStorageRef.read { tx in
+            DependenciesBridge.shared.threadStore.fetchThread(uniqueId: conversation.id, tx: tx)?.shouldThreadBeVisible == true
+        }
+        guard threadExists else {
+            throw SignalIntentError.conversationNotFound
+        }
+
+        try await prepareUIForIntentPresentation()
+        SignalApp.shared.presentConversationForThread(threadUniqueId: conversation.id, action: .compose, animated: true)
+        return .result()
+    }
+}
+
+@available(iOS 16.0, *)
+struct NewSignalMessageIntent: AppIntent {
+    static var title: LocalizedStringResource = "New Message"
+    static var description = IntentDescription("Open the new message composer in Signal.")
+    static var openAppWhenRun = true
+    static var authenticationPolicy: IntentAuthenticationPolicy = .requiresLocalDeviceAuthentication
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        try await ensureSignalReadyAndUnlocked()
+        try await prepareUIForIntentPresentation()
+        SignalApp.shared.showNewConversationView()
+        return .result()
+    }
+}
+
+@available(iOS 16.0, *)
+struct OpenSignalCameraIntent: AppIntent {
+    static var title: LocalizedStringResource = "Open Signal Camera"
+    static var description = IntentDescription("Open the camera view in Signal.")
+    static var openAppWhenRun = true
+    static var authenticationPolicy: IntentAuthenticationPolicy = .requiresLocalDeviceAuthentication
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        try await ensureSignalReadyAndUnlocked()
+        try await prepareUIForIntentPresentation()
+        SignalApp.shared.showCameraCaptureView()
+        return .result()
+    }
+}
+
+@available(iOS 16.0, *)
+struct OpenSignalSettingsIntent: AppIntent {
+    static var title: LocalizedStringResource = "Open Signal Settings"
+    static var description = IntentDescription("Open the Settings screen in Signal.")
+    static var openAppWhenRun = true
+    static var authenticationPolicy: IntentAuthenticationPolicy = .requiresLocalDeviceAuthentication
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        try await ensureSignalReadyAndUnlocked()
+        try await prepareUIForIntentPresentation()
+        SignalApp.shared.conversationSplitViewController?.showAppSettings()
+        return .result()
+    }
+}
+
+@available(iOS 16.0, *)
+struct SignalShortcutsProvider: AppShortcutsProvider {
+    static var shortcutTileColor: ShortcutTileColor = .blue
+
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: SendSignalMessageIntent(),
+            phrases: [
+                "Send a message to \(\.$recipient) in \(.applicationName)",
+                "Message \(\.$recipient) on \(.applicationName)",
+            ],
+            shortTitle: "Send Message",
+            systemImageName: "paperplane.fill",
+        )
+        AppShortcut(
+            intent: OpenSignalConversationIntent(),
+            phrases: [
+                "Open chat with \(\.$conversation) in \(.applicationName)",
+                "Open chat in \(.applicationName)",
+            ],
+            shortTitle: "Open Chat",
+            systemImageName: "bubble.left.and.bubble.right.fill",
+        )
+        AppShortcut(
+            intent: NewSignalMessageIntent(),
+            phrases: ["New message in \(.applicationName)"],
+            shortTitle: "New Message",
+            systemImageName: "square.and.pencil",
+        )
+        AppShortcut(
+            intent: OpenSignalCameraIntent(),
+            phrases: ["Open \(.applicationName) camera"],
+            shortTitle: "Open Camera",
+            systemImageName: "camera.fill",
+        )
+        AppShortcut(
+            intent: OpenSignalSettingsIntent(),
+            phrases: ["Open \(.applicationName) settings"],
+            shortTitle: "Settings",
+            systemImageName: "gearshape.fill",
+        )
+    }
+}

--- a/Signal/AppLaunch/AppDelegate.swift
+++ b/Signal/AppLaunch/AppDelegate.swift
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
+import AppIntents
 import CryptoKit
 import GRDB
 import Intents
@@ -134,6 +135,9 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         // This should be the first thing we do.
         let mainAppContext = MainAppContext()
         SetCurrentAppContext(mainAppContext, isRunningTests: false)
+        if #available(iOS 16.0, *) {
+            SignalShortcutsProvider.updateAppShortcutParameters()
+        }
 
         let debugLogger = DebugLogger.shared
         debugLogger.enableTTYLoggingIfNeeded()

--- a/Signal/test/AppIntentsTest.swift
+++ b/Signal/test/AppIntentsTest.swift
@@ -1,0 +1,19 @@
+//
+// Copyright 2024 Signal Messenger, LLC
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+
+import XCTest
+
+@testable import Signal
+
+@available(iOS 16.0, *)
+final class AppIntentsTest: XCTestCase {
+    func testOnlyQuickSendRunsWithoutForegroundingSignal() {
+        XCTAssertFalse(SendSignalMessageIntent.openAppWhenRun)
+        XCTAssertTrue(OpenSignalConversationIntent.openAppWhenRun)
+        XCTAssertTrue(NewSignalMessageIntent.openAppWhenRun)
+        XCTAssertTrue(OpenSignalCameraIntent.openAppWhenRun)
+        XCTAssertTrue(OpenSignalSettingsIntent.openAppWhenRun)
+    }
+}

--- a/Signal/util/ScreenLockUI.swift
+++ b/Signal/util/ScreenLockUI.swift
@@ -76,6 +76,33 @@ class ScreenLockUI {
         }
     }
 
+    @MainActor
+    var isLockedForAppIntents: Bool {
+        guard appReadiness.isAppReady else {
+            return true
+        }
+        guard ScreenLock.shared.isScreenLockEnabled() else {
+            return false
+        }
+        guard !isScreenLockLocked else {
+            return true
+        }
+        guard !CurrentAppContext().isMainAppAndActiveIsolated else {
+            return false
+        }
+        guard let screenLockCountdownTimestamp else {
+            return true
+        }
+
+        let currentTimestamp = monotonicTimestamp()
+        guard currentTimestamp >= screenLockCountdownTimestamp, currentTimestamp != 0 else {
+            return true
+        }
+
+        let elapsed = TimeInterval(currentTimestamp - screenLockCountdownTimestamp) / TimeInterval(NSEC_PER_SEC)
+        return elapsed >= ScreenLock.shared.screenLockTimeout()
+    }
+
     struct ScreenUnlockActionReplacedError: Error {}
 
     private var pendingScreenUnlockContinuation: CheckedContinuation<Void, Error>?


### PR DESCRIPTION
## Contributor checklist

Administrative:

- [x] I have read the [README](https://github.com/signalapp/Signal-iOS/blob/main/README.md).
- [x] I have read the [CONTRIBUTING](https://github.com/signalapp/Signal-iOS/blob/main/CONTRIBUTING.md) document and understand the caveats in the Pull Requests section.
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/).

Commits and testing:

- [x] My commits are rebased on the latest main branch.
- [x] My commits are well-structured for review.
- [ ] My change has been thoroughly tested, and I am not aware of any regressions to existing features or behaviors. Focused unit and device validation are recorded below; the full Signal test suite was not run.
- [x] I have tested my contribution on these devices:
  - iPhone 15 Pro, iOS 26.6.1: installed development build; manually verified headless Quick Send.
  - iPhone 16 Pro simulator, iOS 18.6: focused App Intents test.

## Description

### Summary

- Add App Shortcuts for Quick Send, Open Chat, New Message, Camera, and Settings.
- Keep Quick Send headless after local device authentication, while foreground shortcuts open Signal.
- Register shortcut parameters at launch so the system refreshes the available shortcuts.

### Security and behavior

- Require local-device authentication for every intent.
- Do not expose conversation suggestions or search results while protected data is unavailable or Signal Screen Lock is locked.
- Revalidate a saved recipient before sending, then enqueue the message through Signal's existing sender queue.
- Start Signal's existing background message fetcher for Quick Send so the chat connection is available during headless execution.
- Allow up to 25 seconds for a cold Signal launch before Quick Send reports that Signal is unavailable.

### Validation

- `swiftformat --lint Signal/AppIntents/SignalAppIntents.swift Signal/test/AppIntentsTest.swift`
- `git diff --check`
- `xcodebuild test -workspace Signal.xcworkspace -scheme Signal -configuration Debug -destination 'platform=iOS Simulator,id=1C12F7AC-636D-4BE1-B075-0479A603EB02' -derivedDataPath /tmp/signal-appintents-pr-derived CODE_SIGNING_ALLOWED=NO -only-testing:SignalTests/AppIntentsTest/testOnlyQuickSendRunsWithoutForegroundingSignal -resultBundlePath /tmp/signal-appintents-checklist-2.xcresult -quiet` — passed (1 test)
- Built, installed, and launched the development build on an iPhone. Manually verified Quick Send completes without first opening Signal.
- [Shortcut gallery screenshot](https://github.com/signalapp/Signal-iOS/pull/6344#issuecomment-5611367627)
